### PR TITLE
feat: SEO config files and accessible inline confirmation UI

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Disallow: /
+
+# Disallow all crawling since this is a private financial application.
+# If public marketing pages are added later, update this file accordingly.
+# Reference sitemap: /sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- Currently empty — this is a private financial application with no public pages. -->
+  <!-- Add public pages here when they exist. Example:
+  <url>
+    <loc>https://yourdomain.com/about</loc>
+    <lastmod>2026-04-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  -->
+</urlset>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { isValidStellarAddress } from './utils/validateStellarAddress';
@@ -10,6 +10,7 @@ import { useNetworkStatus } from './hooks/useNetworkStatus';
 import { useMessages } from './hooks/useMessages';
 import { usePWA } from './hooks/usePWA';
 import { useOfflineQueue } from './hooks/useOfflineQueue';
+import { useRTL } from './hooks/useRTL';
 import { makeVariants, tapScale } from './utils/animations';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { QRCodeModal } from './components/QRCodeModal';
@@ -19,6 +20,7 @@ import { CopyButton } from './components/CopyButton';
 import { Spinner } from './components/Spinner';
 import { TransactionHistory } from './components/TransactionHistory';
 import { FeeDisplay } from './components/FeeDisplay';
+import { InlineConfirmation } from './components/InlineConfirmation';
 import { logError } from './utils/errorLogger';
 import { ImportAccountForm } from './components/ImportAccountForm';
 import { LanguageSelector } from './components/LanguageSelector';
@@ -36,31 +38,23 @@ function withTimeout(promiseFn) {
 }
 
 function App() {
-  const [account, setAccount] = useState(null);
-  const [balance, setBalance] = useState(null);
-  const [recipient, setRecipient] = useState('');
-  const [amount, setAmount] = useState('');
-  const [memo, setMemo] = useState('');
-  const [loading, setLoading] = useState('');
-  const [showQR, setShowQR] = useState(false);
-  const [showShortcuts, setShowShortcuts] = useState(false);
-  const [showImportForm, setShowImportForm] = useState(false);
-  const [confirmClear, setConfirmClear] = useState(false);
   const { account, balance, loading, recipient, amount, showQR, showImportForm, showShortcuts } = useAppState();
   const dispatch = useAppDispatch();
+
+  // Local state not in store
+  const [memo, setMemo] = useState('');
+  const [confirmClear, setConfirmClear] = useState(false);
+  const [replaySecret, setReplaySecret] = useState('');
+  const [showReplayPrompt, setShowReplayPrompt] = useState(false);
 
   const msg = useMessages();
   const { canInstall, install, updateAvailable, applyUpdate } = usePWA();
   const { queue: queueOffline, dequeue, pendingItems, pendingCount } = useOfflineQueue();
-  const [replaySecret, setReplaySecret] = useState('');
-  const [showReplayPrompt, setShowReplayPrompt] = useState(false);
-  const { theme, isDark, toggleTheme } = useTheme();
+  const { isDark, toggleTheme } = useTheme();
   useRTL();
   const prefersReduced = useReducedMotion();
   const v = makeVariants(prefersReduced);
   const tap = tapScale(prefersReduced);
-
-  const setLoading = (val) => dispatch({ type: A.SET_LOADING, payload: val });
 
   const handleWsMessage = useCallback((wsMsg) => {
     if (wsMsg.type === 'transaction') {
@@ -70,7 +64,6 @@ function App() {
       msg.info(text);
       if (wsMsg.balance) dispatch({ type: A.SET_BALANCE, payload: { balances: wsMsg.balance } });
     }
-  }, [msg]);
   }, [msg, dispatch]);
 
   const wsStatus = useWebSocket(account?.publicKey ?? null, handleWsMessage);
@@ -95,7 +88,6 @@ function App() {
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading]);
   }, [loading, showShortcuts]);
 
   // Listen for SW notification that we're back online with queued payments
