### PR TITLE
feat: add memoType 'id' support for exchange deposit addresses

### DIFF
--- a/backend/prisma/migrations/20260424000000_add_memo_fields/migration.sql
+++ b/backend/prisma/migrations/20260424000000_add_memo_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Transaction" ADD COLUMN "memo" TEXT,
+                          ADD COLUMN "memoType" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -29,6 +29,8 @@ model Transaction {
   amount        Decimal
   ledger        Int?
   successful    Boolean        @default(true)
+  memo          String?
+  memoType      String?        // 'text' | 'id'
   createdAt     DateTime       @default(now())
   senderId      String
   sender        User           @relation("sender", fields: [senderId], references: [id])

--- a/backend/src/middleware/validate.js
+++ b/backend/src/middleware/validate.js
@@ -1,6 +1,6 @@
 import { body, param, validationResult } from 'express-validator';
 import { SUPPORTED_ASSETS } from '../config/assets.js';
-import { sanitizeText, MAX_LENGTHS } from '../utils/sanitize.js';
+import { sanitizeText, MAX_LENGTHS, MEMO_TYPES } from '../utils/sanitize.js';
 
 // Stellar public key: starts with G, 56 chars, base32
 const STELLAR_PUBLIC_KEY = /^G[A-Z2-7]{55}$/;
@@ -35,6 +35,13 @@ export const rules = {
       .isLength({ max: MAX_LENGTHS.memo })
       .withMessage(`Memo exceeds ${MAX_LENGTHS.memo} characters`)
       .customSanitizer(v => sanitizeText(v, MAX_LENGTHS.memo)),
+
+  memoTypeField: () =>
+    body('memoType')
+      .optional()
+      .trim()
+      .isIn(MEMO_TYPES)
+      .withMessage(`memoType must be one of: ${MEMO_TYPES.join(', ')}`),
 
   publicKeyParam: param('publicKey')
     .trim()
@@ -76,6 +83,17 @@ export const rules = {
       .isIn(SUPPORTED_ASSETS)
       .withMessage(`Unsupported asset. Supported: ${SUPPORTED_ASSETS.join(', ')}`),
     rules.memoField(),
+    rules.memoTypeField(),
+    // Cross-field: memo type 'id' requires a numeric memo value
+    body('memo').custom((memo, { req }) => {
+      const memoType = req.body.memoType;
+      if (memoType === 'id') {
+        if (!memo) throw new Error('Memo is required when memoType is "id"');
+        if (!/^\d{1,20}$/.test(memo)) throw new Error('Memo must be a numeric ID when memoType is "id"');
+        if (BigInt(memo) > 18446744073709551615n) throw new Error('Memo ID exceeds maximum uint64 value');
+      }
+      return true;
+    }),
   ],
 
   createTrustline: [

--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -127,8 +127,8 @@ router.get('/account/:publicKey', rules.publicKeyParam, validate,
  */
 router.post('/payment/send', rules.sendPayment, validate, async (req, res) => {
   try {
-    const { sourceSecret, destination, amount, assetCode, memo } = req.body;
-    const result = await StellarService.sendPayment(sourceSecret, destination, amount, assetCode, memo);
+    const { sourceSecret, destination, amount, assetCode, memo, memoType } = req.body;
+    const result = await StellarService.sendPayment(sourceSecret, destination, amount, assetCode, memo, memoType);
 
     const notification = { type: 'transaction', hash: result.hash, amount, assetCode: assetCode || 'XLM', timestamp: Date.now() };
 

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -106,11 +106,11 @@ export async function getBalance(publicKey) {
   return { publicKey, balances };
 }
 
-export async function sendPayment(sourceSecret, destination, amount, assetCode = 'XLM', memo = null) {
+export async function sendPayment(sourceSecret, destination, amount, assetCode = 'XLM', memo = null, memoType = 'text') {
   const { assetIssuer } = getConfig().stellar;
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
   const sourcePublicKey = sourceKeypair.publicKey();
-  logger.info('stellar.sendPayment.start', { source: sourcePublicKey, destination, amount, assetCode, memo });
+  logger.info('stellar.sendPayment.start', { source: sourcePublicKey, destination, amount, assetCode, memo, memoType });
 
   const sourceAccount = await getHorizonServer().loadAccount(sourcePublicKey);
   
@@ -135,7 +135,10 @@ export async function sendPayment(sourceSecret, destination, amount, assetCode =
     }));
 
   if (memo) {
-    txBuilder.addMemo(StellarSDK.Memo.text(memo));
+    const stellarMemo = memoType === 'id'
+      ? StellarSDK.Memo.id(memo)
+      : StellarSDK.Memo.text(memo);
+    txBuilder.addMemo(stellarMemo);
   }
 
   const transaction = txBuilder.setTimeout(30).build();
@@ -184,11 +187,12 @@ export async function sendPayment(sourceSecret, destination, amount, assetCode =
     ledger: result.ledger,
     feeBump: usedFeeBump,
     memo,
+    memoType,
   });
 
   await eventMonitor.publishEvent(sourcePublicKey, {
     type: 'PaymentSent',
-    data: { destination, amount, hash: result.hash, feeBump: usedFeeBump, memo },
+    data: { destination, amount, hash: result.hash, feeBump: usedFeeBump, memo, memoType },
     version: 1
   });
 
@@ -207,6 +211,8 @@ export async function sendPayment(sourceSecret, destination, amount, assetCode =
         successful: result.successful,
         senderId: sender.id,
         recipientId: recipient.id,
+        memo: memo ?? null,
+        memoType: memo ? (memoType || 'text') : null,
       },
     });
   }).catch(err => logger.warn('db.transaction.save.failed', { error: err.message }));

--- a/backend/src/utils/sanitize.js
+++ b/backend/src/utils/sanitize.js
@@ -33,9 +33,13 @@ export const MAX_LENGTHS = {
   username: 32,
   text: 500,
   memo: 28,       // Stellar memo text limit
+  memoId: 18,     // uint64 max is 18446744073709551615 (20 digits), but safe integer is 18 digits
   address: 256,
   default: 1000,
 };
+
+/** Allowed Stellar memo types supported by this application. */
+export const MEMO_TYPES = ['text', 'id'];
 
 /**
  * Truncates a string to the given max length.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -40,13 +40,13 @@ function App() {
   const [balance, setBalance] = useState(null);
   const [recipient, setRecipient] = useState('');
   const [amount, setAmount] = useState('');
-  const [memo, setMemo] = useState('');
+
   const [loading, setLoading] = useState('');
   const [showQR, setShowQR] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [showImportForm, setShowImportForm] = useState(false);
   const [confirmClear, setConfirmClear] = useState(false);
-  const { account, balance, loading, recipient, amount, showQR, showImportForm, showShortcuts } = useAppState();
+  const { account, balance, loading, recipient, amount, memo, memoType, showQR, showImportForm, showShortcuts } = useAppState();
   const dispatch = useAppDispatch();
 
   const msg = useMessages();
@@ -110,7 +110,6 @@ function App() {
 
   const resetForm = () => dispatch({ type: A.RESET_FORM });
 
-  const resetForm = () => { setRecipient(''); setAmount(''); setMemo(''); };
   const clearForm = () => {
     if (recipient || amount) { setConfirmClear(true); return; }
     resetForm();
@@ -200,7 +199,7 @@ function App() {
   const sendPayment = async () => {
     if (!account || !recipientValid || !amountValid) return;
     setLoading('send');
-    const payload = { sourceSecret: account.secretKey, destination: recipient, amount, assetCode: 'XLM', memo: memo || undefined };
+    const payload = { sourceSecret: account.secretKey, destination: recipient, amount, assetCode: 'XLM', memo: memo || undefined, memoType: memo ? memoType : undefined };
 
     // Optimistic balance update (deduct amount + base fee to match on-chain deduction)
     const BASE_FEE_XLM = 0.00001;
@@ -664,18 +663,37 @@ function App() {
                     </AnimatePresence>
 
                     <div className="input-wrap">
-                      <label htmlFor="memo-input" className="sr-only">Payment memo (optional, max 28 characters)</label>
+                      <label htmlFor="memo-type-select" className="sr-only">Memo type</label>
+                      <select
+                        id="memo-type-select"
+                        value={memoType}
+                        onChange={(e) => dispatch({ type: A.SET_MEMO_TYPE, payload: e.target.value })}
+                        aria-label="Memo type"
+                        style={{ flexShrink: 0 }}
+                      >
+                        <option value="text">Text</option>
+                        <option value="id">ID (exchange)</option>
+                      </select>
+                      <label htmlFor="memo-input" className="sr-only">
+                        {memoType === 'id' ? 'Numeric memo ID (required for exchange deposits)' : 'Payment memo (optional, max 28 characters)'}
+                      </label>
                       <input
                         id="memo-input"
-                        type="text"
-                        placeholder="Memo (optional, max 28 chars)"
+                        type={memoType === 'id' ? 'number' : 'text'}
+                        inputMode={memoType === 'id' ? 'numeric' : undefined}
+                        placeholder={memoType === 'id' ? 'Numeric memo ID (exchange deposit)' : 'Memo (optional, max 28 chars)'}
                         value={memo}
-                        onChange={(e) => setMemo(e.target.value.slice(0, 28))}
+                        onChange={(e) => {
+                          const val = memoType === 'id'
+                            ? e.target.value.replace(/\D/g, '').slice(0, 20)
+                            : e.target.value.slice(0, 28);
+                          dispatch({ type: A.SET_MEMO, payload: val });
+                        }}
                         onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
-                        aria-label="Payment memo (optional)"
-                        maxLength="28"
+                        aria-label={memoType === 'id' ? 'Numeric memo ID for exchange deposit' : 'Payment memo (optional)'}
+                        maxLength={memoType === 'id' ? 20 : 28}
                       />
-                      {memo && <span className="input-icon" aria-hidden="true">{memo.length}/28</span>}
+                      {memo && memoType === 'text' && <span className="input-icon" aria-hidden="true">{memo.length}/28</span>}
                     </div>
 
                     <FeeDisplay amount={amount} visible={amountValid} />

--- a/frontend/src/store/reducer.js
+++ b/frontend/src/store/reducer.js
@@ -11,6 +11,8 @@ export const A = {
   SET_LOADING: 'SET_LOADING',
   SET_RECIPIENT: 'SET_RECIPIENT',
   SET_AMOUNT: 'SET_AMOUNT',
+  SET_MEMO: 'SET_MEMO',
+  SET_MEMO_TYPE: 'SET_MEMO_TYPE',
   RESET_FORM: 'RESET_FORM',
   SET_SHOW_QR: 'SET_SHOW_QR',
   SET_SHOW_IMPORT: 'SET_SHOW_IMPORT',
@@ -28,6 +30,8 @@ export const initialState = {
   loading: '',         // 'create' | 'balance' | 'send' | 'import' | ''
   recipient: '',
   amount: '',
+  memo: '',
+  memoType: 'text',    // 'text' | 'id'
   showQR: false,
   showImportForm: false,
   showShortcuts: false,
@@ -52,8 +56,12 @@ export function appReducer(state, action) {
       return { ...state, recipient: action.payload };
     case A.SET_AMOUNT:
       return { ...state, amount: action.payload };
+    case A.SET_MEMO:
+      return { ...state, memo: action.payload };
+    case A.SET_MEMO_TYPE:
+      return { ...state, memoType: action.payload };
     case A.RESET_FORM:
-      return { ...state, recipient: '', amount: '' };
+      return { ...state, recipient: '', amount: '', memo: '', memoType: 'text' };
     case A.SET_SHOW_QR:
       return { ...state, showQR: action.payload };
     case A.SET_SHOW_IMPORT:


### PR DESCRIPTION
- Add memo and memoType fields to Transaction model (Prisma schema + migration)
- Add MEMO_TYPES constant and memoId max length to sanitize utils
- Add memoTypeField() validation rule and cross-field numeric check in validate middleware
- Update sendPayment service to branch on Memo.id() vs Memo.text() and persist both fields
- Update /payment/send route to pass memoType through to service
- Add SET_MEMO / SET_MEMO_TYPE actions and state to frontend reducer
- Replace memo text input with memo type selector + context-aware input in payment form
- memoType defaults to 'text'; 'id' mode enforces digits-only, max 20 chars, uint64 range

Prevents lost funds when sending to exchange deposit addresses that require a numeric memo ID.
closes #299 