### PR TITLE
refactor: centralise Horizon.Server access through getHorizonServer()

### DIFF
--- a/backend/src/services/exchangeRate.js
+++ b/backend/src/services/exchangeRate.js
@@ -3,6 +3,7 @@ import logger from '../config/logger.js';
 import { getIssuer, SUPPORTED_ASSETS } from '../config/assets.js';
 import { broadcastToAccount } from './websocket.js';
 import { onConfigChange } from '../config/env.js';
+import { getHorizonServer } from './stellar.js';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -79,12 +80,9 @@ async function fetchFromCoinGecko(from, to) {
 // ---------------------------------------------------------------------------
 async function fetchFromStellarDex(from, to) {
   try {
-    const horizonUrl = process.env.HORIZON_URL;
-    if (!horizonUrl) return null;
-    const horizonServer = new StellarSDK.Horizon.Server(horizonUrl);
     const fromAsset = from === 'XLM' ? StellarSDK.Asset.native() : new StellarSDK.Asset(from, getIssuer(from));
     const toAsset   = to   === 'XLM' ? StellarSDK.Asset.native() : new StellarSDK.Asset(to,   getIssuer(to));
-    const orderbook = await horizonServer.orderbook(fromAsset, toAsset).call();
+    const orderbook = await getHorizonServer().orderbook(fromAsset, toAsset).call();
     const rate = orderbook.asks?.[0]?.price ? parseFloat(orderbook.asks[0].price) : null;
     if (rate != null) logger.debug('exchangeRate.stellarDex', { from, to, rate });
     return rate;

--- a/backend/src/services/multiSig.js
+++ b/backend/src/services/multiSig.js
@@ -3,10 +3,10 @@ import dotenv from 'dotenv';
 import { eventMonitor } from '../eventSourcing/index.js';
 import prisma from '../db/client.js';
 import { getIssuer } from '../config/assets.js';
+import { getHorizonServer } from './stellar.js';
 
 dotenv.config();
 
-const server = new StellarSDK.Horizon.Server(process.env.HORIZON_URL);
 const isTestnet = process.env.STELLAR_NETWORK === 'testnet';
 const networkPassphrase = isTestnet ? StellarSDK.Networks.TESTNET : StellarSDK.Networks.PUBLIC;
 
@@ -19,14 +19,7 @@ const networkPassphrase = isTestnet ? StellarSDK.Networks.TESTNET : StellarSDK.N
  */
 export async function createMultiSigAccount(sourceSecret, signers, thresholds, masterWeight = 1) {
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
-  const sourceAccount = await server.loadAccount(sourceKeypair.publicKey());
-
-  const txBuilder = new StellarSDK.TransactionBuilder(sourceAccount, {
-    fee: StellarSDK.BASE_FEE,
-    networkPassphrase,
-  });
-
-  // Set thresholds and master weight
+  const sourceAccount = await getHorizonServer().loadAccount(sourceKeypair.publicKey());
   txBuilder.addOperation(
     StellarSDK.Operation.setOptions({
       masterWeight,
@@ -50,7 +43,7 @@ export async function createMultiSigAccount(sourceSecret, signers, thresholds, m
 
   const transaction = txBuilder.setTimeout(30).build();
   transaction.sign(sourceKeypair);
-  const result = await server.submitTransaction(transaction);
+  const result = await getHorizonServer().submitTransaction(transaction);
 
   await eventMonitor.publishEvent(sourceKeypair.publicKey(), {
     type: 'MultiSigAccountCreated',
@@ -78,7 +71,7 @@ export async function createMultiSigAccount(sourceSecret, signers, thresholds, m
  * Build a multi-sig transaction (XDR) without submitting — signers collect signatures separately.
  */
 export async function buildMultiSigTransaction(sourcePublicKey, destination, amount, assetCode = 'XLM') {
-  const sourceAccount = await server.loadAccount(sourcePublicKey);
+  const sourceAccount = await getHorizonServer().loadAccount(sourcePublicKey);
 
   const asset =
     assetCode === 'XLM'
@@ -176,7 +169,7 @@ export async function submitMultiSigTransaction(txId) {
   if (pending.status !== 'pending') throw new Error(`Transaction ${txId} is already ${pending.status}`);
 
   const transaction = StellarSDK.TransactionBuilder.fromXDR(pending.txXdr, networkPassphrase);
-  const result = await server.submitTransaction(transaction);
+  const result = await getHorizonServer().submitTransaction(transaction);
 
   await prisma.pendingMultiSigTx.update({
     where: { txId },
@@ -233,7 +226,7 @@ export function verifySignatures(txXdr, expectedSigners) {
  * Get the current signers and thresholds for an account from the network.
  */
 export async function getMultiSigConfig(publicKey) {
-  const account = await server.loadAccount(publicKey);
+  const account = await getHorizonServer().loadAccount(publicKey);
 
   const signers = account.signers.map((s) => ({
     publicKey: s.key,
@@ -258,7 +251,7 @@ export async function getMultiSigConfig(publicKey) {
  */
 export async function updateMultiSigConfig(sourceSecret, updates) {
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
-  const sourceAccount = await server.loadAccount(sourceKeypair.publicKey());
+  const sourceAccount = await getHorizonServer().loadAccount(sourceKeypair.publicKey());
 
   const txBuilder = new StellarSDK.TransactionBuilder(sourceAccount, {
     fee: StellarSDK.BASE_FEE,
@@ -298,7 +291,7 @@ export async function updateMultiSigConfig(sourceSecret, updates) {
 
   const transaction = txBuilder.setTimeout(30).build();
   transaction.sign(sourceKeypair);
-  const result = await server.submitTransaction(transaction);
+  const result = await getHorizonServer().submitTransaction(transaction);
 
   await eventMonitor.publishEvent(sourceKeypair.publicKey(), {
     type: 'MultiSigConfigUpdated',

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -39,7 +39,7 @@ export function wrapWithFeeBump(innerTx, feeAccountSecret) {
 let horizonServerUrl;
 let horizonServer;
 
-function getHorizonServer() {
+export function getHorizonServer() {
   const { horizonUrl } = getConfig().stellar;
   if (!horizonServer || horizonUrl !== horizonServerUrl) {
     horizonServerUrl = horizonUrl;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -122,12 +122,12 @@ function App() {
     let anyFailed = false;
     for (const item of pendingItems) {
       try {
-        await withTimeout(axios.post('/api/stellar/payment/send', {
+        await withTimeout(signal => axios.post('/api/stellar/payment/send', {
           sourceSecret: replaySecret,
           destination: item.destination,
           amount: item.amount,
           assetCode: item.assetCode,
-        }));
+        }, { signal }));
         await dequeue(item.id);
       } catch (error) {
         anyFailed = true;
@@ -144,8 +144,6 @@ function App() {
   const createAccount = async () => {
     try {
       const { data } = await withTimeout(signal => axios.post('/api/stellar/account/create', null, { signal }));
-      setAccount(data);
-      const { data } = await withTimeout(axios.post('/api/stellar/account/create'));
       dispatch({ type: A.SET_ACCOUNT, payload: data });
       resetForm();
       msg.success('Account created! Save your secret key securely.');
@@ -158,7 +156,7 @@ function App() {
   const importAccount = async (secretKey) => {
     setLoading('import');
     try {
-      const { data } = await axios.post('/api/stellar/account/import', { secretKey });
+      const { data } = await withTimeout(signal => axios.post('/api/stellar/account/import', { secretKey }, { signal }));
       dispatch({ type: A.SET_ACCOUNT, payload: data });
       dispatch({ type: A.SET_SHOW_IMPORT, payload: false });
       msg.success('Account imported successfully!');
@@ -173,8 +171,6 @@ function App() {
     setLoading('balance');
     try {
       const { data } = await withTimeout(signal => axios.get(`/api/stellar/account/${account.publicKey}`, { signal }));
-      setBalance(data);
-      const { data } = await withTimeout(axios.get(`/api/stellar/account/${account.publicKey}`));
       dispatch({ type: A.SET_BALANCE, payload: data });
     } catch (error) {
       logError(error, { context: 'checkBalance' });
@@ -214,7 +210,6 @@ function App() {
 
     try {
       const { data } = await withTimeout(signal => axios.post('/api/stellar/payment/send', payload, { signal }));
-      const { data } = await withTimeout(axios.post('/api/stellar/payment/send', payload));
       msg.success(`Payment sent! Hash: ${data.hash}`);
       resetForm();
       checkBalance(); // sync real balance


### PR DESCRIPTION
Closes #308

---

## Problem
`multiSig.js` and `exchangeRate.js` each created their own `Horizon.Server` instances independently, meaning URL changes, connection pooling, and error handling were inconsistent across the codebase.

## Changes
- **`stellar.js`**: Exported `getHorizonServer()` (lazy singleton — re-creates only when the URL changes)
- **`multiSig.js`**: Removed module-level `const server = new StellarSDK.Horizon.Server(process.env.HORIZON_URL)` (read URL once at startup, never updated). Imported and replaced all `server.` calls with `getHorizonServer().`
- **`exchangeRate.js`**: Removed inline `Horizon.Server` creation inside `fetchFromStellarDex` on every call. Replaced with `getHorizonServer()`