### PR TITLE
Validate Friendbot response before reporting funded account

### DIFF
--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -57,7 +57,12 @@ export async function createAccount() {
   logger.info('stellar.createAccount', { publicKey });
   
   if (isTestnet()) {
-    await fetch(`https://friendbot.stellar.org?addr=${publicKey}`);
+    const response = await fetch(`https://friendbot.stellar.org?addr=${publicKey}`);
+    if (!response.ok) {
+      const errorBody = typeof response.text === 'function' ? await response.text() : '';
+      const details = errorBody || response.statusText || 'Unknown Friendbot error';
+      throw new Error(`Friendbot funding failed (${response.status}): ${details}`);
+    }
     logger.debug('stellar.friendbotFunded', { publicKey });
     await eventMonitor.publishEvent(publicKey, {
       type: 'AccountFunded',

--- a/backend/tests/stellar.unit.test.js
+++ b/backend/tests/stellar.unit.test.js
@@ -232,11 +232,10 @@ describe('Stellar Service Unit Tests', () => {
       );
     });
 
-    it('should handle friendbot failure gracefully', async () => {
+    it('should throw when friendbot funding fails', async () => {
       global.fetch = vi.fn(() => Promise.resolve({ ok: false, statusText: 'Bad Request' }));
       
-      // Should not throw, just log warning
-      await expect(stellarService.createAccount()).resolves.toBeDefined();
+      await expect(stellarService.createAccount()).rejects.toThrow(/Friendbot funding failed/);
     });
 
     it('should publish AccountCreated event', async () => {


### PR DESCRIPTION
## Summary
- check Friendbot HTTP response status during testnet account creation
- throw descriptive error when Friendbot funding fails instead of proceeding as funded
- update unit test expectation to assert rejection on Friendbot failure

## Test plan
- mock Friendbot success response and verify account creation still succeeds
- mock Friendbot non-2xx response and verify `createAccount` throws descriptive error

Closes #221