### PR TITLE
feat: add transaction search by hash

### DIFF
--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -191,7 +191,7 @@ router.post('/payment/send', rules.sendPayment, validate, async (req, res) => {
  */
 router.get('/account/:publicKey/transactions', rules.publicKeyParam, validate, async (req, res) => {
   try {
-    const { cursor, limit, type, dateFrom, dateTo } = req.query;
+    const { cursor, limit, type, dateFrom, dateTo, hash } = req.query;
     const result = await StellarService.getTransactions(req.params.publicKey, {
       cursor,
       limit: limit ? Math.min(parseInt(limit), 50) : 10,
@@ -199,6 +199,10 @@ router.get('/account/:publicKey/transactions', rules.publicKeyParam, validate, a
       dateFrom,
       dateTo,
     });
+    if (hash) {
+      const prefix = hash.toLowerCase();
+      result.records = result.records.filter(tx => tx.hash?.toLowerCase().startsWith(prefix));
+    }
     res.json(result);
   } catch (error) {
     res.status(500).json({ error: error.message });

--- a/frontend/src/components/TransactionHistory.jsx
+++ b/frontend/src/components/TransactionHistory.jsx
@@ -95,7 +95,7 @@ export function TransactionHistory({ publicKey }) {
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [selected, setSelected] = useState(null);
-  const [filters, setFilters] = useState({ type: '', dateFrom: '', dateTo: '' });
+  const [filters, setFilters] = useState({ type: '', dateFrom: '', dateTo: '', hash: '' });
   const [cursors, setCursors] = useState([]); // ring-buffer for back-pagination (max 50)
   const [error, setError] = useState(null);
 
@@ -110,6 +110,7 @@ export function TransactionHistory({ publicKey }) {
       if (filters.type) params.type = filters.type;
       if (filters.dateFrom) params.dateFrom = filters.dateFrom;
       if (filters.dateTo) params.dateTo = filters.dateTo;
+      if (filters.hash) params.hash = filters.hash;
       const { data } = await axios.get(`/api/stellar/account/${publicKey}/transactions`, { params });
       setTxs(data.records);
       setNextCursor(data.nextCursor);
@@ -184,6 +185,16 @@ export function TransactionHistory({ publicKey }) {
           aria-label="Filter to date"
         />
         <button type="submit" className="tx-filter-btn">Filter</button>
+        <label htmlFor="tx-hash-filter" className="sr-only">Transaction hash</label>
+        <input
+          id="tx-hash-filter"
+          type="text"
+          placeholder="Search by hash…"
+          value={filters.hash}
+          onChange={e => setFilters(f => ({ ...f, hash: e.target.value }))}
+          aria-label="Filter by transaction hash"
+          spellCheck={false}
+        />
       </form>
 
       <AnimatePresence mode="wait">


### PR DESCRIPTION
Closes #298

---

## Summary

Adds the ability to search transactions by hash in both the frontend UI and backend API.

## Changes

**Backend** `backend/src/routes/stellar.js`
- `GET /api/stellar/account/:publicKey/transactions` now accepts an optional `hash` query parameter
- Results are filtered to records whose hash starts with the provided prefix (case-insensitive)

**Frontend** `frontend/src/components/TransactionHistory.jsx`
- Added a "Search by hash" text input to the existing filter form
- The `hash` value is passed as a query param when filters are applied

## Behaviour
- Partial/prefix matching — users can paste a full hash or just the first few characters
- Empty hash field = no filtering (existing behaviour unchanged)
- Filtering is applied server-side on the already-fetched page