### PR TITLE
fix: never persist secretKey to localStorage in store or tabSync

### DIFF
--- a/frontend/src/store/persistence.js
+++ b/frontend/src/store/persistence.js
@@ -1,20 +1,20 @@
 import { initialState, STATE_VERSION } from './reducer.js';
 
-const STORAGE_KEY = 'app_state_v1';
+// Bump this key whenever the persisted shape changes to evict stale data.
+const STORAGE_KEY = 'app_state_v2';
 
-// Fields persisted to localStorage (never persist secretKey)
-const PERSIST_KEYS = ['account'];
-
+/**
+ * Build the subset of state that is safe to persist.
+ * Only publicKey is kept from the account object — secretKey must never
+ * be written to browser storage.
+ */
 function sanitize(state) {
-  const out = {};
-  for (const key of PERSIST_KEYS) {
-    if (state[key] !== undefined) out[key] = state[key];
-  }
-  // Strip secret key from persisted account
-  if (out.account?.secretKey) {
-    out.account = { publicKey: out.account.publicKey };
-  }
-  return out;
+  return {
+    // Allowlist: only publicKey — never secretKey
+    account: state.account?.publicKey
+      ? { publicKey: state.account.publicKey }
+      : null,
+  };
 }
 
 export function loadState() {
@@ -22,9 +22,12 @@ export function loadState() {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return initialState;
     const saved = JSON.parse(raw);
-    // Migration: if version mismatch, discard persisted state
     if (saved._version !== STATE_VERSION) return initialState;
-    return { ...initialState, ...saved };
+    // Merge only the safe persisted fields back into initial state
+    return {
+      ...initialState,
+      account: saved.account ?? null,
+    };
   } catch {
     return initialState;
   }
@@ -32,7 +35,10 @@ export function loadState() {
 
 export function saveState(state) {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ _version: STATE_VERSION, ...sanitize(state) }));
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ _version: STATE_VERSION, ...sanitize(state) })
+    );
   } catch {
     // ignore quota errors
   }

--- a/frontend/src/store/tabSync.js
+++ b/frontend/src/store/tabSync.js
@@ -12,7 +12,8 @@ export function createTabSync(onMessage) {
     };
   }
 
-  // Fallback: storage events (cross-tab, same origin)
+  // Fallback: storage events (cross-tab, same origin).
+  // Never write secretKey to localStorage — strip it from SET_ACCOUNT payloads.
   const handler = (e) => {
     if (e.key === CHANNEL_NAME) {
       try { onMessage(JSON.parse(e.newValue)); } catch { /* ignore */ }
@@ -21,7 +22,12 @@ export function createTabSync(onMessage) {
   window.addEventListener('storage', handler);
   return {
     broadcast: (msg) => {
-      try { localStorage.setItem(CHANNEL_NAME, JSON.stringify(msg)); } catch { /* ignore */ }
+      try {
+        const safe = msg.type === 'SET_ACCOUNT' && msg.payload?.secretKey
+          ? { ...msg, payload: { publicKey: msg.payload.publicKey } }
+          : msg;
+        localStorage.setItem(CHANNEL_NAME, JSON.stringify(safe));
+      } catch { /* ignore */ }
     },
     destroy: () => window.removeEventListener('storage', handler),
   };


### PR DESCRIPTION
Summary

Fixes a security issue where state.account.secretKey was being saved to localStorage in frontend/src/store/persistence.js. Sensitive data must not be persisted in browser storage.

Changes
- Removed secretKey from persisted state
- Ensured only publicKey (safe data) is stored
- Updated persistence logic to exclude sensitive account fields

Impact
- Prevents exposure of private keys via localStorage or XSS
- Requires re-entry of secret key after reload, while preserving wallet identity via publicKey

Acceptance Criteria
- secretKey not persisted
- Only safe account data stored
- No functional regressions in state restoration

CLoses #234 