### PR TITLE
fix: strip secret key from offline queue, prompt on replay

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -49,27 +49,19 @@ self.addEventListener('fetch', (e) => {
   );
 });
 
-// Background sync for queued transactions
+// Background sync: notify the client to prompt for secret key re-entry.
+// Queued items contain only the payment intent (no secret key), so the SW
+// cannot replay them autonomously — the user must authorise each one.
 self.addEventListener('sync', (e) => {
   if (e.tag === 'sync-transactions') {
-    e.waitUntil(syncPendingTransactions());
+    e.waitUntil(notifyClientToReplay());
   }
 });
 
-async function syncPendingTransactions() {
-  const db = await openDB();
-  const pending = await db.getAll('pending-transactions');
-  for (const tx of pending) {
-    try {
-      const res = await fetch('/api/stellar/payment/send', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(tx.payload),
-      });
-      if (res.ok) await db.delete('pending-transactions', tx.id);
-    } catch {
-      // Will retry on next sync
-    }
+async function notifyClientToReplay() {
+  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+  for (const client of clients) {
+    client.postMessage({ type: 'REPLAY_QUEUED_PAYMENTS' });
   }
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -51,7 +51,9 @@ function App() {
 
   const msg = useMessages();
   const { canInstall, install, updateAvailable, applyUpdate } = usePWA();
-  const { queue: queueOffline, pendingCount } = useOfflineQueue();
+  const { queue: queueOffline, dequeue, pendingItems, pendingCount } = useOfflineQueue();
+  const [replaySecret, setReplaySecret] = useState('');
+  const [showReplayPrompt, setShowReplayPrompt] = useState(false);
   const { theme, isDark, toggleTheme } = useTheme();
   useRTL();
   const prefersReduced = useReducedMotion();
@@ -96,6 +98,16 @@ function App() {
   }, [loading]);
   }, [loading, showShortcuts]);
 
+  // Listen for SW notification that we're back online with queued payments
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) return;
+    const onSwMessage = (e) => {
+      if (e.data?.type === 'REPLAY_QUEUED_PAYMENTS') setShowReplayPrompt(true);
+    };
+    navigator.serviceWorker.addEventListener('message', onSwMessage);
+    return () => navigator.serviceWorker.removeEventListener('message', onSwMessage);
+  }, []);
+
   const resetForm = () => dispatch({ type: A.RESET_FORM });
 
   const resetForm = () => { setRecipient(''); setAmount(''); };
@@ -104,8 +116,30 @@ function App() {
     resetForm();
   };
 
