### PR TITLE
fix: resolve issues #206, #212, #223, #225

### DIFF
--- a/backend/src/config/assets.js
+++ b/backend/src/config/assets.js
@@ -9,16 +9,19 @@ const ASSETS = {
   },
 };
 
-const isTestnet = process.env.STELLAR_NETWORK === 'testnet';
-const network = isTestnet ? 'testnet' : 'mainnet';
+import { getConfig } from './env.js';
 
 /**
  * Returns the issuer public key for a supported non-native asset.
  * Falls back to ASSET_ISSUER env var for custom assets.
  */
 export function getIssuer(assetCode) {
-  return ASSETS[network][assetCode] ?? process.env.ASSET_ISSUER ?? null;
+  const network = getConfig().stellar.network;
+  return ASSETS[network]?.[assetCode] ?? process.env.ASSET_ISSUER ?? null;
 }
 
 /** Returns the list of supported asset codes (including XLM). */
-export const SUPPORTED_ASSETS = ['XLM', ...Object.keys(ASSETS[network])];
+export function getSupportedAssets() {
+  const network = getConfig().stellar.network;
+  return ['XLM', ...Object.keys(ASSETS[network] ?? {})];
+}

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -26,9 +26,10 @@ export function wrapWithFeeBump(innerTx, feeAccountSecret) {
     ? StellarSDK.Networks.TESTNET
     : StellarSDK.Networks.PUBLIC;
 
+  const multiplier = parseInt(process.env.FEE_BUMP_MULTIPLIER ?? '10', 10);
   const feeBumpTx = StellarSDK.TransactionBuilder.buildFeeBumpTransaction(
     feeKeypair,
-    StellarSDK.BASE_FEE * 10, // fee bump pays 10x base fee
+    StellarSDK.BASE_FEE * multiplier,
     innerTx,
     networkPassphrase
   );
@@ -161,7 +162,7 @@ export async function sendPayment(sourceSecret, destination, amount, assetCode =
       });
       // Track stats for cost monitoring
       feeBumpStats.total += 1;
-      feeBumpStats.totalFeeStroops += StellarSDK.BASE_FEE * 10;
+      feeBumpStats.totalFeeStroops += StellarSDK.BASE_FEE * parseInt(process.env.FEE_BUMP_MULTIPLIER ?? '10', 10);
       feeBumpStats.accounts.add(sourcePublicKey);
     }
   }
@@ -169,7 +170,6 @@ export async function sendPayment(sourceSecret, destination, amount, assetCode =
   let result;
   try {
     result = await getHorizonServer().submitTransaction(txToSubmit);
-    result = await getHorizonServer().submitTransaction(transaction);
   } catch (err) {
     logger.error('stellar.sendPayment.failed', { source: sourcePublicKey, destination, amount, assetCode, error: err.message });
     throw err;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -41,7 +41,6 @@ function App() {
   const [recipient, setRecipient] = useState('');
   const [amount, setAmount] = useState('');
   const [memo, setMemo] = useState('');
-  const [loading, setLoading] = useState('');
   const [showQR, setShowQR] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [showImportForm, setShowImportForm] = useState(false);


### PR DESCRIPTION
fix: resolve issues #206, #212, #223, #225

#212 — setLoading redeclared after destructuring (App.jsx) const [loading, setLoading] = useState('') was declared and then immediately shadowed by the dispatch wrapper const setLoading = (val) => dispatch(...). This is a syntax error — loading state lives in the reducer, so the useState line has been removed.

#225 — Network resolved at module load time (
assets.js
) isTestnet and network were module-level constants evaluated once on first import. In test environments where STELLAR_NETWORK is set after module load, getIssuer() would return the wrong issuer for the entire run. Both getIssuer() and SUPPORTED_ASSETS (now getSupportedAssets()) now read getConfig().stellar.network at call time.

#223 — Fee-bump multiplier hardcoded (
stellar.js
) StellarSDK.BASE_FEE * 10 was hardcoded in both wrapWithFeeBump and the stats tracker. During network congestion BASE_FEE alone may be insufficient. The multiplier is now read from FEE_BUMP_MULTIPLIER env var (default 10), consistent with the existing FEE_BUMP_THRESHOLD_XLM pattern.

#206 — Transaction submitted twice (
stellar.js
) Inside the try block of sendPayment, submitTransaction was called twice — first with txToSubmit (the correct fee-bump-wrapped tx), then again with the raw transaction. The second call consumed the already-used sequence number, silently bypassed fee-bump logic, and overwrote result with a failed submission. The duplicate line has been removed.

closes #206, closes #212, closes #223, closes #225