### PR TITLE
feat: add Stellar testnet API integration tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "node --watch src/server.js",
     "start": "node src/server.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:integration": "vitest run tests/stellar.integration.test.js"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.3.0",

--- a/backend/tests/helpers/app.js
+++ b/backend/tests/helpers/app.js
@@ -1,0 +1,22 @@
+/**
+ * Minimal Express app fixture for integration tests.
+ * Mounts only the Stellar routes — no WebSocket, no event sourcing startup.
+ */
+
+import express from 'express';
+import cors from 'cors';
+import stellarRoutes from '../../src/routes/stellar.js';
+
+// Stub out eventMonitor so importing stellar service doesn't blow up
+process.env.NODE_ENV = 'test';
+process.env.STELLAR_NETWORK = 'testnet';
+process.env.HORIZON_URL = 'https://horizon-testnet.stellar.org';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+app.use('/api/stellar', stellarRoutes);
+
+app.get('/health', (_req, res) => res.json({ status: 'ok', network: 'testnet' }));
+
+export default app;

--- a/backend/tests/stellar.integration.test.js
+++ b/backend/tests/stellar.integration.test.js
@@ -1,0 +1,305 @@
+/**
+ * Stellar API Integration Tests — Real Testnet
+ *
+ * These tests hit the actual Stellar testnet via Horizon and Friendbot.
+ * They are intentionally slower than unit tests; run them with:
+ *   vitest run tests/stellar.integration.test.js
+ *
+ * Required env (defaults to testnet if not set):
+ *   STELLAR_NETWORK=testnet
+ *   HORIZON_URL=https://horizon-testnet.stellar.org
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import { createFundedTestAccount, getXLMBalance, waitForAccount } from '../../testing/testnetAccount.js';
+
+// ── Mock event sourcing so the service doesn't need a running store ──────────
+vi.mock('../src/eventSourcing/index.js', () => ({
+  eventMonitor: {
+    publishEvent: vi.fn(() => Promise.resolve({})),
+    initialize: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+// ── Import app AFTER mocks are in place ──────────────────────────────────────
+const { default: app } = await import('./helpers/app.js');
+
+// ── Shared test state ─────────────────────────────────────────────────────────
+let sourceAccount; // funded account used as payment sender
+let destAccount;   // funded account used as payment recipient
+
+const VALID_PUBLIC_KEY = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7IXLMQVVXTNQRYUOP7H';
+const INVALID_PUBLIC_KEY = 'not-a-valid-key';
+const INVALID_SECRET_KEY = 'not-a-valid-secret';
+
+// ── Setup / Teardown ──────────────────────────────────────────────────────────
+beforeAll(async () => {
+  // Create and fund two testnet accounts in parallel
+  [sourceAccount, destAccount] = await Promise.all([
+    createFundedTestAccount(),
+    createFundedTestAccount(),
+  ]);
+
+  // Wait for both to be indexed on Horizon
+  await Promise.all([
+    waitForAccount(sourceAccount.publicKey),
+    waitForAccount(destAccount.publicKey),
+  ]);
+}, 60_000);
+
+afterAll(() => {
+  // Testnet accounts are ephemeral — nothing to clean up
+});
+
+// ── Test Suites ───────────────────────────────────────────────────────────────
+
+describe('POST /api/stellar/account/create', () => {
+  it('returns a new keypair with publicKey and secretKey', async () => {
+    const res = await request(app).post('/api/stellar/account/create');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('publicKey');
+    expect(res.body).toHaveProperty('secretKey');
+    expect(res.body.publicKey).toMatch(/^G[A-Z2-7]{55}$/);
+    expect(res.body.secretKey).toMatch(/^S[A-Z2-7]{55}$/);
+  });
+
+  it('returns a unique keypair on each call', async () => {
+    const [a, b] = await Promise.all([
+      request(app).post('/api/stellar/account/create'),
+      request(app).post('/api/stellar/account/create'),
+    ]);
+
+    expect(a.body.publicKey).not.toBe(b.body.publicKey);
+    expect(a.body.secretKey).not.toBe(b.body.secretKey);
+  });
+});
+
+describe('GET /api/stellar/account/:publicKey', () => {
+  it('returns balances for a funded testnet account', async () => {
+    const res = await request(app).get(`/api/stellar/account/${sourceAccount.publicKey}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('publicKey', sourceAccount.publicKey);
+    expect(res.body).toHaveProperty('balances');
+    expect(Array.isArray(res.body.balances)).toBe(true);
+
+    const xlm = res.body.balances.find((b) => b.asset === 'XLM');
+    expect(xlm).toBeDefined();
+    expect(parseFloat(xlm.balance)).toBeGreaterThan(0);
+  });
+
+  it('returns balance shape with asset and balance fields', async () => {
+    const res = await request(app).get(`/api/stellar/account/${sourceAccount.publicKey}`);
+
+    res.body.balances.forEach((b) => {
+      expect(b).toHaveProperty('asset');
+      expect(b).toHaveProperty('balance');
+      expect(typeof b.balance).toBe('string');
+    });
+  });
+
+  it('returns 422 for an invalid public key', async () => {
+    const res = await request(app).get(`/api/stellar/account/${INVALID_PUBLIC_KEY}`);
+
+    expect(res.status).toBe(422);
+    expect(res.body).toHaveProperty('errors');
+    expect(res.body.errors[0]).toHaveProperty('field', 'publicKey');
+  });
+
+  it('returns 500 for a valid-format but non-existent account', async () => {
+    const res = await request(app).get(`/api/stellar/account/${VALID_PUBLIC_KEY}`);
+
+    // Horizon returns 404 which the service surfaces as a 500
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty('error');
+  });
+});
+
+describe('POST /api/stellar/payment/send', () => {
+  it('sends XLM between two funded testnet accounts', async () => {
+    const balanceBefore = parseFloat(await getXLMBalance(destAccount.publicKey));
+
+    const res = await request(app)
+      .post('/api/stellar/payment/send')
+      .send({
+        sourceSecret: sourceAccount.secretKey,
+        destination: destAccount.publicKey,
+        amount: '1',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('hash');
+    expect(res.body).toHaveProperty('ledger');
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.hash).toBe('string');
+    expect(res.body.hash).toHaveLength(64);
+
+    // Verify recipient balance increased
+    const balanceAfter = parseFloat(await getXLMBalance(destAccount.publicKey));
+    expect(balanceAfter).toBeGreaterThan(balanceBefore);
+  }, 30_000);
+
+  it('returns 422 for missing required fields', async () => {
+    const res = await request(app)
+      .post('/api/stellar/payment/send')
+      .send({ destination: destAccount.publicKey, amount: '1' }); // missing sourceSecret
+
+    expect(res.status).toBe(422);
+    expect(res.body).toHaveProperty('errors');
+  });
+
+  it('returns 422 for an invalid secret key', async () => {
+    const res = await request(app)
+      .post('/api/stellar/payment/send')
+      .send({
+        sourceSecret: INVALID_SECRET_KEY,
+        destination: destAccount.publicKey,
+        amount: '1',
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.errors[0]).toHaveProperty('field', 'sourceSecret');
+  });
+
+  it('returns 422 for an invalid destination key', async () => {
+    const res = await request(app)
+      .post('/api/stellar/payment/send')
+      .send({
+        sourceSecret: sourceAccount.secretKey,
+        destination: INVALID_PUBLIC_KEY,
+        amount: '1',
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.errors[0]).toHaveProperty('field', 'destination');
+  });
+
+  it('returns 422 for a zero or negative amount', async () => {
+    const res = await request(app)
+      .post('/api/stellar/payment/send')
+      .send({
+        sourceSecret: sourceAccount.secretKey,
+        destination: destAccount.publicKey,
+        amount: '-5',
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.errors[0]).toHaveProperty('field', 'amount');
+  });
+
+  it('returns 422 for an invalid asset code', async () => {
+    const res = await request(app)
+      .post('/api/stellar/payment/send')
+      .send({
+        sourceSecret: sourceAccount.secretKey,
+        destination: destAccount.publicKey,
+        amount: '1',
+        assetCode: 'TOOLONGASSETCODE',
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.errors[0]).toHaveProperty('field', 'assetCode');
+  });
+
+  it('returns 500 when sending more XLM than available balance', async () => {
+    const res = await request(app)
+      .post('/api/stellar/payment/send')
+      .send({
+        sourceSecret: sourceAccount.secretKey,
+        destination: destAccount.publicKey,
+        amount: '999999999',
+      });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty('error');
+  }, 30_000);
+});
+
+describe('GET /api/stellar/exchange-rate/:from/:to', () => {
+  it('returns a rate for XLM/USD', async () => {
+    const res = await request(app).get('/api/stellar/exchange-rate/XLM/USD');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('rate');
+    expect(typeof res.body.rate).toBe('number');
+  });
+
+  it('returns 422 for invalid asset codes', async () => {
+    const res = await request(app).get('/api/stellar/exchange-rate/!!!!/USD');
+
+    expect(res.status).toBe(422);
+    expect(res.body).toHaveProperty('errors');
+  });
+});
+
+describe('GET /api/stellar/network/status', () => {
+  it('returns network status with expected fields', async () => {
+    const res = await request(app).get('/api/stellar/network/status');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('network', 'testnet');
+    expect(res.body).toHaveProperty('online');
+    expect(res.body).toHaveProperty('horizonUrl');
+  });
+
+  it('reports online: true when testnet is reachable', async () => {
+    const res = await request(app).get('/api/stellar/network/status');
+
+    expect(res.body.online).toBe(true);
+  });
+});
+
+describe('API response validation — shape contracts', () => {
+  it('account/create response matches schema', async () => {
+    const res = await request(app).post('/api/stellar/account/create');
+
+    expect(Object.keys(res.body)).toEqual(expect.arrayContaining(['publicKey', 'secretKey']));
+  });
+
+  it('account balance response matches schema', async () => {
+    const res = await request(app).get(`/api/stellar/account/${sourceAccount.publicKey}`);
+
+    expect(res.body).toMatchObject({
+      publicKey: expect.stringMatching(/^G[A-Z2-7]{55}$/),
+      balances: expect.arrayContaining([
+        expect.objectContaining({ asset: expect.any(String), balance: expect.any(String) }),
+      ]),
+    });
+  });
+
+  it('payment response matches schema', async () => {
+    const res = await request(app)
+      .post('/api/stellar/payment/send')
+      .send({
+        sourceSecret: sourceAccount.secretKey,
+        destination: destAccount.publicKey,
+        amount: '0.5',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      hash: expect.any(String),
+      ledger: expect.any(Number),
+      success: true,
+    });
+  }, 30_000);
+
+  it('error responses always include an error field', async () => {
+    const res = await request(app).get(`/api/stellar/account/${VALID_PUBLIC_KEY}`);
+
+    expect(res.body).toHaveProperty('error');
+    expect(typeof res.body.error).toBe('string');
+  });
+
+  it('validation error responses include errors array with field and message', async () => {
+    const res = await request(app).get(`/api/stellar/account/${INVALID_PUBLIC_KEY}`);
+
+    expect(res.body.errors).toBeInstanceOf(Array);
+    res.body.errors.forEach((e) => {
+      expect(e).toHaveProperty('field');
+      expect(e).toHaveProperty('message');
+    });
+  });
+});

--- a/testing/index.js
+++ b/testing/index.js
@@ -5,6 +5,7 @@
 
 export * from './factories.js';
 export * from './environment.js';
+export * from './testnetAccount.js';
 export * from './visual-regression.js';
 export * from './accessibility.js';
 export * from './cross-browser.js';

--- a/testing/testnetAccount.js
+++ b/testing/testnetAccount.js
@@ -1,0 +1,54 @@
+/**
+ * Testnet Account Manager
+ * Creates and funds Stellar testnet accounts for integration tests.
+ * Uses Friendbot to fund accounts so no real XLM is needed.
+ */
+
+import * as StellarSDK from '@stellar/stellar-sdk';
+
+const HORIZON_TESTNET = 'https://horizon-testnet.stellar.org';
+const FRIENDBOT_URL = 'https://friendbot.stellar.org';
+const server = new StellarSDK.Horizon.Server(HORIZON_TESTNET);
+
+/**
+ * Generate a fresh keypair and fund it via Friendbot.
+ * @returns {{ publicKey: string, secretKey: string }}
+ */
+export async function createFundedTestAccount() {
+  const keypair = StellarSDK.Keypair.random();
+  const publicKey = keypair.publicKey();
+
+  const res = await fetch(`${FRIENDBOT_URL}?addr=${publicKey}`);
+  if (!res.ok) {
+    throw new Error(`Friendbot failed for ${publicKey}: ${res.statusText}`);
+  }
+
+  return { publicKey, secretKey: keypair.secret() };
+}
+
+/**
+ * Load the XLM balance for an account.
+ * @param {string} publicKey
+ * @returns {string} balance string e.g. "10000.0000000"
+ */
+export async function getXLMBalance(publicKey) {
+  const account = await server.loadAccount(publicKey);
+  const xlm = account.balances.find((b) => b.asset_type === 'native');
+  return xlm ? xlm.balance : '0';
+}
+
+/**
+ * Wait until an account exists on the testnet (poll up to maxAttempts).
+ * Useful after Friendbot to ensure the account is indexed.
+ */
+export async function waitForAccount(publicKey, maxAttempts = 10, delayMs = 1000) {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      await server.loadAccount(publicKey);
+      return true;
+    } catch {
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  throw new Error(`Account ${publicKey} not found after ${maxAttempts} attempts`);
+}


### PR DESCRIPTION
- Add testing/testnetAccount.js: Friendbot-funded account manager with createFundedTestAccount, getXLMBalance, waitForAccount
- Add backend/tests/helpers/app.js: minimal Express fixture for integration tests (no WebSocket/event-sourcing startup)
- Add backend/tests/stellar.integration.test.js: full integration test suite covering account creation, balance retrieval, payment sending, exchange rate, network status, error scenarios, edge cases, and API response shape validation
- Add test:integration script to backend/package.json
- Export testnetAccount utilities from testing/index.js

close #42