### PR TITLE
Fix #211, #220, #226: remove duplicate useEffect closing, drop BalanceChecked event, reuse shared Horizon server in DEX fallback

### DIFF
--- a/backend/src/services/exchangeRate.js
+++ b/backend/src/services/exchangeRate.js
@@ -3,6 +3,7 @@ import logger from '../config/logger.js';
 import { getIssuer, SUPPORTED_ASSETS } from '../config/assets.js';
 import { broadcastToAccount } from './websocket.js';
 import { onConfigChange } from '../config/env.js';
+import { getHorizonServer } from './stellar.js';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -79,12 +80,9 @@ async function fetchFromCoinGecko(from, to) {
 // ---------------------------------------------------------------------------
 async function fetchFromStellarDex(from, to) {
   try {
-    const horizonUrl = process.env.HORIZON_URL;
-    if (!horizonUrl) return null;
-    const horizonServer = new StellarSDK.Horizon.Server(horizonUrl);
     const fromAsset = from === 'XLM' ? StellarSDK.Asset.native() : new StellarSDK.Asset(from, getIssuer(from));
     const toAsset   = to   === 'XLM' ? StellarSDK.Asset.native() : new StellarSDK.Asset(to,   getIssuer(to));
-    const orderbook = await horizonServer.orderbook(fromAsset, toAsset).call();
+    const orderbook = await getHorizonServer().orderbook(fromAsset, toAsset).call();
     const rate = orderbook.asks?.[0]?.price ? parseFloat(orderbook.asks[0].price) : null;
     if (rate != null) logger.debug('exchangeRate.stellarDex', { from, to, rate });
     return rate;

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -39,7 +39,7 @@ export function wrapWithFeeBump(innerTx, feeAccountSecret) {
 let horizonServerUrl;
 let horizonServer;
 
-function getHorizonServer() {
+export function getHorizonServer() {
   const { horizonUrl } = getConfig().stellar;
   if (!horizonServer || horizonUrl !== horizonServerUrl) {
     horizonServerUrl = horizonUrl;
@@ -97,11 +97,6 @@ export async function getBalance(publicKey) {
   }));
 
   logger.info('stellar.balanceFetched', { publicKey, balances });
-  await eventMonitor.publishEvent(publicKey, {
-    type: 'BalanceChecked',
-    data: { balances },
-    version: 1
-  });
 
   return { publicKey, balances };
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -94,8 +94,6 @@ function App() {
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading]);
   }, [loading, showShortcuts]);
 
   // Listen for SW notification that we're back online with queued payments


### PR DESCRIPTION
Fix #207, #211, #220, #226

- **#211** — Removed duplicate }, [loading]); closing from the keyboard shortcut useEffect in App.jsx; kept the correct }, [loading, showShortcuts]);
- **#220** — Removed BalanceChecked event publication from getBalance in stellar.js to prevent unbounded event store growth
- **#226** — Exported getHorizonServer() from stellar.js and updated fetchFromStellarDex in exchangeRate.js to reuse the shared Horizon server instance instead of 
creating a new one per call
- **#207** — No change needed; getTransactions already uses getHorizonServer().transactions()
Closes #211 
Closes #220 
Closes #226 
Closes #207 