### PR TITLE
fix: include base fee in optimistic XLM balance deduction

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -154,11 +154,12 @@ function App() {
     setLoading('send');
     const payload = { sourceSecret: account.secretKey, destination: recipient, amount, assetCode: 'XLM' };
 
-    // Optimistic balance update
+    // Optimistic balance update (deduct amount + base fee to match on-chain deduction)
+    const BASE_FEE_XLM = 0.00001;
     const numAmount = parseFloat(amount);
     if (xlmBalance !== null) {
       const optimisticBalances = balance.balances.map(b =>
-        b.asset === 'XLM' ? { ...b, balance: String((parseFloat(b.balance) - numAmount).toFixed(7)) } : b
+        b.asset === 'XLM' ? { ...b, balance: String((parseFloat(b.balance) - numAmount - BASE_FEE_XLM).toFixed(7)) } : b
       );
       dispatch({ type: A.SET_BALANCE_OPTIMISTIC, payload: { balances: optimisticBalances } });
     }


### PR DESCRIPTION
Summary

Fixes a discrepancy in frontend/src/App.jsx where optimistic balance updates only deducted the transaction amount, excluding the network base fee. This caused the UI to temporarily display a slightly higher balance than the actual on-chain value.

Changes
Updated optimistic balance calculation to subtract amount + base fee (~0.00001 XLM)
Ensures displayed balance more accurately reflects expected post-transaction state

Behavioral Impact
Before: balance = balance - amount → temporarily overstated balance
After: balance = balance - (amount + fee) → accurate optimistic balance

Tests / Validation
✅ Verified UI balance matches on-chain balance after transaction settles
✅ Confirmed no regression in transaction flow or rendering

Acceptance Criteria
 Base fee included in optimistic deduction
 UI balance aligns with actual on-chain deduction
 No visual or functional regressions

Closes #231 