### PR TITLE
Add memo support to payment form and send flow

### DIFF
--- a/backend/src/middleware/validate.js
+++ b/backend/src/middleware/validate.js
@@ -75,6 +75,12 @@ export const rules = {
       .withMessage('Invalid asset code')
       .isIn(SUPPORTED_ASSETS)
       .withMessage(`Unsupported asset. Supported: ${SUPPORTED_ASSETS.join(', ')}`),
+    body('memo')
+      .optional()
+      .trim()
+      .custom((value) => Buffer.byteLength(value, 'utf8') <= MAX_LENGTHS.memo)
+      .withMessage(`Memo exceeds ${MAX_LENGTHS.memo} bytes`)
+      .customSanitizer(v => sanitizeText(v, MAX_LENGTHS.memo)),
   ],
 
   createTrustline: [

--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -127,8 +127,8 @@ router.get('/account/:publicKey', rules.publicKeyParam, validate,
  */
 router.post('/payment/send', rules.sendPayment, validate, async (req, res) => {
   try {
-    const { sourceSecret, destination, amount, assetCode } = req.body;
-    const result = await StellarService.sendPayment(sourceSecret, destination, amount, assetCode);
+    const { sourceSecret, destination, amount, assetCode, memo } = req.body;
+    const result = await StellarService.sendPayment(sourceSecret, destination, amount, assetCode, memo);
 
     const notification = { type: 'transaction', hash: result.hash, amount, assetCode: assetCode || 'XLM', timestamp: Date.now() };
 

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -102,7 +102,7 @@ export async function getBalance(publicKey) {
   return { publicKey, balances };
 }
 
-export async function sendPayment(sourceSecret, destination, amount, assetCode = 'XLM') {
+export async function sendPayment(sourceSecret, destination, amount, assetCode = 'XLM', memo = '') {
   const { assetIssuer } = getConfig().stellar;
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
   const sourcePublicKey = sourceKeypair.publicKey();
@@ -129,6 +129,7 @@ export async function sendPayment(sourceSecret, destination, amount, assetCode =
       asset,
       amount: amount.toString()
     }))
+    .addMemo(StellarSDK.Memo.text(memo || ''))
     .setTimeout(30)
     .build();
   
@@ -172,6 +173,7 @@ export async function sendPayment(sourceSecret, destination, amount, assetCode =
     destination,
     amount,
     assetCode,
+    memo: memo || null,
     hash: result.hash,
     ledger: result.ledger,
     feeBump: usedFeeBump,
@@ -179,7 +181,7 @@ export async function sendPayment(sourceSecret, destination, amount, assetCode =
 
   await eventMonitor.publishEvent(sourcePublicKey, {
     type: 'PaymentSent',
-    data: { destination, amount, hash: result.hash, feeBump: usedFeeBump },
+    data: { destination, amount, hash: result.hash, feeBump: usedFeeBump, memo: memo || null },
     version: 1
   });
 

--- a/backend/tests/stellar.unit.test.js
+++ b/backend/tests/stellar.unit.test.js
@@ -25,6 +25,9 @@ vi.mock('@stellar/stellar-sdk', () => ({
     payment: vi.fn(),
     changeTrust: vi.fn(),
   },
+  Memo: {
+    text: vi.fn((value) => ({ type: 'text', value })),
+  },
   Networks: {
     TESTNET: 'Test SDF Network ; September 2015',
     PUBLIC: 'Public Global Stellar Network ; September 2015',
@@ -119,6 +122,7 @@ describe('Stellar Service Unit Tests', () => {
     
     mockTransactionBuilder = {
       addOperation: vi.fn().mockReturnThis(),
+      addMemo: vi.fn().mockReturnThis(),
       setTimeout: vi.fn().mockReturnThis(),
       build: vi.fn(() => mockTransaction),
     };
@@ -186,6 +190,7 @@ describe('Stellar Service Unit Tests', () => {
     StellarSDK.TransactionBuilder.mockReturnValue(mockTransactionBuilder);
     StellarSDK.Operation.payment.mockReturnValue({});
     StellarSDK.Operation.changeTrust.mockReturnValue({});
+    StellarSDK.Memo.text.mockImplementation((value) => ({ type: 'text', value }));
     
     // Import the service
     stellarService = await import('../src/services/stellar.js');
@@ -340,6 +345,18 @@ describe('Stellar Service Unit Tests', () => {
       
       expect(result).toHaveProperty('hash');
       expect(result.success).toBe(true);
+    });
+
+    it('should include memo when sending payment', async () => {
+      const sourceSecret = 'SBZVMB74Z76QZ3ZVU4Z7YVCC5L7GXWCF7IXLMQVVXTNQRYUOP7HGHJH';
+      const destination = 'GBXIJJGUJJBBX7IXLMQVVXTNQRYUOP7HGHJHGBRPYHIL2CI3WHZDTOOQFC6';
+      const amount = '10';
+      const memo = 'Invoice 123';
+
+      await stellarService.sendPayment(sourceSecret, destination, amount, 'XLM', memo);
+
+      expect(StellarSDK.Memo.text).toHaveBeenCalledWith(memo);
+      expect(mockTransactionBuilder.addMemo).toHaveBeenCalled();
     });
 
     it('should throw error for non-XLM without asset issuer', async () => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -42,6 +42,7 @@ function App() {
   const [balance, setBalance] = useState(null);
   const [recipient, setRecipient] = useState('');
   const [amount, setAmount] = useState('');
+  const [memo, setMemo] = useState('');
   const [loading, setLoading] = useState('');
   const [showQR, setShowQR] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
@@ -102,6 +103,7 @@ function App() {
   const clearForm = () => {
     if ((recipient || amount) && !window.confirm('Clear the payment form?')) return;
     resetForm();
+    setMemo('');
   };
 
   const createAccount = async () => {
@@ -152,7 +154,7 @@ function App() {
   const sendPayment = async () => {
     if (!account || !recipientValid || !amountValid) return;
     setLoading('send');
-    const payload = { sourceSecret: account.secretKey, destination: recipient, amount, assetCode: 'XLM' };
+    const payload = { sourceSecret: account.secretKey, destination: recipient, amount, assetCode: 'XLM', memo };
 
     // Optimistic balance update
     const numAmount = parseFloat(amount);
@@ -452,6 +454,17 @@ function App() {
                     </motion.p>
                   )}
                 </AnimatePresence>
+                <div className="input-wrap">
+                  <input
+                    type="text"
+                    placeholder="Memo (optional, max 28 bytes)"
+                    value={memo}
+                    maxLength={28}
+                    onChange={(e) => setMemo(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
+                    aria-label="Payment memo"
+                  />
+                </div>
                 <FeeDisplay amount={amount} visible={amountValid} />
                 <div style={{ display: 'flex', gap: 8 }}>
                   <motion.button onClick={sendPayment} {...tap} disabled={!recipientValid || !amountValid || loading === 'send'}>
@@ -592,6 +605,19 @@ function App() {
                         </motion.p>
                       )}
                     </AnimatePresence>
+                    <div className="input-wrap">
+                      <label htmlFor="memo-input" className="sr-only">Payment memo</label>
+                      <input
+                        id="memo-input"
+                        type="text"
+                        placeholder="Memo (optional, max 28 bytes)"
+                        value={memo}
+                        maxLength={28}
+                        onChange={(e) => setMemo(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
+                        aria-label="Payment memo"
+                      />
+                    </div>
 
                     <FeeDisplay amount={amount} visible={amountValid} />
                     <div style={{ display: 'flex', gap: 8 }}>

--- a/frontend/tests/App.component.test.jsx
+++ b/frontend/tests/App.component.test.jsx
@@ -283,6 +283,7 @@ describe('App — send payment form interactions', () => {
         destination: mockRecipient,
         amount: '10',
         assetCode: 'XLM',
+        memo: '',
       })
     );
   });


### PR DESCRIPTION
## Summary
- add optional memo input to the payment form and include it in the payment API payload
- validate memo in `rules.sendPayment` with Stellar-compatible 28-byte limit
- pass memo through payment route into service layer and apply it via `StellarSDK.Memo.text(...)` in transaction build
- extend backend/frontend tests to cover memo propagation and builder usage

## Test plan
- submit payment with empty memo and confirm request succeeds
- submit payment with memo up to 28 bytes and confirm request succeeds
- submit payment with memo exceeding 28 bytes and confirm validation failure
- verify transaction builder receives `Memo.text` with provided memo

Closes #254