### PR TITLE
Fix: missing import, multi-sig persistence, Friendbot error handling, and exchange rate

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -152,3 +152,16 @@ model AMLAlert {
   riskLevel     String
   createdAt     DateTime @default(now())
 }
+
+model PendingMultiSigTx {
+  txId            String   @id
+  txXdr           String
+  sourcePublicKey String
+  destination     String
+  amount          String
+  assetCode       String   @default("XLM")
+  signatures      Json     @default("[]")
+  status          String   @default("pending")
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+}

--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -219,6 +219,9 @@ router.get('/exchange-rate/:from/:to', rules.assetCodeParams, validate,
     try {
       const { from, to } = req.params;
       const rate = await getRate(from, to);
+      if (rate === null) {
+        return res.status(503).json({ error: `Exchange rate unavailable for ${from}/${to}: no liquidity in orderbook` });
+      }
       res.json({ from, to, rate });
     } catch (error) {
       res.status(500).json({ error: error.message });

--- a/backend/src/services/multiSig.js
+++ b/backend/src/services/multiSig.js
@@ -1,15 +1,13 @@
 import * as StellarSDK from '@stellar/stellar-sdk';
 import dotenv from 'dotenv';
 import { eventMonitor } from '../eventSourcing/index.js';
+import prisma from '../db/client.js';
 
 dotenv.config();
 
 const server = new StellarSDK.Horizon.Server(process.env.HORIZON_URL);
 const isTestnet = process.env.STELLAR_NETWORK === 'testnet';
 const networkPassphrase = isTestnet ? StellarSDK.Networks.TESTNET : StellarSDK.Networks.PUBLIC;
-
-// In-memory store for pending multi-sig transactions (replace with DB in production)
-const pendingTransactions = new Map();
 
 /**
  * Create a multi-signature account by setting signers and threshold on an existing account.
@@ -103,16 +101,17 @@ export async function buildMultiSigTransaction(sourcePublicKey, destination, amo
   const txXdr = transaction.toXDR();
   const txId = `multisig-${Date.now()}-${Math.random().toString(36).substr(2, 6)}`;
 
-  pendingTransactions.set(txId, {
-    txId,
-    txXdr,
-    sourcePublicKey,
-    destination,
-    amount,
-    assetCode,
-    signatures: [],
-    createdAt: new Date().toISOString(),
-    status: 'pending',
+  await prisma.pendingMultiSigTx.create({
+    data: {
+      txId,
+      txXdr,
+      sourcePublicKey,
+      destination,
+      amount: amount.toString(),
+      assetCode,
+      signatures: [],
+      status: 'pending',
+    },
   });
 
   await eventMonitor.publishEvent(sourcePublicKey, {
@@ -128,37 +127,42 @@ export async function buildMultiSigTransaction(sourcePublicKey, destination, amo
  * Add a signature to a pending multi-sig transaction.
  */
 export async function addSignature(txId, signerSecret) {
-  const pending = pendingTransactions.get(txId);
+  const pending = await prisma.pendingMultiSigTx.findUnique({ where: { txId } });
   if (!pending) throw new Error(`Transaction ${txId} not found`);
   if (pending.status !== 'pending') throw new Error(`Transaction ${txId} is already ${pending.status}`);
 
   const signerKeypair = StellarSDK.Keypair.fromSecret(signerSecret);
   const signerPublicKey = signerKeypair.publicKey();
 
+  const signatures = pending.signatures;
   // Prevent duplicate signatures
-  if (pending.signatures.some((s) => s.publicKey === signerPublicKey)) {
+  if (signatures.some((s) => s.publicKey === signerPublicKey)) {
     throw new Error(`Signer ${signerPublicKey} has already signed this transaction`);
   }
 
   const transaction = StellarSDK.TransactionBuilder.fromXDR(pending.txXdr, networkPassphrase);
   transaction.sign(signerKeypair);
 
-  // Update stored XDR with new signature
-  pending.txXdr = transaction.toXDR();
-  pending.signatures.push({ publicKey: signerPublicKey, signedAt: new Date().toISOString() });
+  const updatedSignatures = [...signatures, { publicKey: signerPublicKey, signedAt: new Date().toISOString() }];
+  const updatedXdr = transaction.toXDR();
+
+  await prisma.pendingMultiSigTx.update({
+    where: { txId },
+    data: { txXdr: updatedXdr, signatures: updatedSignatures },
+  });
 
   await eventMonitor.publishEvent(pending.sourcePublicKey, {
     type: 'MultiSigTransactionSigned',
-    data: { txId, signerPublicKey, totalSignatures: pending.signatures.length },
+    data: { txId, signerPublicKey, totalSignatures: updatedSignatures.length },
     version: 1,
   });
 
   return {
     txId,
     signerPublicKey,
-    totalSignatures: pending.signatures.length,
-    signatures: pending.signatures,
-    txXdr: pending.txXdr,
+    totalSignatures: updatedSignatures.length,
+    signatures: updatedSignatures,
+    txXdr: updatedXdr,
   };
 }
 
@@ -166,14 +170,17 @@ export async function addSignature(txId, signerSecret) {
  * Submit a fully-signed multi-sig transaction to the network.
  */
 export async function submitMultiSigTransaction(txId) {
-  const pending = pendingTransactions.get(txId);
+  const pending = await prisma.pendingMultiSigTx.findUnique({ where: { txId } });
   if (!pending) throw new Error(`Transaction ${txId} not found`);
   if (pending.status !== 'pending') throw new Error(`Transaction ${txId} is already ${pending.status}`);
 
   const transaction = StellarSDK.TransactionBuilder.fromXDR(pending.txXdr, networkPassphrase);
   const result = await server.submitTransaction(transaction);
 
-  pending.status = result.successful ? 'submitted' : 'failed';
+  await prisma.pendingMultiSigTx.update({
+    where: { txId },
+    data: { status: result.successful ? 'submitted' : 'failed' },
+  });
 
   await eventMonitor.publishEvent(pending.sourcePublicKey, {
     type: 'MultiSigTransactionSubmitted',
@@ -304,39 +311,16 @@ export async function updateMultiSigConfig(sourceSecret, updates) {
 /**
  * Get all pending multi-sig transactions for a given source account.
  */
-export function getPendingTransactions(sourcePublicKey) {
-  const results = [];
-  for (const tx of pendingTransactions.values()) {
-    if (tx.sourcePublicKey === sourcePublicKey) {
-      results.push({
-        txId: tx.txId,
-        destination: tx.destination,
-        amount: tx.amount,
-        assetCode: tx.assetCode,
-        signatures: tx.signatures,
-        status: tx.status,
-        createdAt: tx.createdAt,
-      });
-    }
-  }
-  return results;
+export async function getPendingTransactions(sourcePublicKey) {
+  const rows = await prisma.pendingMultiSigTx.findMany({ where: { sourcePublicKey } });
+  return rows.map(({ txId, destination, amount, assetCode, signatures, status, createdAt }) => ({
+    txId, destination, amount, assetCode, signatures, status, createdAt,
+  }));
 }
 
 /**
  * Get a specific pending transaction by ID.
  */
-export function getPendingTransaction(txId) {
-  const tx = pendingTransactions.get(txId);
-  if (!tx) return null;
-  return {
-    txId: tx.txId,
-    txXdr: tx.txXdr,
-    sourcePublicKey: tx.sourcePublicKey,
-    destination: tx.destination,
-    amount: tx.amount,
-    assetCode: tx.assetCode,
-    signatures: tx.signatures,
-    status: tx.status,
-    createdAt: tx.createdAt,
-  };
+export async function getPendingTransaction(txId) {
+  return prisma.pendingMultiSigTx.findUnique({ where: { txId } });
 }

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -57,7 +57,10 @@ export async function createAccount() {
   logger.info('stellar.createAccount', { publicKey });
   
   if (isTestnet()) {
-    await fetch(`https://friendbot.stellar.org?addr=${publicKey}`);
+    const friendbotRes = await fetch(`https://friendbot.stellar.org?addr=${publicKey}`);
+    if (!friendbotRes.ok) {
+      throw new Error(`Friendbot funding failed: ${friendbotRes.status} ${friendbotRes.statusText}`);
+    }
     logger.debug('stellar.friendbotFunded', { publicKey });
     await eventMonitor.publishEvent(publicKey, {
       type: 'AccountFunded',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import { TransactionHistory } from './components/TransactionHistory';
 import { FeeDisplay } from './components/FeeDisplay';
 import { logError } from './utils/errorLogger';
 import { ImportAccountForm } from './components/ImportAccountForm';
+import { LanguageSelector } from './components/LanguageSelector';
 import { FileUpload } from './components/FileUpload';
 import { useTheme } from './contexts/ThemeContext';
 import { useAppState, useAppDispatch, A } from './store/index.js';


### PR DESCRIPTION
                                                                 
                                                                                                                
  closes #215  — Add missing `LanguageSelector` import (`frontend/src/App.jsx`)                                         
                                                                                                                
  <LanguageSelector /> was rendered in JSX but never imported, causing a runtime crash. Added:                  
                                                                                                                
  import { LanguageSelector } from './components/LanguageSelector';                                             
                                                                                                                
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                
  closes #217  — Persist pending multi-sig transactions to database (`backend/src/services/multiSig.js`,                
  `backend/prisma/schema.prisma`)                                                                               
                                                                                                                
  Pending multi-sig transactions were stored in a module-level Map, which is wiped on every server restart,     
  crash, or when running multiple instances.                                                                    
                                                                                                                
  - Added a PendingMultiSigTx Prisma model to schema.prisma                                                     
  - Replaced all pendingTransactions.set/get calls in buildMultiSigTransaction, addSignature,                   
  submitMultiSigTransaction, getPendingTransactions, and getPendingTransaction with prisma.pendingMultiSigTx    
  CRUD operations                                                                                               
                                                                                                                
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                
  closes #221  — Check Friendbot response status (`backend/src/services/stellar.js`)                                    
                                                                                                                
  The Friendbot fetch call was fire-and-forget — a non-2xx response (rate limit, account already exists, network
  error) was silently swallowed and the account was returned as if it were funded. Now checks response.ok and   
  throws a descriptive error on failure:                                                                        
                                                                                                                
  const friendbotRes = await fetch(`https://friendbot.stellar.org?addr=${publicKey}`);                          
  if (!friendbotRes.ok) {                                                                                       
    throw new Error(`Friendbot funding failed: ${friendbotRes.status} ${friendbotRes.statusText}`);             
  }                                                                                                             
                                                                                                                
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                
 closes #222  — Return 503 when exchange rate is unavailable (`backend/src/routes/stellar.js`)                         
                                                                                                                
  When the orderbook had no asks, getRate returned null and the route responded { from, to, rate: null } with   
  HTTP 200, making it indistinguishable from a valid zero rate. The route handler now returns a 503 with a      
  descriptive message when rate === null.