### PR TITLE
fix(#247): use getIssuer('USDC') instead of hardcoded mainnet issuer in getFeeStats

### DIFF
--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -1,6 +1,7 @@
 import * as StellarSDK from '@stellar/stellar-sdk';
 import { eventMonitor } from '../eventSourcing/index.js';
 import { getConfig } from '../config/env.js';
+import { getIssuer } from '../config/assets.js';
 import logger from '../config/logger.js';
 import prisma from '../db/client.js';
 
@@ -309,7 +310,7 @@ export async function getFeeStats() {
   // Fetch XLM/USD price via Stellar SDEX (XLM/USDC order book)
   let xlmUsd = null;
   try {
-    const usdc = new StellarSDK.Asset('USDC', 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+    const usdc = new StellarSDK.Asset('USDC', getIssuer('USDC'));
     const book = await getHorizonServer().orderbook(StellarSDK.Asset.native(), usdc).limit(1).call();
     const ask = parseFloat(book.asks?.[0]?.price);
     if (ask > 0) xlmUsd = ask;


### PR DESCRIPTION
## Summary

Closes #247

In `getFeeStats`, the USDC issuer was hardcoded to the mainnet address `GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN`. On testnet this address does not exist, causing the orderbook call to fail silently and `xlmUsd` to always return `null`.

## Change

Replace the hardcoded issuer with `getIssuer('USDC')`, which already resolves the correct issuer per network (`GBBD47IF...` on testnet, `GA5ZSEJ...` on mainnet) based on the `STELLAR_NETWORK` env var.

```diff
- const usdc = new StellarSDK.Asset('USDC', 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+ const usdc = new StellarSDK.Asset('USDC', getIssuer('USDC'));
```