### PR TITLE
Add PaymentStream composite index for active stream scans

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -93,6 +93,9 @@ model PaymentStream {
   metadata        Json?
   createdAt       DateTime     @default(now())
   updatedAt       DateTime     @updatedAt
+  @@index([status, lastProcessedAt])
+}
+
 model Notification {
   id        String   @id @default(uuid())
   userId    String
@@ -122,6 +125,8 @@ model NotificationPreference {
   quietHoursEnd    Int      @default(7)
   typeOverrides    Json?
   updatedAt        DateTime @updatedAt
+}
+
 model KYCRecord {
   id             String   @id @default(uuid())
   userId         String   @unique


### PR DESCRIPTION
## Summary
- add composite index on `PaymentStream(status, lastProcessedAt)` to optimize active stream worker queries
- ensure schema block structure remains valid where the index is defined

## Test plan
- run Prisma schema validation
- run stream worker query path and verify query planner can leverage the new composite index for `status = 'ACTIVE'`

Closes #239