### PR TITLE
fix(#235): strip secretKey from tab sync broadcast payload

### DIFF
--- a/frontend/src/store/AppStateContext.jsx
+++ b/frontend/src/store/AppStateContext.jsx
@@ -34,7 +34,10 @@ export function AppStateProvider({ children }) {
   const syncedDispatch = useCallback((action) => {
     dispatch(action);
     if ([A.SET_ACCOUNT, A.CLEAR_ACCOUNT, A.SET_BALANCE].includes(action.type)) {
-      syncRef.current?.broadcast(action);
+      const safeAction = action.type === A.SET_ACCOUNT
+        ? { ...action, payload: { ...action.payload, secretKey: undefined } }
+        : action;
+      syncRef.current?.broadcast(safeAction);
     }
   }, []);
 


### PR DESCRIPTION
Account state synced via BroadcastChannel/localStorage included the raw secretKey, making it readable by any same-origin script in another tab. Strip secretKey from the SET_ACCOUNT payload before broadcasting.

Closes #235