### PR TITLE
feat: add copy-to-clipboard for transaction hash in success message (#295)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -239,7 +239,7 @@ function App() {
     try {
       const { data } = await withTimeout(signal => axios.post('/api/stellar/payment/send', payload, { signal }));
       const { data } = await withTimeout(axios.post('/api/stellar/payment/send', payload));
-      msg.success(`Payment sent! Hash: ${data.hash}`);
+      msg.success(`Payment sent! Hash: ${data.hash.slice(0, 8)}…`, { hash: data.hash });
       resetForm();
       checkBalance(); // sync real balance
     } catch (error) {

--- a/frontend/src/components/StatusMessage.jsx
+++ b/frontend/src/components/StatusMessage.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { CopyButton } from './CopyButton';
 
 const VARIANTS = {
   hidden: { opacity: 0, y: 12, scale: 0.97 },
@@ -20,6 +21,7 @@ function Message({ msg, onRemove, onRetry }) {
     >
       <span className="sm-icon" aria-hidden="true">{msg.icon}</span>
       <span className="sm-text">{msg.message}</span>
+      {msg.hash && <CopyButton text={msg.hash} label="Copy transaction hash" />}
       {msg.retry && (
         <button className="sm-retry" onClick={() => { onRetry(msg.id); msg.retry(); }} aria-label="Retry action">Retry</button>
       )}

--- a/frontend/src/hooks/useMessages.js
+++ b/frontend/src/hooks/useMessages.js
@@ -20,9 +20,9 @@ const AUTO_DISMISS = { success: 5000, info: 4000, warning: 0, error: 0 };
 export function useMessages() {
   const [state, dispatch] = useReducer(reducer, { messages: [], history: [] });
 
-  const add = useCallback((type, message, { retry, timeout } = {}) => {
+  const add = useCallback((type, message, { retry, timeout, hash } = {}) => {
     const id = nextId++;
-    const msg = { id, type, message, retry, timestamp: new Date(), icon: ICONS[type] };
+    const msg = { id, type, message, retry, hash, timestamp: new Date(), icon: ICONS[type] };
     dispatch({ type: 'ADD', msg });
     const ms = timeout ?? AUTO_DISMISS[type];
     if (ms > 0) setTimeout(() => dispatch({ type: 'REMOVE', id }), ms);


### PR DESCRIPTION
Closes #295

After a successful payment the toast now shows a truncated hash and a copy button so users can grab the full hash without opening transaction history.

**3 files, 5 lines added / 3 changed:**

- `hooks/useMessages.js` — thread optional `hash` field through `add()` into the message object
- `components/StatusMessage.jsx` — import `CopyButton` and render it next to the text when `msg.hash` is present
- `App.jsx` — pass `{ hash: data.hash }` to `msg.success()`; display truncated hash (`abc12345…`) in the label to keep the toast compact while the full hash is on the clipboard