### PR TITLE
Fix/236 strip secret key from import response

### DIFF
--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -48,7 +48,7 @@ router.post('/account/import', rules.importAccount, validate, async (req, res) =
     const keypair = StellarSDK.Keypair.fromSecret(secretKey);
     const publicKey = keypair.publicKey();
     const balance = await StellarService.getBalance(publicKey);
-    res.json({ publicKey, secretKey, balances: balance.balances });
+    res.json({ publicKey, balances: balance.balances });
   } catch (error) {
     res.status(400).json({ error: 'Invalid secret key or account not found on network' });
   }

--- a/frontend/src/store/AppStateContext.jsx
+++ b/frontend/src/store/AppStateContext.jsx
@@ -34,7 +34,10 @@ export function AppStateProvider({ children }) {
   const syncedDispatch = useCallback((action) => {
     dispatch(action);
     if ([A.SET_ACCOUNT, A.CLEAR_ACCOUNT, A.SET_BALANCE].includes(action.type)) {
-      syncRef.current?.broadcast(action);
+      const safeAction = action.type === A.SET_ACCOUNT
+        ? { ...action, payload: { ...action.payload, secretKey: undefined } }
+        : action;
+      syncRef.current?.broadcast(safeAction);
     }
   }, []);
 


### PR DESCRIPTION
                                                                                
  fix: don't echo secretKey in import account response                          
                                                                                
  POST /api/stellar/account/import was returning the submitted secretKey in the 
  response body, exposing it to proxy logs, network inspection tools, and       
  browser DevTools history.                                                     
                                                                                
  Response now returns only { publicKey, balances } — the client already has the
  secret key and doesn't need it back.          

Closes #236                                 