### PR TITLE
feat: add confirm before send dialog

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import { TransactionHistory } from './components/TransactionHistory';
 import { FeeDisplay } from './components/FeeDisplay';
 import { logError } from './utils/errorLogger';
 import { ImportAccountForm } from './components/ImportAccountForm';
+import { ConfirmSendDialog } from './components/ConfirmSendDialog';
 import { LanguageSelector } from './components/LanguageSelector';
 import { FileUpload } from './components/FileUpload';
 import { useTheme } from './contexts/ThemeContext';
@@ -46,6 +47,7 @@ function App() {
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [showImportForm, setShowImportForm] = useState(false);
   const [confirmClear, setConfirmClear] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
   const { account, balance, loading, recipient, amount, showQR, showImportForm, showShortcuts } = useAppState();
   const dispatch = useAppDispatch();
 
@@ -470,7 +472,7 @@ function App() {
                     placeholder="Recipient Public Key"
                     value={recipient}
                     onChange={(e) => dispatch({ type: A.SET_RECIPIENT, payload: e.target.value })}
-                    onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
+                    onKeyDown={(e) => e.key === 'Enter' && setShowConfirm(true)}
                     style={{ border: `2px solid ${recipientTouched ? (recipientValid ? '#22c55e' : '#ef4444') : '#ccc'}` }}
                     aria-label="Recipient public key"
                   />
@@ -489,7 +491,7 @@ function App() {
                     placeholder="Amount (XLM)"
                     value={amount}
                     onChange={(e) => dispatch({ type: A.SET_AMOUNT, payload: formatAmount(e.target.value) })}
-                    onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
+                    onKeyDown={(e) => e.key === 'Enter' && setShowConfirm(true)}
                     style={{ border: `2px solid ${amountTouched ? (amountValid ? '#22c55e' : '#ef4444') : '#ccc'}` }}
                     aria-label="Payment amount in XLM"
                   />
@@ -610,7 +612,7 @@ function App() {
                         placeholder="Recipient Public Key"
                         value={recipient}
                         onChange={(e) => setRecipient(e.target.value)}
-                        onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
+                        onKeyDown={(e) => e.key === 'Enter' && setShowConfirm(true)}
                         style={{ border: `2px solid ${recipientTouched ? (recipientValid ? '#22c55e' : '#ef4444') : '#ccc'}` }}
                         aria-label="Recipient public key"
                         aria-invalid={recipientTouched && !recipientValid}
@@ -636,7 +638,7 @@ function App() {
                         placeholder="Amount (XLM)"
                         value={amount}
                         onChange={(e) => setAmount(formatAmount(e.target.value))}
-                        onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
+                        onKeyDown={(e) => e.key === 'Enter' && setShowConfirm(true)}
                         style={{ border: `2px solid ${amountTouched ? (amountValid ? '#22c55e' : '#ef4444') : '#ccc'}` }}
                         aria-label="Payment amount in XLM"
                         aria-invalid={amountTouched && !!amountError}
@@ -671,7 +673,7 @@ function App() {
                         placeholder="Memo (optional, max 28 chars)"
                         value={memo}
                         onChange={(e) => setMemo(e.target.value.slice(0, 28))}
-                        onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
+                        onKeyDown={(e) => e.key === 'Enter' && setShowConfirm(true)}
                         aria-label="Payment memo (optional)"
                         maxLength="28"
                       />
@@ -681,7 +683,7 @@ function App() {
                     <FeeDisplay amount={amount} visible={amountValid} />
                     <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
                       <motion.button
-                        onClick={sendPayment}
+                        onClick={() => setShowConfirm(true)}
                         {...tap}
                         disabled={!recipientValid || !amountValid || loading === 'send'}
                         aria-busy={loading === 'send'}
@@ -732,6 +734,15 @@ function App() {
             <QRCodeModal publicKey={account.publicKey} onClose={() => setShowQR(false)} />
           )}
         </AnimatePresence>
+
+        <ConfirmSendDialog
+          open={showConfirm}
+          recipient={recipient}
+          amount={amount}
+          asset="XLM"
+          onConfirm={() => { setShowConfirm(false); sendPayment(); }}
+          onCancel={() => setShowConfirm(false)}
+        />
       </div>
     </>
       {/* QR Code Modal */}

--- a/frontend/src/components/ConfirmSendDialog.jsx
+++ b/frontend/src/components/ConfirmSendDialog.jsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import { Modal } from '../design-system/Modal';
+
+function truncate(addr) {
+  if (!addr || addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-6)}`;
+}
+
+/**
+ * ConfirmSendDialog — shows a summary of the pending payment and requires
+ * explicit confirmation before the transaction is submitted.
+ *
+ * @param {boolean}    open
+ * @param {() => void} onConfirm
+ * @param {() => void} onCancel
+ * @param {string}     recipient
+ * @param {string}     amount
+ * @param {string}     asset
+ */
+export function ConfirmSendDialog({ open, onConfirm, onCancel, recipient, amount, asset = 'XLM' }) {
+  const [fee, setFee] = useState(null);
+  const [usdRate, setUsdRate] = useState(null);
+  const cache = useRef({});
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (!cache.current.fee) {
+      axios.get('/api/stellar/fee-stats')
+        .then(({ data }) => { cache.current.fee = data; setFee(data); })
+        .catch(() => {});
+    } else {
+      setFee(cache.current.fee);
+    }
+
+    if (!cache.current.rate) {
+      axios.get('/api/stellar/exchange-rate/XLM/USD')
+        .then(({ data }) => { cache.current.rate = data.rate; setUsdRate(data.rate); })
+        .catch(() => {});
+    } else {
+      setUsdRate(cache.current.rate);
+    }
+  }, [open]);
+
+  const amtNum = parseFloat(amount) || 0;
+  const feeXLM = fee ? parseFloat(fee.feeXLM) : null;
+  const totalXLM = feeXLM !== null ? (amtNum + feeXLM).toFixed(7).replace(/\.?0+$/, '') : null;
+  const amtUsd = usdRate ? (amtNum * usdRate).toFixed(2) : null;
+
+  return (
+    <Modal open={open} onClose={onCancel} title="Confirm Payment" size="sm">
+      <dl className="confirm-dialog__summary">
+        <div className="confirm-dialog__row">
+          <dt>Recipient</dt>
+          <dd title={recipient}>{truncate(recipient)}</dd>
+        </div>
+        <div className="confirm-dialog__row">
+          <dt>Amount</dt>
+          <dd>
+            {amount} {asset}
+            {amtUsd && <span className="confirm-dialog__usd"> ≈ ${amtUsd} USD</span>}
+          </dd>
+        </div>
+        <div className="confirm-dialog__row">
+          <dt>Estimated fee</dt>
+          <dd>
+            {feeXLM !== null
+              ? <>{feeXLM} XLM{fee?.feeUsd && <span className="confirm-dialog__usd"> ≈ ${fee.feeUsd} USD</span>}</>
+              : '—'}
+          </dd>
+        </div>
+        {totalXLM && (
+          <div className="confirm-dialog__row confirm-dialog__row--total">
+            <dt>Total deducted</dt>
+            <dd>{totalXLM} {asset}</dd>
+          </div>
+        )}
+      </dl>
+      <div className="confirm-dialog__actions">
+        <button type="button" onClick={onConfirm} className="confirm-dialog__btn-confirm">
+          Confirm &amp; Send
+        </button>
+        <button type="button" onClick={onCancel} className="confirm-dialog__btn-cancel btn-clear">
+          Cancel
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -885,3 +885,76 @@ kbd {
 }
 .replay-modal__hint { font-size: 0.78rem; color: #6b7280; }
 .replay-modal__actions { display: flex; gap: 8px; }
+
+/* Confirm Send Dialog */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+.modal {
+  background: var(--card, #fff);
+  color: var(--text, #111);
+  border-radius: 12px;
+  padding: 24px;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  outline: none;
+}
+.modal-sm  { max-width: 380px; }
+.modal-md  { max-width: 520px; }
+.modal-lg  { max-width: 720px; }
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.modal-title { margin: 0; font-size: 1.1rem; }
+.modal-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--text-secondary, #6b7280);
+  padding: 4px;
+  line-height: 1;
+}
+.modal-close:hover { color: var(--danger, #ef4444); }
+.modal-body { display: flex; flex-direction: column; gap: 16px; }
+
+.confirm-dialog__summary {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.confirm-dialog__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 0.9rem;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border, #e5e7eb);
+}
+.confirm-dialog__row:last-child { border-bottom: none; }
+.confirm-dialog__row dt { color: var(--text-secondary, #6b7280); flex-shrink: 0; }
+.confirm-dialog__row dd { margin: 0; font-weight: 500; text-align: right; word-break: break-all; }
+.confirm-dialog__row--total dt,
+.confirm-dialog__row--total dd { font-weight: 700; }
+.confirm-dialog__usd { font-size: 0.8rem; color: var(--text-secondary, #6b7280); margin-left: 4px; }
+
+.confirm-dialog__actions {
+  display: flex;
+  gap: 8px;
+}
+.confirm-dialog__btn-confirm { flex: 1; }
+.confirm-dialog__btn-cancel  { flex: 1; }


### PR DESCRIPTION
Closes #297

---

## Summary

Adds a confirmation dialog that appears before any payment is submitted, preventing accidental sends.

## Changes

- **New component** `ConfirmSendDialog.jsx` — modal dialog built on the existing `Modal` design system component
- **Send button** now opens the dialog instead of submitting immediately
- **Enter key** on recipient/amount/memo inputs also opens the dialog
- **Dialog shows:**
  - Recipient address (truncated, e.g. `GABCDE…FGHIJK`)
  - Amount + asset
  - Estimated network fee (XLM + USD)
  - Total deducted (amount + fee)
  - Estimated USD value of the send amount
- Fee and exchange rate data fetched from existing `/api/stellar/fee-stats` and `/api/stellar/exchange-rate/XLM/USD` endpoints, cached per dialog instance
- CSS added to `index.css` for the `Modal` design system component and confirm dialog layout

## Closes

Resolves: Add "Confirm before send" dialog