+  const replayQueued = async () => {
+    if (!replaySecret) return;
+    setShowReplayPrompt(false);
+    let anyFailed = false;
+    for (const item of pendingItems) {
+      try {
+        await withTimeout(axios.post('/api/stellar/payment/send', {
+          sourceSecret: replaySecret,
+          destination: item.destination,
+          amount: item.amount,
+          assetCode: item.assetCode,
+        }));
+        await dequeue(item.id);
+      } catch (error) {
+        anyFailed = true;
+        logError(error, { context: 'replayQueued' });
+      }
+    }
+    setReplaySecret('');
+    if (anyFailed) msg.error('Some queued payments failed to send. Please retry.');
+    else { msg.success('All queued payments sent.'); checkBalance(); }
+  };
+
   const createAccount = async () => {
-    setLoading('create');
     try {
       const { data } = await withTimeout(axios.post('/api/stellar/account/create'));
       dispatch({ type: A.SET_ACCOUNT, payload: data });
@@ -171,8 +205,8 @@ function App() {
     } catch (error) {
       dispatch({ type: A.REVERT_BALANCE }); // roll back optimistic update
       if (!navigator.onLine) {
-        await queueOffline(payload);
-        msg.info('You are offline. Payment queued and will sync automatically.');
+        await queueOffline({ destination: payload.destination, amount: payload.amount, assetCode: payload.assetCode });
+        msg.info('You are offline. Payment queued — you\'ll be prompted to re-enter your secret key when back online.');
       } else {
         logError(error, { context: 'sendPayment' });
         msg.error(getFriendlyError(error), { retry: sendPayment });
@@ -645,6 +679,58 @@ function App() {
       <AnimatePresence>
         {showQR && account && (
           <QRCodeModal publicKey={account.publicKey} onClose={() => dispatch({ type: A.SET_SHOW_QR, payload: false })} />
+        )}
+      </AnimatePresence>
+
+      {/* Offline replay prompt */}
+      <AnimatePresence>
+        {showReplayPrompt && pendingCount > 0 && (
+          <motion.div
+            className="replay-modal-overlay"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="replay-title"
+            variants={v.pop} initial="hidden" animate="visible" exit="exit"
+          >
+            <div className="replay-modal">
+              <h2 id="replay-title">Send queued payments</h2>
+              <p>
+                You have {pendingCount} queued payment{pendingCount > 1 ? 's' : ''} waiting to be sent.
+                Enter your secret key to authorise {pendingCount > 1 ? 'them' : 'it'}.
+              </p>
+              <label htmlFor="replay-secret" className="sr-only">Secret key</label>
+              <input
+                id="replay-secret"
+                type="password"
+                placeholder="Secret key (S…)"
+                value={replaySecret}
+                onChange={(e) => setReplaySecret(e.target.value)}
+                autoComplete="off"
+                aria-describedby="replay-secret-hint"
+              />
+              <p id="replay-secret-hint" className="replay-modal__hint">
+                Your key is used only in memory to sign these transactions and is never stored.
+              </p>
+              <div className="replay-modal__actions">
+                <button
+                  type="button"
+                  onClick={replayQueued}
+                  disabled={!replaySecret}
+                  aria-label="Send queued payments"
+                >
+                  Send now
+                </button>
+                <button
+                  type="button"
+                  className="btn-clear"
+                  onClick={() => { setShowReplayPrompt(false); setReplaySecret(''); }}
+                  aria-label="Dismiss, send later"
+                >
+                  Later
+                </button>
+              </div>
+            </div>
+          </motion.div>
         )}
       </AnimatePresence>
     </div>

--- a/frontend/src/hooks/useOfflineQueue.js
+++ b/frontend/src/hooks/useOfflineQueue.js
@@ -14,35 +14,46 @@ function openDB() {
 }
 
 /**
- * Queue a transaction for background sync when offline.
- * Returns { queue, pendingCount }
+ * Queue a payment intent for later replay when back online.
+ * Only stores { destination, amount, assetCode } — never the secret key.
+ * Returns { queue, dequeue, pendingItems, pendingCount }
  */
 export function useOfflineQueue() {
-  const [pendingCount, setPendingCount] = useState(0);
+  const [pendingItems, setPendingItems] = useState([]);
 
-  const refreshCount = useCallback(async () => {
+  const refresh = useCallback(async () => {
     try {
       const db = await openDB();
       const tx = db.transaction(STORE, 'readonly');
-      const req = tx.objectStore(STORE).count();
-      req.onsuccess = () => setPendingCount(req.result);
+      const req = tx.objectStore(STORE).getAll();
+      req.onsuccess = () => setPendingItems(req.result ?? []);
     } catch { /* ignore */ }
   }, []);
 
-  useEffect(() => { refreshCount(); }, [refreshCount]);
+  useEffect(() => { refresh(); }, [refresh]);
 
-  const queue = useCallback(async (payload) => {
+  const queue = useCallback(async ({ destination, amount, assetCode }) => {
+    // Explicitly store only the payment intent — no sourceSecret
+    const intent = { destination, amount, assetCode, queuedAt: Date.now() };
     const db = await openDB();
     const tx = db.transaction(STORE, 'readwrite');
-    tx.objectStore(STORE).add({ payload, queuedAt: Date.now() });
+    tx.objectStore(STORE).add(intent);
     await new Promise((res) => { tx.oncomplete = res; });
-    refreshCount();
-    // Request background sync if supported
+    refresh();
+    // Register background sync so the SW can notify the client when online
     if ('serviceWorker' in navigator && 'SyncManager' in window) {
       const reg = await navigator.serviceWorker.ready;
       await reg.sync.register('sync-transactions').catch(() => {});
     }
-  }, [refreshCount]);
+  }, [refresh]);
 
-  return { queue, pendingCount };
+  const dequeue = useCallback(async (id) => {
+    const db = await openDB();
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).delete(id);
+    await new Promise((res) => { tx.oncomplete = res; });
+    refresh();
+  }, [refresh]);
+
+  return { queue, dequeue, pendingItems, pendingCount: pendingItems.length };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -799,3 +799,39 @@ kbd {
 
 .fu-actions { display: flex; gap: 8px; }
 .fu-actions button { flex: 1; }
+
+/* Offline replay modal */
+.replay-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+.replay-modal {
+  background: var(--card, #fff);
+  color: var(--text, #111);
+  border-radius: 12px;
+  padding: 24px;
+  max-width: 420px;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.replay-modal h2 { margin: 0; font-size: 1.1rem; }
+.replay-modal p  { margin: 0; font-size: 0.9rem; color: var(--text-secondary, #6b7280); }
+.replay-modal input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  box-sizing: border-box;
+}
+.replay-modal__hint { font-size: 0.78rem; color: #6b7280; }
+.replay-modal__actions { display: flex; gap: 8px; }


### PR DESCRIPTION
Summary

This PR fixes a critical security issue in frontend/src/hooks/useOfflineQueue.js where the full payment payload—including sourceSecret—was being persisted to localStorage. Since localStorage is accessible to any JavaScript running on the same origin, this exposed sensitive credentials to potential theft or XSS attacks.

Changes

1. Removed sourceSecret from all offline queue persistence logic
2. Updated offline queue to store only non-sensitive payment intent data:
-  destination
-  amount
-  asset
3. Added flow to prompt users to re-enter their secret key when reconnecting online
4. Adjusted queue replay logic to require fresh authentication input before execution

Security Impact
- Prevents sensitive key exposure via browser storage
- Mitigates risk from XSS and malicious injected scripts
- Aligns frontend behavior with secure key management practices

Behavioral Impact
1. Before: Full payment payload (including secret key) stored in localStorage and replayed automatically
2. After: Only payment intent is stored; secret key must be re-entered after reconnection

Tests / Validation
- [ ] Verified offline payments queue without storing sensitive data
- [ ] Confirmed replay flow requires user re-authentication
- [ ] Ensured no regression in offline/online payment transitions

Acceptance Criteria
- [ ]  sourceSecret removed from persisted offline queue
- [ ]  Only payment intent data stored in localStorage
- [ ]  User prompted to re-enter secret key on reconnect
- [ ]  Offline payment flow remains functional without credential leakage

Closes #233 