### PR TITLE
Fix missing useRTL import in App component

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import { useNetworkStatus } from './hooks/useNetworkStatus';
 import { useMessages } from './hooks/useMessages';
 import { usePWA } from './hooks/usePWA';
 import { useOfflineQueue } from './hooks/useOfflineQueue';
+import { useRTL } from './hooks/useRTL';
 import { makeVariants, tapScale } from './utils/animations';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { QRCodeModal } from './components/QRCodeModal';


### PR DESCRIPTION
## Summary
- add missing `useRTL` import in `frontend/src/App.jsx`
- prevent runtime `ReferenceError` caused by calling `useRTL()` without import

## Test plan
- run frontend app
- verify app renders without `useRTL is not defined` runtime error

Closes #214