### PR TITLE
feat: add POST /api/stellar/account/fund testnet endpoint (#293)

### DIFF
--- a/backend/src/middleware/validate.js
+++ b/backend/src/middleware/validate.js
@@ -36,6 +36,11 @@ export const rules = {
       .withMessage(`Memo exceeds ${MAX_LENGTHS.memo} characters`)
       .customSanitizer(v => sanitizeText(v, MAX_LENGTHS.memo)),
 
+  publicKeyBody: body('publicKey')
+    .trim()
+    .matches(STELLAR_PUBLIC_KEY)
+    .withMessage('Invalid Stellar public key'),
+
   publicKeyParam: param('publicKey')
     .trim()
     .matches(STELLAR_PUBLIC_KEY)

--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -42,6 +42,16 @@ router.post('/account/create', async (req, res) => {
   }
 });
 
+router.post('/account/fund', rules.publicKeyBody, validate, async (req, res) => {
+  if (!StellarService.isTestnet()) return res.status(403).json({ error: 'Only available on testnet' });
+  try {
+    const result = await StellarService.fundAccount(req.body.publicKey);
+    res.json(result);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
 router.post('/account/import', rules.importAccount, validate, async (req, res) => {
   try {
     const { secretKey } = req.body;

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -48,8 +48,16 @@ function getHorizonServer() {
   return horizonServer;
 }
 
-function isTestnet() {
+export function isTestnet() {
   return getConfig().stellar.network === 'testnet';
+}
+
+export async function fundAccount(publicKey) {
+  if (!isTestnet()) throw new Error('Only available on testnet');
+  const res = await fetch(`https://friendbot.stellar.org?addr=${publicKey}`);
+  if (!res.ok) throw new Error(`Friendbot funding failed: ${res.status} ${res.statusText}`);
+  logger.debug('stellar.friendbotFunded', { publicKey });
+  return { funded: true, publicKey };
 }
 
 export async function createAccount() {


### PR DESCRIPTION
## Summary

Closes #293

Exposes a dedicated endpoint to re-fund an **existing** testnet account via Friendbot — useful when an account runs out of XLM during testing without needing to create a new keypair.

## Changes

- **`services/stellar.js`** — exported `isTestnet()` and added `fundAccount(publicKey)` which calls Friendbot
- **`routes/stellar.js`** — added `POST /api/stellar/account/fund` guarded by `isTestnet()` → 403 on mainnet
- **`middleware/validate.js`** — added `publicKeyBody` validation rule (mirrors existing `publicKeyParam` but for request body)

## Endpoint

```
POST /api/stellar/account/fund
Content-Type: application/json

{ "publicKey": "G..." }
```

Returns `{ funded: true, publicKey }` on success, `403` on mainnet.