### PR TITLE
feat: add account label / nickname support (#294)

### DIFF
--- a/backend/prisma/migrations/20260424000000_add_account_label/migration.sql
+++ b/backend/prisma/migrations/20260424000000_add_account_label/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Setting" ADD COLUMN "accountLabel" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -57,6 +57,7 @@ model Setting {
   user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   defaultAsset    String   @default("XLM")
   notificationsOn Boolean  @default(true)
+  accountLabel    String?
   updatedAt       DateTime @updatedAt
 }
 

--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import { body } from 'express-validator';
 import * as StellarSDK from '@stellar/stellar-sdk';
 import * as StellarService from '../services/stellar.js';
 import * as AMMService from '../services/amm.js';
@@ -9,6 +10,7 @@ import { SUPPORTED_ASSETS, getIssuer } from '../config/assets.js';
 import { dispatchEvent } from '../webhooks/dispatcher.js';
 import { cacheMiddleware } from '../middleware/cache.js';
 import { keys as cacheKeys, TTL, invalidateBalance } from '../cache/appCache.js';
+import prisma from '../db/client.js';
 
 const router = express.Router();
 
@@ -345,6 +347,41 @@ router.post('/trustline', rules.createTrustline, validate, async (req, res) => {
     res.status(500).json({ error: error.message });
   }
 });
