### PR TITLE
Validate KYC date of birth and store as DateTime

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -128,7 +128,7 @@ model KYCRecord {
   user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   status         String   @default("PENDING")  // PENDING | APPROVED | REJECTED | UNDER_REVIEW
   fullName       String
-  dateOfBirth    String
+  dateOfBirth    DateTime
   nationality    String
   documentType   String
   documentNumber String

--- a/backend/src/compliance/kycCollector.js
+++ b/backend/src/compliance/kycCollector.js
@@ -16,12 +16,21 @@ class KYCCollector {
     return path.join(KYC_DIR, `${userId}.json`);
   }
 
+  _normalizeDateOfBirth(value) {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) throw new Error('dateOfBirth must be a valid date');
+    const today = new Date();
+    if (parsed > today) throw new Error('dateOfBirth cannot be in the future');
+    return parsed.toISOString();
+  }
+
   async submitKYC(userId, data) {
     await this.initialize();
 
     const required = ['fullName', 'dateOfBirth', 'nationality', 'documentType', 'documentNumber', 'address'];
     const missing = required.filter(f => !data[f]);
     if (missing.length) throw new Error(`Missing required KYC fields: ${missing.join(', ')}`);
+    const dateOfBirth = this._normalizeDateOfBirth(data.dateOfBirth);
 
     const record = {
       userId,
@@ -30,7 +39,7 @@ class KYCCollector {
       updatedAt: new Date().toISOString(),
       data: {
         fullName: data.fullName,
-        dateOfBirth: data.dateOfBirth,
+        dateOfBirth,
         nationality: data.nationality,
         documentType: data.documentType,   // PASSPORT | NATIONAL_ID | DRIVERS_LICENSE
         documentNumber: data.documentNumber,

--- a/backend/tests/compliance.regulatory.test.js
+++ b/backend/tests/compliance.regulatory.test.js
@@ -58,6 +58,12 @@ describe('KYC Testing', () => {
     ).rejects.toThrow(/Missing required KYC fields/);
   });
 
+  it('rejects KYC submission with invalid date of birth', async () => {
+    await expect(
+      kycCollector.submitKYC('user-2b', { ...validKYC, dateOfBirth: 'yesterday' })
+    ).rejects.toThrow(/dateOfBirth must be a valid date/);
+  });
+
   it('retrieves an existing KYC record', async () => {
     await kycCollector.submitKYC('user-3', validKYC);
     const record = await kycCollector.getKYCRecord('user-3');


### PR DESCRIPTION
## Summary
- change `KYCRecord.dateOfBirth` type from `String` to `DateTime` in Prisma schema
- validate `dateOfBirth` in `kycCollector.submitKYC` to reject invalid and future dates
- normalize accepted date of birth values to ISO format before persisting
- add regulatory test coverage for invalid date-of-birth submissions

## Test plan
- submit KYC with valid `dateOfBirth` and verify record creation
- submit KYC with invalid `dateOfBirth` and verify rejection
- submit KYC with future `dateOfBirth` and verify rejection

Closes #240