### PR TITLE
Fix/issues 214 216 218 224

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,6 +28,11 @@ PLATFORM_FEE_ACCOUNT_SECRET=
 # XLM balance threshold below which fee bumping is applied (default: 2)
 FEE_BUMP_THRESHOLD_XLM=2
 
+# Payment Streaming
+# AES-256-GCM key used to encrypt per-stream sender secrets at rest (required)
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+STREAM_SECRET_ENCRYPTION_KEY=
+
 # Security
 JWT_SECRET=change-me
 

--- a/backend/prisma/migrations/20260424000000_fee_bump_stats_and_stream_secret/migration.sql
+++ b/backend/prisma/migrations/20260424000000_fee_bump_stats_and_stream_secret/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable: FeeBumpStat (singleton row for persisted fee-bump counters)
+CREATE TABLE "FeeBumpStat" (
+    "id"              TEXT NOT NULL DEFAULT 'singleton',
+    "total"           INTEGER NOT NULL DEFAULT 0,
+    "totalFeeStroops" BIGINT NOT NULL DEFAULT 0,
+    "accounts"        JSONB NOT NULL DEFAULT '[]',
+    "updatedAt"       TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FeeBumpStat_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable: add encrypted senderSecret to PaymentStream
+ALTER TABLE "PaymentStream" ADD COLUMN "senderSecret" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -84,6 +84,7 @@ model PaymentStream {
   status          StreamStatus @default(ACTIVE)
   failureCount    Int          @default(0)
   metadata        Json?
+  senderSecret    String?
   createdAt       DateTime     @default(now())
   updatedAt       DateTime     @updatedAt
 
@@ -152,6 +153,14 @@ model AMLAlert {
   riskScore     Int
   riskLevel     String
   createdAt     DateTime    @default(now())
+}
+
+model FeeBumpStat {
+  id              String   @id @default("singleton")
+  total           Int      @default(0)
+  totalFeeStroops BigInt   @default(0)
+  accounts        Json     @default("[]")
+  updatedAt       DateTime @updatedAt
 }
 
 model PendingMultiSigTx {

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -146,10 +146,7 @@ httpServer.listen(PORT, () => {
   const STREAM_INTERVAL = 60 * 1000; // Check every minute
   setInterval(async () => {
     try {
-      const workerSecret = process.env.STREAM_WORKER_SECRET;
-      if (workerSecret) {
-        await processActiveStreams(workerSecret);
-      }
+      await processActiveStreams();
     } catch (err) {
       logger.error('streaming.worker.failed', { error: err.message });
     }

--- a/backend/src/services/multiSig.js
+++ b/backend/src/services/multiSig.js
@@ -1,14 +1,27 @@
 import * as StellarSDK from '@stellar/stellar-sdk';
-import dotenv from 'dotenv';
 import { eventMonitor } from '../eventSourcing/index.js';
+import { getConfig } from '../config/env.js';
 import prisma from '../db/client.js';
 import { getIssuer } from '../config/assets.js';
 
-dotenv.config();
+function isTestnet() {
+  return getConfig().stellar.network === 'testnet';
+}
 
-const server = new StellarSDK.Horizon.Server(process.env.HORIZON_URL);
-const isTestnet = process.env.STELLAR_NETWORK === 'testnet';
-const networkPassphrase = isTestnet ? StellarSDK.Networks.TESTNET : StellarSDK.Networks.PUBLIC;
+function getNetworkPassphrase() {
+  return isTestnet() ? StellarSDK.Networks.TESTNET : StellarSDK.Networks.PUBLIC;
+}
+
+let _horizonServer;
+let _horizonUrl;
+function getServer() {
+  const { horizonUrl } = getConfig().stellar;
+  if (!_horizonServer || horizonUrl !== _horizonUrl) {
+    _horizonUrl = horizonUrl;
+    _horizonServer = new StellarSDK.Horizon.Server(horizonUrl);
+  }
+  return _horizonServer;
+}
 
 /**
  * Create a multi-signature account by setting signers and threshold on an existing account.
@@ -19,11 +32,11 @@ const networkPassphrase = isTestnet ? StellarSDK.Networks.TESTNET : StellarSDK.N
  */
 export async function createMultiSigAccount(sourceSecret, signers, thresholds, masterWeight = 1) {
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
-  const sourceAccount = await server.loadAccount(sourceKeypair.publicKey());
+  const sourceAccount = await getServer().loadAccount(sourceKeypair.publicKey());
 
   const txBuilder = new StellarSDK.TransactionBuilder(sourceAccount, {
     fee: StellarSDK.BASE_FEE,
-    networkPassphrase,
+    getNetworkPassphrase(),
   });
 
   // Set thresholds and master weight
@@ -50,7 +63,7 @@ export async function createMultiSigAccount(sourceSecret, signers, thresholds, m
 
   const transaction = txBuilder.setTimeout(30).build();
   transaction.sign(sourceKeypair);
-  const result = await server.submitTransaction(transaction);
+  const result = await getServer().submitTransaction(transaction);
 
   await eventMonitor.publishEvent(sourceKeypair.publicKey(), {
     type: 'MultiSigAccountCreated',
@@ -78,7 +91,7 @@ export async function createMultiSigAccount(sourceSecret, signers, thresholds, m
  * Build a multi-sig transaction (XDR) without submitting — signers collect signatures separately.
  */
 export async function buildMultiSigTransaction(sourcePublicKey, destination, amount, assetCode = 'XLM') {
-  const sourceAccount = await server.loadAccount(sourcePublicKey);
+  const sourceAccount = await getServer().loadAccount(sourcePublicKey);
 
   const asset =
     assetCode === 'XLM'
@@ -87,7 +100,7 @@ export async function buildMultiSigTransaction(sourcePublicKey, destination, amo
 
   const transaction = new StellarSDK.TransactionBuilder(sourceAccount, {
     fee: StellarSDK.BASE_FEE,
-    networkPassphrase,
+    getNetworkPassphrase(),
   })
     .addOperation(
       StellarSDK.Operation.payment({
@@ -141,7 +154,7 @@ export async function addSignature(txId, signerSecret) {
     throw new Error(`Signer ${signerPublicKey} has already signed this transaction`);
   }
 
-  const transaction = StellarSDK.TransactionBuilder.fromXDR(pending.txXdr, networkPassphrase);
+  const transaction = StellarSDK.TransactionBuilder.fromXDR(pending.txXdr, getNetworkPassphrase());
   transaction.sign(signerKeypair);
 
   const updatedSignatures = [...signatures, { publicKey: signerPublicKey, signedAt: new Date().toISOString() }];
@@ -175,8 +188,8 @@ export async function submitMultiSigTransaction(txId) {
   if (!pending) throw new Error(`Transaction ${txId} not found`);
   if (pending.status !== 'pending') throw new Error(`Transaction ${txId} is already ${pending.status}`);
 
-  const transaction = StellarSDK.TransactionBuilder.fromXDR(pending.txXdr, networkPassphrase);
-  const result = await server.submitTransaction(transaction);
+  const transaction = StellarSDK.TransactionBuilder.fromXDR(pending.txXdr, getNetworkPassphrase());
+  const result = await getServer().submitTransaction(transaction);
 
   await prisma.pendingMultiSigTx.update({
     where: { txId },
@@ -208,7 +221,7 @@ export async function submitMultiSigTransaction(txId) {
  * Verify that a transaction XDR has valid signatures from the expected signers.
  */
 export function verifySignatures(txXdr, expectedSigners) {
-  const transaction = StellarSDK.TransactionBuilder.fromXDR(txXdr, networkPassphrase);
+  const transaction = StellarSDK.TransactionBuilder.fromXDR(txXdr, getNetworkPassphrase());
   const txHash = transaction.hash();
 
   const results = expectedSigners.map((publicKey) => {
@@ -233,7 +246,7 @@ export function verifySignatures(txXdr, expectedSigners) {
  * Get the current signers and thresholds for an account from the network.
  */
 export async function getMultiSigConfig(publicKey) {
-  const account = await server.loadAccount(publicKey);
+  const account = await getServer().loadAccount(publicKey);
 
   const signers = account.signers.map((s) => ({
     publicKey: s.key,
@@ -258,11 +271,11 @@ export async function getMultiSigConfig(publicKey) {
  */
 export async function updateMultiSigConfig(sourceSecret, updates) {
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
-  const sourceAccount = await server.loadAccount(sourceKeypair.publicKey());
+  const sourceAccount = await getServer().loadAccount(sourceKeypair.publicKey());
 
   const txBuilder = new StellarSDK.TransactionBuilder(sourceAccount, {
     fee: StellarSDK.BASE_FEE,
-    networkPassphrase,
+    getNetworkPassphrase(),
   });
 
   if (updates.thresholds || updates.masterWeight !== undefined) {
@@ -298,7 +311,7 @@ export async function updateMultiSigConfig(sourceSecret, updates) {
 
   const transaction = txBuilder.setTimeout(30).build();
   transaction.sign(sourceKeypair);
-  const result = await server.submitTransaction(transaction);
+  const result = await getServer().submitTransaction(transaction);
 
   await eventMonitor.publishEvent(sourceKeypair.publicKey(), {
     type: 'MultiSigConfigUpdated',

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -5,15 +5,39 @@ import { getIssuer } from '../config/assets.js';
 import logger from '../config/logger.js';
 import prisma from '../db/client.js';
 
-// In-memory fee bump usage stats for admin dashboard
-const feeBumpStats = { total: 0, totalFeeStroops: 0, accounts: new Set() };
-
-export function getFeeBumpStats() {
+export async function getFeeBumpStats() {
+  const row = await prisma.feeBumpStat.findUnique({ where: { id: 'singleton' } });
   return {
-    total: feeBumpStats.total,
-    totalFeeStroops: feeBumpStats.totalFeeStroops,
-    uniqueAccounts: feeBumpStats.accounts.size,
+    total: row?.total ?? 0,
+    totalFeeStroops: Number(row?.totalFeeStroops ?? 0),
+    uniqueAccounts: Array.isArray(row?.accounts) ? row.accounts.length : 0,
   };
+}
+
+async function incrementFeeBumpStats(sourcePublicKey, feeStroops) {
+  try {
+    // Upsert the singleton row, then atomically add the new account to the set
+    await prisma.$transaction(async (tx) => {
+      const existing = await tx.feeBumpStat.upsert({
+        where: { id: 'singleton' },
+        create: { id: 'singleton', total: 1, totalFeeStroops: feeStroops, accounts: [sourcePublicKey] },
+        update: {
+          total: { increment: 1 },
+          totalFeeStroops: { increment: feeStroops },
+        },
+      });
+      // Add account to set if not already present
+      const accounts = Array.isArray(existing.accounts) ? existing.accounts : [];
+      if (!accounts.includes(sourcePublicKey)) {
+        await tx.feeBumpStat.update({
+          where: { id: 'singleton' },
+          data: { accounts: [...accounts, sourcePublicKey] },
+        });
+      }
+    });
+  } catch (err) {
+    logger.warn('stellar.feeBumpStats.persist.failed', { error: err.message });
+  }
 }
 
 /**
@@ -160,16 +184,13 @@ export async function sendPayment(sourceSecret, destination, amount, assetCode =
         threshold: feeBumpThreshold,
       });
       // Track stats for cost monitoring
-      feeBumpStats.total += 1;
-      feeBumpStats.totalFeeStroops += StellarSDK.BASE_FEE * 10;
-      feeBumpStats.accounts.add(sourcePublicKey);
+      await incrementFeeBumpStats(sourcePublicKey, StellarSDK.BASE_FEE * 10);
     }
   }
 
   let result;
   try {
     result = await getHorizonServer().submitTransaction(txToSubmit);
-    result = await getHorizonServer().submitTransaction(transaction);
   } catch (err) {
     logger.error('stellar.sendPayment.failed', { source: sourcePublicKey, destination, amount, assetCode, error: err.message });
     throw err;

--- a/backend/src/services/streaming.js
+++ b/backend/src/services/streaming.js
@@ -3,8 +3,19 @@ import prisma from '../db/client.js';
 import { sendPayment } from './stellar.js';
 import { eventMonitor } from '../eventSourcing/index.js';
 import logger from '../config/logger.js';
+import { encryptToEnvValue, decryptFromEnvValue } from '../config/secrets.js';
 
-export async function createStream({ senderPublicKey, recipientPublicKey, assetCode, rateAmount, intervalSeconds = 60, endTime, metadata }) {
+function getStreamEncryptionKey() {
+  const key = process.env.STREAM_SECRET_ENCRYPTION_KEY;
+  if (!key) throw new Error('STREAM_SECRET_ENCRYPTION_KEY is not set');
+  return key;
+}
+
+export async function createStream({ senderPublicKey, senderSecret, recipientPublicKey, assetCode, rateAmount, intervalSeconds = 60, endTime, metadata }) {
+  if (!senderSecret) throw new Error('senderSecret is required to create a stream');
+
+  const encryptedSecret = encryptToEnvValue(senderSecret, getStreamEncryptionKey());
+
   // Ensure users exist
   const [sender, recipient] = await Promise.all([
     prisma.user.upsert({ where: { publicKey: senderPublicKey }, update: {}, create: { publicKey: senderPublicKey } }),
@@ -21,6 +32,7 @@ export async function createStream({ senderPublicKey, recipientPublicKey, assetC
       endTime: endTime ? new Date(endTime) : null,
       metadata: metadata || {},
       status: 'ACTIVE',
+      senderSecret: encryptedSecret,
     },
   });
 
@@ -119,12 +131,7 @@ export async function getStreamAnalytics() {
   };
 }
 
-export async function processActiveStreams(sourceSecret) {
-  if (!sourceSecret) {
-    logger.warn('streaming.worker.skip', { reason: 'No sourceSecret provided' });
-    return;
-  }
-
+export async function processActiveStreams() {
   const now = new Date();
   const activeStreams = await prisma.paymentStream.findMany({
     where: {
@@ -145,9 +152,14 @@ export async function processActiveStreams(sourceSecret) {
 
     if (secondsSinceLast >= stream.intervalSeconds) {
        try {
-         // Execute payment on Stellar
+         if (!stream.senderSecret) {
+           throw new Error('Stream has no senderSecret — cannot sign transaction');
+         }
+         const senderSecret = decryptFromEnvValue(stream.senderSecret, getStreamEncryptionKey());
+
+         // Execute payment on Stellar using the actual sender's secret
          const result = await sendPayment(
-           sourceSecret, 
+           senderSecret,
            stream.recipient.publicKey, 
            stream.rateAmount.toString(), 
            stream.assetCode

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import { useNetworkStatus } from './hooks/useNetworkStatus';
 import { useMessages } from './hooks/useMessages';
 import { usePWA } from './hooks/usePWA';
 import { useOfflineQueue } from './hooks/useOfflineQueue';
+import { useRTL } from './hooks/useRTL';
 import { makeVariants, tapScale } from './utils/animations';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { QRCodeModal } from './components/QRCodeModal';


### PR DESCRIPTION

<h2>Summary</h2>
<p>Four bugs fixed across the frontend and backend — a missing import causing a runtime crash, network config read at module load time, streaming payments sent from the wrong account, and admin dashboard metrics that reset on every server restart.</p>
<hr>
<h2>Issue #214 — <code>useRTL</code> called without being imported (<code>frontend/src/App.jsx</code>)</h2>
<p><code>useRTL()</code> was invoked inside <code>App</code> but never imported, causing a <code>ReferenceError</code> at runtime that crashes the app on load.</p>
<p><strong>Fix:</strong> Added <code>import { useRTL } from './hooks/useRTL'</code> to the imports section of <code>App.jsx</code>.</p>
<hr>
<h2>Issue #216 — Network config read at module load time (<code>backend/src/services/multiSig.js</code>)</h2>
<p><code>const isTestnet = process.env.STELLAR_NETWORK === 'testnet'</code> and <code>const networkPassphrase = ...</code> were evaluated once when the module was first imported. If the env var was set after module load (e.g. in tests), the wrong network passphrase would be used for the entire process lifetime. Same problem applied to the <code>server</code> instance being constructed from <code>process.env.HORIZON_URL</code> at import time.</p>
<p><strong>Fix:</strong></p>
<ul>
<li>Removed the module-level <code>isTestnet</code>, <code>networkPassphrase</code>, and <code>server</code> constants.</li>
<li>Removed the <code>dotenv.config()</code> side-effect import.</li>
<li>Added <code>isTestnet()</code>, <code>getNetworkPassphrase()</code>, and <code>getServer()</code> helper functions that call <code>getConfig().stellar</code> on each invocation, consistent with the pattern used in <code>stellar.js</code>.</li>
<li>All functions in the file now call these helpers instead of the stale module-level values.</li>
</ul>
<hr>
<h2>Issue #218 — All streaming payments sent from platform account (<code>backend/src/services/streaming.js</code>)</h2>
<p><code>processActiveStreams</code> was signing every streaming payment with <code>STREAM_WORKER_SECRET</code> — the platform's own key — regardless of which user created the stream. Funds were debited from the platform account, not the actual sender's account.</p>
<p><strong>Fix:</strong></p>
<ul>
<li><code>createStream</code> now accepts a <code>senderSecret</code> parameter, encrypts it with AES-256-GCM using <code>STREAM_SECRET_ENCRYPTION_KEY</code> (via the existing <code>encryptToEnvValue</code> utility), and stores the ciphertext in the new <code>PaymentStream.senderSecret</code> column.</li>
<li><code>processActiveStreams</code> no longer takes a <code>sourceSecret</code> argument. It decrypts each stream's own <code>senderSecret</code> at execution time and passes it to <code>sendPayment</code>, so every payment is signed and debited from the correct sender.</li>
<li>The call site in <code>server.js</code> is updated accordingly.</li>
<li><code>STREAM_SECRET_ENCRYPTION_KEY</code> added to <code>.env.example</code> with a generation command.</li>
</ul>
<hr>
<h2>Issue #224 — Fee-bump stats reset on restart (<code>backend/src/services/stellar.js</code>)</h2>
<p><code>feeBumpStats</code> was a module-level object (<code>total</code>, <code>totalFeeStroops</code>, <code>accounts</code>). Every server restart wiped the counters, making the admin dashboard metrics meaningless in production.</p>
<p><strong>Fix:</strong></p>
<ul>
<li>Removed the in-memory object entirely.</li>
<li>Added a <code>FeeBumpStat</code> Prisma model — a singleton row (<code>id = 'singleton'</code>) that survives restarts.</li>
<li><code>getFeeBumpStats()</code> is now <code>async</code> and reads from the DB.</li>
<li><code>incrementFeeBumpStats()</code> upserts the singleton with atomic <code>increment</code> operations and deduplicates the accounts array. Stat writes fail silently so a DB hiccup never blocks a payment.</li>
<li>Also fixed a pre-existing double-submit bug where <code>submitTransaction</code> was called twice in <code>sendPayment</code>.</li>
</ul>
<hr>
<h2>Schema &amp; Migration</h2>
<ul>
<li>New model: <code>FeeBumpStat</code> — singleton row for persisted fee-bump counters.</li>
<li>New column: <code>PaymentStream.senderSecret String?</code> — AES-256-GCM encrypted sender secret key.</li>
<li>Migration: <code>20260424000000_fee_bump_stats_and_stream_secret</code></li>
</ul>
<hr>
<h2>Files Changed</h2>

File | Change
-- | --
frontend/src/App.jsx | Add missing useRTL import
backend/src/services/multiSig.js | Replace module-level config reads with getConfig() call-time helpers
backend/src/services/stellar.js | Replace in-memory stats with DB persistence; fix double-submit
backend/src/services/streaming.js | Per-stream encrypted sender secret; remove platform key dependency
backend/src/server.js | Remove STREAM_WORKER_SECRET arg from worker call
backend/prisma/schema.prisma | Add FeeBumpStat model and senderSecret field
backend/prisma/migrations/... | Migration SQL for new table and column
backend/.env.example | Document STREAM_SECRET_ENCRYPTION_KEY


</body></html><!--EndFragment-->
</body>
</html>

closes #214 closes #216 closes #218 closes #224 