+
+router.get('/account/:publicKey/label', rules.publicKeyParam, validate, async (req, res) => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { publicKey: req.params.publicKey },
+      include: { settings: true },
+    });
+    res.json({ accountLabel: user?.settings?.accountLabel ?? null });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+router.put('/account/:publicKey/label', rules.publicKeyParam, validate,
+  body('accountLabel').trim().isLength({ max: 50 }).withMessage('Label must be 50 characters or fewer'),
+  validate,
+  async (req, res) => {
+    try {
+      const { accountLabel } = req.body;
+      const user = await prisma.user.upsert({
+        where: { publicKey: req.params.publicKey },
+        update: {},
+        create: { publicKey: req.params.publicKey },
+      });
+      await prisma.setting.upsert({
+        where: { userId: user.id },
+        update: { accountLabel: accountLabel || null },
+        create: { userId: user.id, accountLabel: accountLabel || null },
+      });
+      res.json({ accountLabel: accountLabel || null });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  }
+);
 
 export default router;
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -46,7 +46,7 @@ function App() {
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [showImportForm, setShowImportForm] = useState(false);
   const [confirmClear, setConfirmClear] = useState(false);
-  const { account, balance, loading, recipient, amount, showQR, showImportForm, showShortcuts } = useAppState();
+  const { account, balance, loading, recipient, amount, showQR, showImportForm, showShortcuts, accountLabel } = useAppState();
   const dispatch = useAppDispatch();
 
   const msg = useMessages();
@@ -54,6 +54,8 @@ function App() {
   const { queue: queueOffline, dequeue, pendingItems, pendingCount } = useOfflineQueue();
   const [replaySecret, setReplaySecret] = useState('');
   const [showReplayPrompt, setShowReplayPrompt] = useState(false);
+  const [editingLabel, setEditingLabel] = useState(false);
+  const [labelDraft, setLabelDraft] = useState('');
   const { theme, isDark, toggleTheme } = useTheme();
   useRTL();
   const prefersReduced = useReducedMotion();
@@ -108,9 +110,13 @@ function App() {
     return () => navigator.serviceWorker.removeEventListener('message', onSwMessage);
   }, []);
 
-  const resetForm = () => dispatch({ type: A.RESET_FORM });
+  // Load label from backend when account is restored from persisted state
+  useEffect(() => {
+    if (account?.publicKey && !accountLabel) loadLabel(account.publicKey);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account?.publicKey]);
 
-  const resetForm = () => { setRecipient(''); setAmount(''); setMemo(''); };
+  const resetForm = () => dispatch({ type: A.RESET_FORM });
   const clearForm = () => {
     if (recipient || amount) { setConfirmClear(true); return; }
     resetForm();
@@ -141,12 +147,29 @@ function App() {
   const confirmClearYes = () => { setConfirmClear(false); resetForm(); };
   const confirmClearNo  = () => setConfirmClear(false);
 
+  const loadLabel = useCallback(async (publicKey) => {
+    try {
+      const { data } = await axios.get(`/api/stellar/account/${publicKey}/label`);
+      dispatch({ type: A.SET_LABEL, payload: data.accountLabel ?? '' });
+    } catch { /* non-critical */ }
+  }, [dispatch]);
+
+  const saveLabel = async () => {
+    if (!account) return;
+    try {
+      await axios.put(`/api/stellar/account/${account.publicKey}/label`, { accountLabel: labelDraft });
+      dispatch({ type: A.SET_LABEL, payload: labelDraft });
+      setEditingLabel(false);
+    } catch (error) {
+      msg.error('Failed to save label');
+    }
+  };
+
   const createAccount = async () => {
     try {
-      const { data } = await withTimeout(signal => axios.post('/api/stellar/account/create', null, { signal }));
-      setAccount(data);
       const { data } = await withTimeout(axios.post('/api/stellar/account/create'));
       dispatch({ type: A.SET_ACCOUNT, payload: data });
+      dispatch({ type: A.SET_LABEL, payload: '' });
       resetForm();
       msg.success('Account created! Save your secret key securely.');
     } catch (error) {
@@ -161,6 +184,7 @@ function App() {
       const { data } = await axios.post('/api/stellar/account/import', { secretKey });
       dispatch({ type: A.SET_ACCOUNT, payload: data });
       dispatch({ type: A.SET_SHOW_IMPORT, payload: false });
+      await loadLabel(data.publicKey);
       msg.success('Account imported successfully!');
     } catch (error) {
       logError(error, { context: 'importAccount' });
@@ -342,7 +366,39 @@ function App() {
 
         <header>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <h1>Stellar Remittance Platform</h1>
+            <div>
+              <h1>Stellar Remittance Platform</h1>
+              {account && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}>
+                  {editingLabel ? (
+                    <>
+                      <input
+                        type="text"
+                        value={labelDraft}
+                        onChange={(e) => setLabelDraft(e.target.value.slice(0, 50))}
+                        onKeyDown={(e) => { if (e.key === 'Enter') saveLabel(); if (e.key === 'Escape') setEditingLabel(false); }}
+                        placeholder="Add a nickname…"
+                        maxLength={50}
+                        aria-label="Account nickname"
+                        style={{ fontSize: '0.85rem', padding: '2px 6px' }}
+                        autoFocus
+                      />
+                      <button type="button" onClick={saveLabel} style={{ fontSize: '0.8rem' }} aria-label="Save nickname">Save</button>
+                      <button type="button" onClick={() => setEditingLabel(false)} style={{ fontSize: '0.8rem' }} aria-label="Cancel editing nickname">Cancel</button>
+                    </>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => { setLabelDraft(accountLabel); setEditingLabel(true); }}
+                      style={{ fontSize: '0.85rem', background: 'none', border: 'none', cursor: 'pointer', padding: 0, color: 'inherit', textDecoration: 'underline dotted' }}
+                      aria-label={accountLabel ? `Account nickname: ${accountLabel}. Click to edit.` : 'Add account nickname'}
+                    >
+                      {accountLabel || `${account.publicKey.slice(0, 6)}…${account.publicKey.slice(-4)}`}
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
               <button
                 type="button"

--- a/frontend/src/store/persistence.js
+++ b/frontend/src/store/persistence.js
@@ -14,6 +14,7 @@ function sanitize(state) {
     account: state.account?.publicKey
       ? { publicKey: state.account.publicKey }
       : null,
+    accountLabel: state.accountLabel || '',
   };
 }
 
@@ -27,6 +28,7 @@ export function loadState() {
     return {
       ...initialState,
       account: saved.account ?? null,
+      accountLabel: saved.accountLabel ?? '',
     };
   } catch {
     return initialState;

--- a/frontend/src/store/reducer.js
+++ b/frontend/src/store/reducer.js
@@ -15,6 +15,8 @@ export const A = {
   SET_SHOW_QR: 'SET_SHOW_QR',
   SET_SHOW_IMPORT: 'SET_SHOW_IMPORT',
   SET_SHOW_SHORTCUTS: 'SET_SHOW_SHORTCUTS',
+  // Label
+  SET_LABEL: 'SET_LABEL',
 };
 
 // ── Initial state ─────────────────────────────────────────────────────────────
@@ -31,6 +33,7 @@ export const initialState = {
   showQR: false,
   showImportForm: false,
   showShortcuts: false,
+  accountLabel: '',    // human-readable nickname
 };
 
 // ── Reducer ───────────────────────────────────────────────────────────────────
@@ -39,7 +42,7 @@ export function appReducer(state, action) {
     case A.SET_ACCOUNT:
       return { ...state, account: action.payload };
     case A.CLEAR_ACCOUNT:
-      return { ...state, account: null, balance: null };
+      return { ...state, account: null, balance: null, accountLabel: '' };
     case A.SET_BALANCE:
       return { ...state, balance: action.payload, _prevBalance: null };
     case A.SET_BALANCE_OPTIMISTIC:
@@ -60,6 +63,8 @@ export function appReducer(state, action) {
       return { ...state, showImportForm: action.payload };
     case A.SET_SHOW_SHORTCUTS:
       return { ...state, showShortcuts: action.payload };
+    case A.SET_LABEL:
+      return { ...state, accountLabel: action.payload };
     default:
       return state;
   }


### PR DESCRIPTION
## Summary

Closes #294

Allows users to assign a human-readable nickname (e.g. "My Main Wallet") to their account. The label is stored in the `Setting` model and displayed in the header instead of the truncated public key.

## Changes

### Backend
- **`prisma/schema.prisma`** — added `accountLabel String?` to `Setting` model
- **`prisma/migrations/20260424000000_add_account_label`** — `ALTER TABLE "Setting" ADD COLUMN "accountLabel" TEXT`
- **`routes/stellar.js`** — added two endpoints:
  - `GET  /api/stellar/account/:publicKey/label` → returns `{ accountLabel }`
  - `PUT  /api/stellar/account/:publicKey/label` → accepts `{ accountLabel }` (max 50 chars), upserts Setting row

### Frontend
- **`store/reducer.js`** — added `SET_LABEL` action + `accountLabel` field to initial state; `CLEAR_ACCOUNT` resets it
- **`store/persistence.js`** — `accountLabel` included in the persisted/sanitized state slice
- **`App.jsx`**:
  - Destructures `accountLabel` from app state
  - `loadLabel(publicKey)` fetches label from backend (called on import and on page restore via `useEffect`)
  - `saveLabel()` PUTs the draft to backend and dispatches `SET_LABEL`
  - Header shows label (or `GABCD…WXYZ` truncated key if no label set) as a clickable inline-edit button
  - Editing: input with Save/Cancel buttons; Enter saves, Escape cancels

## UX


Clicking the label (or truncated key) opens an inline text input. Max 50 characters.