### PR TITLE
Persist fee-bump metrics to database storage

### DIFF
--- a/backend/src/routes/metrics.js
+++ b/backend/src/routes/metrics.js
@@ -21,12 +21,16 @@ router.delete('/', (_req, res) => {
 // GET /api/metrics/websocket — live WebSocket analytics
 router.get('/websocket', (_req, res) => {
   res.json(getWsStats());
+});
 // GET /api/metrics/fee-bump — fee bump usage stats for cost tracking
-router.get('/fee-bump', (_req, res) => {
-  res.json(getFeeBumpStats());
+router.get('/fee-bump', async (_req, res) => {
+  const stats = await getFeeBumpStats();
+  res.json(stats);
+});
 // GET /api/metrics/cdn — CDN analytics and config
 router.get('/cdn', (_req, res) => {
   res.json(getCdnStats());
+});
 // GET /api/metrics/shards — shard pool stats
 router.get('/shards', (_req, res) => {
   res.json(getShardStats());

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -4,14 +4,51 @@ import { getConfig } from '../config/env.js';
 import logger from '../config/logger.js';
 import prisma from '../db/client.js';
 
-// In-memory fee bump usage stats for admin dashboard
-const feeBumpStats = { total: 0, totalFeeStroops: 0, accounts: new Set() };
+let feeBumpTableReady = false;
 
-export function getFeeBumpStats() {
+async function ensureFeeBumpUsageTable() {
+  if (feeBumpTableReady) return;
+  await prisma.$executeRawUnsafe(`
+    CREATE TABLE IF NOT EXISTS fee_bump_usage (
+      id BIGSERIAL PRIMARY KEY,
+      account_public_key TEXT NOT NULL,
+      fee_stroops INTEGER NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+  feeBumpTableReady = true;
+}
+
+async function recordFeeBumpUsage(accountPublicKey, feeStroops) {
+  try {
+    await ensureFeeBumpUsageTable();
+    await prisma.$executeRawUnsafe(
+      `
+        INSERT INTO fee_bump_usage (account_public_key, fee_stroops)
+        VALUES ($1, $2)
+      `,
+      accountPublicKey,
+      feeStroops
+    );
+  } catch (error) {
+    logger.warn('stellar.feeBump.stats.persist.failed', { error: error.message });
+  }
+}
+
+export async function getFeeBumpStats() {
+  await ensureFeeBumpUsageTable();
+  const rows = await prisma.$queryRawUnsafe(`
+    SELECT
+      COUNT(*)::BIGINT AS total,
+      COALESCE(SUM(fee_stroops), 0)::BIGINT AS total_fee_stroops,
+      COUNT(DISTINCT account_public_key)::BIGINT AS unique_accounts
+    FROM fee_bump_usage
+  `);
+  const stats = rows?.[0] ?? {};
   return {
-    total: feeBumpStats.total,
-    totalFeeStroops: feeBumpStats.totalFeeStroops,
-    uniqueAccounts: feeBumpStats.accounts.size,
+    total: Number(stats.total ?? 0),
+    totalFeeStroops: Number(stats.total_fee_stroops ?? 0),
+    uniqueAccounts: Number(stats.unique_accounts ?? 0),
   };
 }
 
@@ -151,10 +188,7 @@ export async function sendPayment(sourceSecret, destination, amount, assetCode =
         xlmBalance: xlmAmount,
         threshold: feeBumpThreshold,
       });
-      // Track stats for cost monitoring
-      feeBumpStats.total += 1;
-      feeBumpStats.totalFeeStroops += StellarSDK.BASE_FEE * 10;
-      feeBumpStats.accounts.add(sourcePublicKey);
+      await recordFeeBumpUsage(sourcePublicKey, StellarSDK.BASE_FEE * 10);
     }
   }
 


### PR DESCRIPTION
## Summary
- replace in-memory fee-bump counters with persistent database-backed tracking
- record each fee-bump usage with source account and charged stroops
- aggregate persisted fee-bump stats (`total`, `totalFeeStroops`, `uniqueAccounts`) for admin metrics
- update `GET /api/metrics/fee-bump` to return async persisted stats

## Validation
- applied fee-bump flow now writes usage records instead of mutating in-memory state
- metrics endpoint reads aggregated values from database storage
- stats remain available after backend restart since data is persisted

## Notes
- implemented with lazy `CREATE TABLE IF NOT EXISTS` bootstrap for `fee_bump_usage` to avoid startup migration coupling

Closes #224