@@ -110,11 +102,12 @@ function App() {
 
   const resetForm = () => dispatch({ type: A.RESET_FORM });
 
-  const resetForm = () => { setRecipient(''); setAmount(''); setMemo(''); };
   const clearForm = () => {
     if (recipient || amount) { setConfirmClear(true); return; }
     resetForm();
   };
+  const confirmClearYes = () => { setConfirmClear(false); resetForm(); };
+  const confirmClearNo  = () => setConfirmClear(false);
 
   const replayQueued = async () => {
     if (!replaySecret) return;
@@ -122,12 +115,12 @@ function App() {
     let anyFailed = false;
     for (const item of pendingItems) {
       try {
-        await withTimeout(axios.post('/api/stellar/payment/send', {
+        await withTimeout(signal => axios.post('/api/stellar/payment/send', {
           sourceSecret: replaySecret,
           destination: item.destination,
           amount: item.amount,
           assetCode: item.assetCode,
-        }));
+        }, { signal }));
         await dequeue(item.id);
       } catch (error) {
         anyFailed = true;
@@ -138,48 +131,43 @@ function App() {
     if (anyFailed) msg.error('Some queued payments failed to send. Please retry.');
     else { msg.success('All queued payments sent.'); checkBalance(); }
   };
-  const confirmClearYes = () => { setConfirmClear(false); resetForm(); };
-  const confirmClearNo  = () => setConfirmClear(false);
 
   const createAccount = async () => {
+    dispatch({ type: A.SET_LOADING, payload: 'create' });
     try {
       const { data } = await withTimeout(signal => axios.post('/api/stellar/account/create', null, { signal }));
-      setAccount(data);
-      const { data } = await withTimeout(axios.post('/api/stellar/account/create'));
       dispatch({ type: A.SET_ACCOUNT, payload: data });
       resetForm();
       msg.success('Account created! Save your secret key securely.');
     } catch (error) {
       logError(error, { context: 'createAccount' });
       msg.error(getFriendlyError(error), { retry: createAccount });
-    } finally { setLoading(''); }
+    } finally { dispatch({ type: A.SET_LOADING, payload: '' }); }
   };
 
   const importAccount = async (secretKey) => {
-    setLoading('import');
+    dispatch({ type: A.SET_LOADING, payload: 'import' });
     try {
-      const { data } = await axios.post('/api/stellar/account/import', { secretKey });
+      const { data } = await withTimeout(signal => axios.post('/api/stellar/account/import', { secretKey }, { signal }));
       dispatch({ type: A.SET_ACCOUNT, payload: data });
       dispatch({ type: A.SET_SHOW_IMPORT, payload: false });
       msg.success('Account imported successfully!');
     } catch (error) {
       logError(error, { context: 'importAccount' });
       msg.error(getFriendlyError(error));
-    } finally { setLoading(''); }
+    } finally { dispatch({ type: A.SET_LOADING, payload: '' }); }
   };
 
   const checkBalance = async () => {
     if (!account) return;
-    setLoading('balance');
+    dispatch({ type: A.SET_LOADING, payload: 'balance' });
     try {
       const { data } = await withTimeout(signal => axios.get(`/api/stellar/account/${account.publicKey}`, { signal }));
-      setBalance(data);
-      const { data } = await withTimeout(axios.get(`/api/stellar/account/${account.publicKey}`));
       dispatch({ type: A.SET_BALANCE, payload: data });
     } catch (error) {
       logError(error, { context: 'checkBalance' });
       msg.error(getFriendlyError(error), { retry: checkBalance });
-    } finally { setLoading(''); }
+    } finally { dispatch({ type: A.SET_LOADING, payload: '' }); }
   };
 
   const recipientValid = isValidStellarAddress(recipient);
@@ -191,35 +179,30 @@ function App() {
 
   const handleSendMax = () => {
     if (xlmBalance === null) return;
-    const BASE_FEE_XLM = 0.00001;
-    const MINIMUM_RESERVE_XLM = 1;
-    const maxSendable = Math.max(0, parseFloat(xlmBalance) - MINIMUM_RESERVE_XLM - BASE_FEE_XLM);
-    setAmount(maxSendable.toFixed(7).replace(/\.?0+$/, ''));
+    const maxSendable = Math.max(0, parseFloat(xlmBalance) - 1 - 0.00001);
+    dispatch({ type: A.SET_AMOUNT, payload: maxSendable.toFixed(7).replace(/\.?0+$/, '') });
   };
 
   const sendPayment = async () => {
     if (!account || !recipientValid || !amountValid) return;
-    setLoading('send');
+    dispatch({ type: A.SET_LOADING, payload: 'send' });
     const payload = { sourceSecret: account.secretKey, destination: recipient, amount, assetCode: 'XLM', memo: memo || undefined };
 
-    // Optimistic balance update (deduct amount + base fee to match on-chain deduction)
-    const BASE_FEE_XLM = 0.00001;
-    const numAmount = parseFloat(amount);
+    // Optimistic balance update
     if (xlmBalance !== null) {
       const optimisticBalances = balance.balances.map(b =>
-        b.asset === 'XLM' ? { ...b, balance: String((parseFloat(b.balance) - numAmount - BASE_FEE_XLM).toFixed(7)) } : b
+        b.asset === 'XLM' ? { ...b, balance: String((parseFloat(b.balance) - parseFloat(amount) - 0.00001).toFixed(7)) } : b
       );
       dispatch({ type: A.SET_BALANCE_OPTIMISTIC, payload: { balances: optimisticBalances } });
     }
 
     try {
       const { data } = await withTimeout(signal => axios.post('/api/stellar/payment/send', payload, { signal }));
-      const { data } = await withTimeout(axios.post('/api/stellar/payment/send', payload));
       msg.success(`Payment sent! Hash: ${data.hash}`);
       resetForm();
-      checkBalance(); // sync real balance
+      checkBalance();
     } catch (error) {
-      dispatch({ type: A.REVERT_BALANCE }); // roll back optimistic update
+      dispatch({ type: A.REVERT_BALANCE });
       if (!navigator.onLine) {
         await queueOffline({ destination: payload.destination, amount: payload.amount, assetCode: payload.assetCode });
         msg.info('You are offline. Payment queued — you\'ll be prompted to re-enter your secret key when back online.');
@@ -227,111 +210,21 @@ function App() {
         logError(error, { context: 'sendPayment' });
         msg.error(getFriendlyError(error), { retry: sendPayment });
       }
-    } finally { setLoading(''); }
+    } finally { dispatch({ type: A.SET_LOADING, payload: '' }); }
   };
 
   return (
     <>
-      {/* Skip navigation link */}
       <a href="#main-content" className="skip-link">Skip to main content</a>
 
       <div className="app">
-        {/* Screen-reader live region for loading states */}
         <div aria-live="polite" aria-atomic="true" className="sr-only">
           {loading === 'create' && 'Creating account…'}
           {loading === 'balance' && 'Checking balance…'}
           {loading === 'send' && 'Sending payment…'}
           {loading === 'import' && 'Importing account…'}
-      {/* PWA: offline queue indicator */}
-      <AnimatePresence>
-        {pendingCount > 0 && (
-          <motion.div className="pwa-banner pwa-banner--queue" variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit">
-            {pendingCount} payment{pendingCount > 1 ? 's' : ''} queued offline — will sync when back online.
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <h1>Stellar Remittance Platform</h1>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <button
-            type="button"
-            className="theme-toggle-btn"
-            onClick={toggleTheme}
-            aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
-            title={`Switch to ${isDark ? 'light' : 'dark'} mode`}
-          >
-            {isDark ? '☀️ Light' : '🌙 Dark'}
-          </button>
-          <LanguageSelector />
-          {canInstall && (
-            <button type="button" className="pwa-install-btn" onClick={install} title="Install app">
-              ⬇ Install
-            </button>
-          )}
-          <button
-            type="button"
-            className="shortcuts-help-btn"
-            onClick={() => dispatch({ type: A.SET_SHOW_SHORTCUTS, payload: !showShortcuts })}
-            title="Keyboard shortcuts (?)"
-            aria-label="Show keyboard shortcuts"
-          >
-            ⌨
-          </button>
-          <NetworkBadge status={networkStatus} />
-          <motion.span
-            animate={{ opacity: [0.6, 1, 0.6] }}
-            transition={{ repeat: Infinity, duration: 2 }}
-            style={{ fontSize: '0.8rem', display: 'flex', alignItems: 'center', gap: 6 }}
-          >
-            <span style={{ width: 10, height: 10, borderRadius: '50%', background: STATUS_COLORS[wsStatus], display: 'inline-block' }} />
-            {wsStatus}
-          </motion.span>
         </div>
 
-        {/* PWA banners */}
-        <AnimatePresence>
-          {updateAvailable && (
-            <motion.div className="pwa-banner pwa-banner--update" role="status" variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit">
-              <span>A new version is available.</span>
-              <button type="button" className="pwa-banner__btn" onClick={applyUpdate}>Update now</button>
-            </motion.div>
-          )}
-        </AnimatePresence>
-      {/* Keyboard shortcuts panel */}
-      <AnimatePresence>
-        {showShortcuts && (
-          <motion.div className="shortcuts-panel" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts" variants={v.pop} initial="hidden" animate="visible" exit="exit">
-            <div className="shortcuts-panel__header">
-              <strong>Keyboard Shortcuts</strong>
-              <button type="button" className="qr-close" onClick={() => dispatch({ type: A.SET_SHOW_SHORTCUTS, payload: false })} aria-label="Close">✕</button>
-            </div>
-            <ul className="shortcuts-list">
-              <li><kbd>Ctrl+N</kbd> Create new account</li>
-              <li><kbd>Ctrl+C</kbd> Copy key (when copy button focused)</li>
-              <li><kbd>Escape</kbd> Close modals</li>
-              <li><kbd>?</kbd> Toggle this help</li>
-              <li><kbd>Tab</kbd> Navigate between fields</li>
-              <li><kbd>Enter</kbd> Submit focused form</li>
-            </ul>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      {/* Create / Import Account */}
-      <motion.div className="section" variants={v.fadeSlide} initial="hidden" animate="visible">
-        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-          <motion.button onClick={createAccount} {...tap} disabled={loading === 'create'} title="Create account (Ctrl+N)">
-            {loading === 'create' ? <Spinner label="Creating account..." /> : 'Create Account'}
-          </motion.button>
-          <motion.button
-            onClick={() => dispatch({ type: A.SET_SHOW_IMPORT, payload: !showImportForm })}
-            {...tap}
-            style={{ background: '#6366f1' }}
-          >
-            {showImportForm ? 'Cancel Import' : 'Import Account'}
-          </motion.button>
-        </div>
         <AnimatePresence>
           {pendingCount > 0 && (
             <motion.div className="pwa-banner pwa-banner--queue" role="status" variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit">
@@ -349,10 +242,10 @@ function App() {
                 className="theme-toggle-btn"
                 onClick={toggleTheme}
                 aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
-                title={`Switch to ${isDark ? 'light' : 'dark'} mode`}
               >
                 {isDark ? '☀️ Light' : '🌙 Dark'}
               </button>
+              <LanguageSelector />
               {canInstall && (
                 <button type="button" className="pwa-install-btn" onClick={install} aria-label="Install app">
                   ⬇ Install
@@ -361,7 +254,7 @@ function App() {
               <button
                 type="button"
                 className="shortcuts-help-btn"
-                onClick={() => setShowShortcuts((s) => !s)}
+                onClick={() => dispatch({ type: A.SET_SHOW_SHORTCUTS, payload: !showShortcuts })}
                 aria-label="Show keyboard shortcuts"
                 aria-expanded={showShortcuts}
                 aria-controls="shortcuts-panel"
@@ -381,9 +274,17 @@ function App() {
               </motion.span>
             </div>
           </div>
+
+          <AnimatePresence>
+            {updateAvailable && (
+              <motion.div className="pwa-banner pwa-banner--update" role="status" variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit">
+                <span>A new version is available.</span>
+                <button type="button" className="pwa-banner__btn" onClick={applyUpdate}>Update now</button>
+              </motion.div>
+            )}
+          </AnimatePresence>
         </header>
 
-        {/* Keyboard shortcuts panel */}
         <AnimatePresence>
           {showShortcuts && (
             <motion.div
@@ -396,7 +297,7 @@ function App() {
             >
               <div className="shortcuts-panel__header">
                 <strong id="shortcuts-title">Keyboard Shortcuts</strong>
-                <button type="button" className="qr-close" onClick={() => setShowShortcuts(false)} aria-label="Close keyboard shortcuts">✕</button>
+                <button type="button" className="qr-close" onClick={() => dispatch({ type: A.SET_SHOW_SHORTCUTS, payload: false })} aria-label="Close keyboard shortcuts">✕</button>
               </div>
               <ul className="shortcuts-list">
                 <li><kbd>Ctrl+N</kbd> Create new account</li>
@@ -406,24 +307,6 @@ function App() {
                 <li><kbd>Tab</kbd> Navigate between fields</li>
                 <li><kbd>Enter</kbd> Submit focused form</li>
               </ul>
-        <AnimatePresence>
-          {account && (
-            <motion.div className="account-info" variants={v.pop} initial="hidden" animate="visible" exit="exit">
-              <div className="key-row">
-                <span className="key-label">Public Key:</span>
-                <span className="key-value">{account.publicKey}</span>
-                <CopyButton text={account.publicKey} label="Copy public key" />
-              </div>
-              {account.secretKey && (
-                <div className="key-row">
-                  <span className="key-label">Secret Key:</span>
-                  <span className="key-value">{account.secretKey}</span>
-                  <CopyButton text={account.secretKey} label="Copy secret key" />
-                </div>
-              )}
-              <motion.button className="qr-trigger" onClick={() => dispatch({ type: A.SET_SHOW_QR, payload: true })} {...tap}>
-                🔲 Show QR Code
-              </motion.button>
             </motion.div>
           )}
         </AnimatePresence>
@@ -437,13 +320,13 @@ function App() {
                 onClick={createAccount}
                 {...tap}
                 disabled={loading === 'create'}
-                aria-label="Create new Stellar account (Ctrl+N)"
                 aria-busy={loading === 'create'}
+                aria-label="Create new Stellar account (Ctrl+N)"
               >
                 {loading === 'create' ? <Spinner label="Creating account…" /> : 'Create Account'}
               </motion.button>
               <motion.button
-                onClick={() => setShowImportForm((s) => !s)}
+                onClick={() => dispatch({ type: A.SET_SHOW_IMPORT, payload: !showImportForm })}
                 {...tap}
                 style={{ background: '#6366f1' }}
                 aria-expanded={showImportForm}
@@ -460,90 +343,25 @@ function App() {
                 </motion.div>
               )}
             </AnimatePresence>
-            {/* Send Payment */}
-            <motion.div className="section" variants={v.fadeSlide}>
-              <ErrorBoundary context="send-payment">
-                <h3>Send Payment</h3>
-                <div className="input-wrap">
-                  <input
-                    type="text"
-                    placeholder="Recipient Public Key"
-                    value={recipient}
-                    onChange={(e) => dispatch({ type: A.SET_RECIPIENT, payload: e.target.value })}
-                    onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
-                    style={{ border: `2px solid ${recipientTouched ? (recipientValid ? '#22c55e' : '#ef4444') : '#ccc'}` }}
-                    aria-label="Recipient public key"
-                  />
-                  {recipientTouched && <span className="input-icon">{recipientValid ? '✅' : '❌'}</span>}
-                </div>
-                <AnimatePresence>
-                  {recipientTouched && !recipientValid && (
-                    <motion.p className="field-error" variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit">
-                      Invalid Stellar address format (must start with G and be 56 characters)
-                    </motion.p>
-                  )}
-                </AnimatePresence>
-                <div className="input-wrap">
-                  <input
-                    type="text"
-                    placeholder="Amount (XLM)"
-                    value={amount}
-                    onChange={(e) => dispatch({ type: A.SET_AMOUNT, payload: formatAmount(e.target.value) })}
-                    onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
-                    style={{ border: `2px solid ${amountTouched ? (amountValid ? '#22c55e' : '#ef4444') : '#ccc'}` }}
-                    aria-label="Payment amount in XLM"
-                  />
-                  {amountTouched && <span className="input-icon">{amountValid ? '✅' : '❌'}</span>}
-                </div>
-                <AnimatePresence>
-                  {amountTouched && amountError && (
-                    <motion.p className="field-error" variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit">
-                      {amountError}
-                    </motion.p>
-                  )}
-                </AnimatePresence>
-                <FeeDisplay amount={amount} visible={amountValid} />
-                <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-                  <motion.button onClick={sendPayment} {...tap} disabled={!recipientValid || !amountValid || loading === 'send'}>
-                    {loading === 'send' ? <Spinner label="Sending payment..." /> : 'Send'}
-                  </motion.button>
-                  {confirmClear ? (
-                    <span className="confirm-clear" role="group" aria-label="Confirm clear form">
-                      <span className="confirm-clear__label">Clear form?</span>
-                      <button type="button" className="confirm-clear__yes" onClick={confirmClearYes} aria-label="Yes, clear the form">Yes</button>
-                      <button type="button" className="confirm-clear__no"  onClick={confirmClearNo}  aria-label="No, keep the form">No</button>
-                    </span>
-                  ) : (
-                    <motion.button
-                      className="btn-clear"
-                      onClick={clearForm}
-                      {...tap}
-                      disabled={loading === 'send' || (!recipient && !amount)}
-                      aria-label="Clear payment form"
-                    >
-                      Clear
-                    </motion.button>
-                  )}
-                </div>
-              </ErrorBoundary>
-            </motion.div>
 
             <AnimatePresence>
               {account && (
                 <motion.div className="account-info" variants={v.pop} initial="hidden" animate="visible" exit="exit" aria-label="Account details">
                   <div className="key-row">
-                    <span className="key-label" id="pubkey-label">Public Key:</span>
-                    <span className="key-value" aria-labelledby="pubkey-label">{account.publicKey}</span>
+                    <span className="key-label">Public Key:</span>
+                    <span className="key-value">{account.publicKey}</span>
                     <CopyButton text={account.publicKey} label="Copy public key" />
                   </div>
-                  <div className="key-row">
-                    <span className="key-label" id="seckey-label">Secret Key:</span>
-                    <span className="key-value" aria-labelledby="seckey-label">{account.secretKey}</span>
-                    <CopyButton text={account.secretKey} label="Copy secret key" />
-                  </div>
+                  {account.secretKey && (
+                    <div className="key-row">
+                      <span className="key-label">Secret Key:</span>
+                      <span className="key-value">{account.secretKey}</span>
+                      <CopyButton text={account.secretKey} label="Copy secret key" />
+                    </div>
+                  )}
                   <motion.button
                     className="qr-trigger"
-                    onClick={() => setShowQR(true)}
+                    onClick={() => dispatch({ type: A.SET_SHOW_QR, payload: true })}
                     {...tap}
                     aria-label="Show QR code for this account"
                   >
@@ -554,15 +372,6 @@ function App() {
             </AnimatePresence>
           </motion.section>
 
-            {/* File Upload */}
-            <motion.div className="section" variants={v.fadeSlide}>
-              <h3>File Upload</h3>
-              <FileUpload />
-            </motion.div>
-
-          </motion.div>
-        )}
-      </AnimatePresence>
           <AnimatePresence>
             {account && (
               <motion.div variants={v.stagger} initial="hidden" animate="visible" exit="exit">
@@ -609,10 +418,9 @@ function App() {
                         type="text"
                         placeholder="Recipient Public Key"
                         value={recipient}
-                        onChange={(e) => setRecipient(e.target.value)}
+                        onChange={(e) => dispatch({ type: A.SET_RECIPIENT, payload: e.target.value })}
                         onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
                         style={{ border: `2px solid ${recipientTouched ? (recipientValid ? '#22c55e' : '#ef4444') : '#ccc'}` }}
-                        aria-label="Recipient public key"
                         aria-invalid={recipientTouched && !recipientValid}
                         aria-describedby={recipientTouched && !recipientValid ? 'recipient-error' : undefined}
                         autoComplete="off"
@@ -635,10 +443,9 @@ function App() {
                         inputMode="decimal"
                         placeholder="Amount (XLM)"
                         value={amount}
-                        onChange={(e) => setAmount(formatAmount(e.target.value))}
+                        onChange={(e) => dispatch({ type: A.SET_AMOUNT, payload: formatAmount(e.target.value) })}
                         onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
                         style={{ border: `2px solid ${amountTouched ? (amountValid ? '#22c55e' : '#ef4444') : '#ccc'}` }}
-                        aria-label="Payment amount in XLM"
                         aria-invalid={amountTouched && !!amountError}
                         aria-describedby={amountTouched && amountError ? 'amount-error' : undefined}
                       />
@@ -649,7 +456,6 @@ function App() {
                         onClick={handleSendMax}
                         {...tap}
                         disabled={xlmBalance === null || loading === 'send'}
-                        title="Send maximum available amount (balance - 1 XLM reserve - fee)"
                         aria-label="Send maximum available amount"
                       >
                         Max
@@ -664,7 +470,7 @@ function App() {
                     </AnimatePresence>
 
                     <div className="input-wrap">
-                      <label htmlFor="memo-input" className="sr-only">Payment memo (optional, max 28 characters)</label>
+                      <label htmlFor="memo-input" className="sr-only">Payment memo (optional)</label>
                       <input
                         id="memo-input"
                         type="text"
@@ -672,7 +478,6 @@ function App() {
                         value={memo}
                         onChange={(e) => setMemo(e.target.value.slice(0, 28))}
                         onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
-                        aria-label="Payment memo (optional)"
                         maxLength="28"
                       />
                       {memo && <span className="input-icon" aria-hidden="true">{memo.length}/28</span>}
@@ -689,13 +494,15 @@ function App() {
                       >
                         {loading === 'send' ? <Spinner label="Sending payment…" /> : 'Send'}
                       </motion.button>
-                      {confirmClear ? (
-                        <span className="confirm-clear" role="group" aria-label="Confirm clear form">
-                          <span className="confirm-clear__label">Clear form?</span>
-                          <button type="button" className="confirm-clear__yes" onClick={confirmClearYes} aria-label="Yes, clear the form">Yes</button>
-                          <button type="button" className="confirm-clear__no"  onClick={confirmClearNo}  aria-label="No, keep the form">No</button>
-                        </span>
-                      ) : (
+                      <InlineConfirmation
+                        isVisible={confirmClear}
+                        message="Clear form?"
+                        onConfirm={confirmClearYes}
+                        onCancel={confirmClearNo}
+                        confirmText="Yes"
+                        cancelText="No"
+                      />
+                      {!confirmClear && (
                         <motion.button
                           className="btn-clear"
                           onClick={clearForm}
@@ -708,6 +515,12 @@ function App() {
                       )}
                     </div>
                   </ErrorBoundary>
+                </motion.section>
+
+                {/* File Upload */}
+                <motion.section className="section" variants={v.fadeSlide}>
+                  <h2 className="sr-only">File Upload</h2>
+                  <FileUpload />
                 </motion.section>
 
                 {/* Transaction History */}
@@ -729,70 +542,58 @@ function App() {
 
         <AnimatePresence>
           {showQR && account && (
-            <QRCodeModal publicKey={account.publicKey} onClose={() => setShowQR(false)} />
+            <QRCodeModal publicKey={account.publicKey} onClose={() => dispatch({ type: A.SET_SHOW_QR, payload: false })} />
+          )}
+        </AnimatePresence>
+
+        {/* Offline replay prompt */}
+        <AnimatePresence>
+          {showReplayPrompt && pendingCount > 0 && (
+            <motion.div
+              className="replay-modal-overlay"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="replay-title"
+              variants={v.pop} initial="hidden" animate="visible" exit="exit"
+            >
+              <div className="replay-modal">
+                <h2 id="replay-title">Send queued payments</h2>
+                <p>
+                  You have {pendingCount} queued payment{pendingCount > 1 ? 's' : ''} waiting to be sent.
+                  Enter your secret key to authorise {pendingCount > 1 ? 'them' : 'it'}.
+                </p>
+                <label htmlFor="replay-secret" className="sr-only">Secret key</label>
+                <input
+                  id="replay-secret"
+                  type="password"
+                  placeholder="Secret key (S…)"
+                  value={replaySecret}
+                  onChange={(e) => setReplaySecret(e.target.value)}
+                  autoComplete="off"
+                  aria-describedby="replay-secret-hint"
+                />
+                <p id="replay-secret-hint" className="replay-modal__hint">
+                  Your key is used only in memory to sign these transactions and is never stored.
+                </p>
+                <div className="replay-modal__actions">
+                  <button type="button" onClick={replayQueued} disabled={!replaySecret} aria-label="Send queued payments">
+                    Send now
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-clear"
+                    onClick={() => { setShowReplayPrompt(false); setReplaySecret(''); }}
+                    aria-label="Dismiss, send later"
+                  >
+                    Later
+                  </button>
+                </div>
+              </div>
+            </motion.div>
           )}
         </AnimatePresence>
       </div>
     </>
-      {/* QR Code Modal */}
-      <AnimatePresence>
-        {showQR && account && (
-          <QRCodeModal publicKey={account.publicKey} onClose={() => dispatch({ type: A.SET_SHOW_QR, payload: false })} />
-        )}
-      </AnimatePresence>
-
-      {/* Offline replay prompt */}
-      <AnimatePresence>
-        {showReplayPrompt && pendingCount > 0 && (
-          <motion.div
-            className="replay-modal-overlay"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="replay-title"
-            variants={v.pop} initial="hidden" animate="visible" exit="exit"
-          >
-            <div className="replay-modal">
-              <h2 id="replay-title">Send queued payments</h2>
-              <p>
-                You have {pendingCount} queued payment{pendingCount > 1 ? 's' : ''} waiting to be sent.
-                Enter your secret key to authorise {pendingCount > 1 ? 'them' : 'it'}.
-              </p>
-              <label htmlFor="replay-secret" className="sr-only">Secret key</label>
-              <input
-                id="replay-secret"
-                type="password"
-                placeholder="Secret key (S…)"
-                value={replaySecret}
-                onChange={(e) => setReplaySecret(e.target.value)}
-                autoComplete="off"
-                aria-describedby="replay-secret-hint"
-              />
-              <p id="replay-secret-hint" className="replay-modal__hint">
-                Your key is used only in memory to sign these transactions and is never stored.
-              </p>
-              <div className="replay-modal__actions">
-                <button
-                  type="button"
-                  onClick={replayQueued}
-                  disabled={!replaySecret}
-                  aria-label="Send queued payments"
-                >
-                  Send now
-                </button>
-                <button
-                  type="button"
-                  className="btn-clear"
-                  onClick={() => { setShowReplayPrompt(false); setReplaySecret(''); }}
-                  aria-label="Dismiss, send later"
-                >
-                  Later
-                </button>
-              </div>
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
   );
 }
 

--- a/frontend/src/components/InlineConfirmation.jsx
+++ b/frontend/src/components/InlineConfirmation.jsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { makeVariants, tapScale } from '../utils/animations';
+
+/**
+ * InlineConfirmation — non-blocking inline confirmation UI.
+ *
+ * @param {boolean}  isVisible
+ * @param {string}   message
+ * @param {Function} onConfirm
+ * @param {Function} onCancel
+ * @param {string}   confirmText
+ * @param {string}   cancelText
+ */
+export function InlineConfirmation({
+  isVisible,
+  message,
+  onConfirm,
+  onCancel,
+  confirmText = 'Clear',
+  cancelText = 'Cancel',
+}) {
+  const prefersReduced = useReducedMotion();
+  const v = makeVariants(prefersReduced);
+  const tap = tapScale(prefersReduced);
+  const confirmRef = useRef(null);
+
+  // Move focus to the confirm button when shown
+  useEffect(() => {
+    if (isVisible) confirmRef.current?.focus();
+  }, [isVisible]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isVisible) return;
+    const onKey = (e) => { if (e.key === 'Escape') onCancel(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [isVisible, onCancel]);
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.span
+          className="confirm-clear"
+          role="group"
+          aria-label="Confirm clear form"
+          variants={v.fadeSlide}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+        >
+          <span id="confirm-clear-msg" className="confirm-clear__label">{message}</span>
+          <motion.button
+            ref={confirmRef}
+            type="button"
+            className="confirm-clear__yes"
+            onClick={onConfirm}
+            aria-label={`Confirm: ${confirmText}`}
+            aria-describedby="confirm-clear-msg"
+            {...tap}
+          >
+            {confirmText}
+          </motion.button>
+          <motion.button
+            type="button"
+            className="confirm-clear__no"
+            onClick={onCancel}
+            aria-label={`Cancel: ${cancelText}`}
+            {...tap}
+          >
+            {cancelText}
+          </motion.button>
+        </motion.span>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #303
Closes #304

## Changes

### Issue #303 — SEO Configuration
- **`frontend/public/robots.txt`** — disallows all crawlers; this is a private financial application. Update when public pages are added.
- **`frontend/public/sitemap.xml`** — valid empty sitemap with commented example for future public pages. Both files are served at root level by Vite's static file handling.

### Issue #304 — Replace `window.confirm` with Inline UI
- **`frontend/src/components/InlineConfirmation.jsx`** — new reusable component using existing `makeVariants`/`tapScale` animation patterns, `AnimatePresence` for smooth transitions, auto-focus on confirm button, Escape key to cancel, and proper ARIA attributes.
- **`frontend/src/App.jsx`** — fixed corrupted merge (duplicate declarations, missing `useState`/`useRTL` imports), wired `InlineConfirmation` into the payment form replacing the old inline ternary.