### PR TITLE
feat: add Ctrl+B keyboard shortcut for Check Balance (#296)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -84,6 +84,10 @@ function App() {
         e.preventDefault();
         if (loading !== 'create') createAccount();
       }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'b') {
+        e.preventDefault();
+        if (loading !== 'balance') checkBalance();
+      }
       if (e.key === 'Escape') {
         dispatch({ type: A.SET_SHOW_QR, payload: false });
         dispatch({ type: A.SET_SHOW_SHORTCUTS, payload: false });
@@ -332,6 +336,7 @@ function App() {
             </div>
             <ul className="shortcuts-list">
               <li><kbd>Ctrl+N</kbd> Create new account</li>
+              <li><kbd>Ctrl+B</kbd> Check balance</li>
               <li><kbd>Ctrl+C</kbd> Copy key (when copy button focused)</li>
               <li><kbd>Escape</kbd> Close modals</li>
               <li><kbd>?</kbd> Toggle this help</li>
@@ -456,6 +461,7 @@ function App() {
               </div>
               <ul className="shortcuts-list">
                 <li><kbd>Ctrl+N</kbd> Create new account</li>
+                <li><kbd>Ctrl+B</kbd> Check balance</li>
                 <li><kbd>Ctrl+C</kbd> Copy key (when copy button focused)</li>
                 <li><kbd>Escape</kbd> Close modals</li>
                 <li><kbd>?</kbd> Toggle this help</li>


### PR DESCRIPTION
## Summary
Adds **Ctrl+B** (Cmd+B on Mac) keyboard shortcut to trigger the "Check Balance" action.

## Changes
- Added keydown handler for Ctrl+B that calls `checkBalance()` when not already loading
- Updated both shortcuts help modal instances to document the new shortcut

## Testing
- [x] Shortcut triggers balance check when account exists
- [x] Shortcut is ignored when balance check is already in-flight
- [x] Shortcut is documented in the help panel (press `?` to view)

Closes #296