### PR TITLE
Fix optimistic XLM balance deduction to include network fee

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import { CopyButton } from './components/CopyButton';
 import { Spinner } from './components/Spinner';
 import { TransactionHistory } from './components/TransactionHistory';
 import { FeeDisplay } from './components/FeeDisplay';
+import { getOptimisticXlmBalance } from './utils/stellarFee';
 import { logError } from './utils/errorLogger';
 import { ImportAccountForm } from './components/ImportAccountForm';
 import { FileUpload } from './components/FileUpload';
@@ -158,7 +159,7 @@ function App() {
     const numAmount = parseFloat(amount);
     if (xlmBalance !== null) {
       const optimisticBalances = balance.balances.map(b =>
-        b.asset === 'XLM' ? { ...b, balance: String((parseFloat(b.balance) - numAmount).toFixed(7)) } : b
+        b.asset === 'XLM' ? { ...b, balance: getOptimisticXlmBalance(b.balance, numAmount) } : b
       );
       dispatch({ type: A.SET_BALANCE_OPTIMISTIC, payload: { balances: optimisticBalances } });
     }

--- a/frontend/src/utils/stellarFee.js
+++ b/frontend/src/utils/stellarFee.js
@@ -1,0 +1,8 @@
+const BASE_TRANSACTION_FEE_XLM = 0.00001;
+
+export function getOptimisticXlmBalance(currentBalance, amount) {
+  const parsedBalance = parseFloat(currentBalance);
+  const parsedAmount = parseFloat(amount);
+  const nextBalance = parsedBalance - parsedAmount - BASE_TRANSACTION_FEE_XLM;
+  return String(nextBalance.toFixed(7));
+}


### PR DESCRIPTION
## Summary
- Include Stellar network fee in optimistic XLM balance deduction
- Extract optimistic balance calculation into a reusable utility (`frontend/src/utils/stellarFee.js`)
- Keep optimistic update payload shape unchanged to avoid UI/reducer regressions

## Validation
- Verified import and call path in `frontend/src/App.jsx`
- Verified balance format remains 7-decimal string output
- No dependency/API contract changes introduced

Closes #231