### PR TITLE
Fix transaction modal overlay accessibility visibility

### DIFF
--- a/frontend/src/components/TransactionHistory.jsx
+++ b/frontend/src/components/TransactionHistory.jsx
@@ -57,7 +57,6 @@ function TxModal({ tx, onClose }) {
       className="tx-overlay"
       onClick={onClose}
       initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-      aria-hidden="true"
     >
       <motion.div
         ref={modalRef}


### PR DESCRIPTION
## Summary
- remove `aria-hidden="true"` from the transaction modal overlay backdrop
- keep dialog semantics on the inner modal (`role="dialog"`, `aria-modal="true"`) so assistive technologies can access modal content

## Test plan
- open transaction details modal in UI
- verify modal remains readable and focusable via assistive technologies

Closes #248