### PR TITLE
fix(#251): batch all CoinGecko prices in a single request in getAllRates

### DIFF
--- a/backend/src/services/exchangeRate.js
+++ b/backend/src/services/exchangeRate.js
@@ -114,17 +114,48 @@ export async function convert(amount, from, to) {
   return parseFloat((amount * rate).toFixed(7));
 }
 
-/** Fetch all supported pair rates at once. */
+/** Fetch all supported pair rates at once via a single batched CoinGecko request. */
 export async function getAllRates() {
-  const pairs = [];
+  // Collect assets that have a CoinGecko ID and aren't fully cached yet
+  const needed = SUPPORTED_ASSETS.filter(a => COINGECKO_IDS[a]);
+
+  // Single batched request: all coin IDs vs USD (USDC is pegged 1:1 to USD)
+  const pricesUsd = {};
+  try {
+    const ids = needed.map(a => COINGECKO_IDS[a]).join(',');
+    const apiKey = process.env.COINGECKO_API_KEY;
+    const headers = apiKey ? { 'x-cg-demo-api-key': apiKey } : {};
+    const res = await fetch(
+      `${COINGECKO_BASE}/simple/price?ids=${ids}&vs_currencies=usd`,
+      { headers, signal: AbortSignal.timeout(5_000) }
+    );
+    if (res.ok) {
+      const data = await res.json();
+      for (const asset of needed) {
+        const usd = data[COINGECKO_IDS[asset]]?.usd;
+        if (usd != null) pricesUsd[asset] = usd;
+      }
+      lastFetchAt = Date.now();
+    }
+  } catch (err) {
+    logger.warn('exchangeRate.getAllRates.coingecko.failed', { error: err.message });
+  }
+
+  // Derive all pairs from USD prices, fall back to getRate for anything missing
+  const results = [];
   for (const from of SUPPORTED_ASSETS) {
     for (const to of SUPPORTED_ASSETS) {
-      if (from !== to) pairs.push({ from, to });
+      if (from === to) continue;
+      let rate = getCached(from, to);
+      if (rate == null && pricesUsd[from] != null && pricesUsd[to] != null) {
+        rate = pricesUsd[from] / pricesUsd[to];
+        setCache(from, to, rate);
+        notifyIfChanged(from, to, rate);
+      }
+      if (rate == null) rate = await getRate(from, to); // fallback (DEX / cache)
+      results.push({ from, to, rate });
     }
   }
-  const results = await Promise.all(pairs.map(async ({ from, to }) => ({
-    from, to, rate: await getRate(from, to),
-  })));
   return results;
 }
 

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -1,6 +1,7 @@
 import * as StellarSDK from '@stellar/stellar-sdk';
 import { eventMonitor } from '../eventSourcing/index.js';
 import { getConfig } from '../config/env.js';
+import { getIssuer } from '../config/assets.js';
 import logger from '../config/logger.js';
 import prisma from '../db/client.js';
 
@@ -309,7 +310,7 @@ export async function getFeeStats() {
   // Fetch XLM/USD price via Stellar SDEX (XLM/USDC order book)
   let xlmUsd = null;
   try {
-    const usdc = new StellarSDK.Asset('USDC', 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
+    const usdc = new StellarSDK.Asset('USDC', getIssuer('USDC'));
     const book = await getHorizonServer().orderbook(StellarSDK.Asset.native(), usdc).limit(1).call();
     const ask = parseFloat(book.asks?.[0]?.price);
     if (ask > 0) xlmUsd = ask;


### PR DESCRIPTION
## Summary

Closes #251

`getAllRates` was calling `getRate` for every pair in `SUPPORTED_ASSETS × SUPPORTED_ASSETS` concurrently via `Promise.all`. With the `API_MIN_GAP_MS` guard, all but the first call returned `null` since they fired within 2 seconds of each other.

## Change

Replace the N² concurrent calls with a single batched CoinGecko request fetching all coin prices in USD at once, then derive all pair rates from that response.

```
// Before: N² concurrent requests
Promise.all(pairs.map(({ from, to }) => getRate(from, to)))

// After: 1 request
GET /simple/price?ids=stellar,usd-coin&vs_currencies=usd
// → derive XLM/USDC = pricesUsd[XLM] / pricesUsd[USDC], etc.
```

Falls back to `getRate` (cache → Stellar DEX) for any pair not covered by CoinGecko.