### PR TITLE
feat: tx lookup, live rates, fee USD preview, address book (#259 #260 #262 #263)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,8 +28,11 @@ import { ConfirmSendDialog } from './components/ConfirmSendDialog';
 import { LanguageSelector } from './components/LanguageSelector';
 import { FileUpload } from './components/FileUpload';
 import { AccountCreatedCelebration } from './components/AccountCreatedCelebration';
+import { TxLookup } from './components/TxLookup';
+import { AddressBook } from './components/AddressBook';
 import { useTheme } from './contexts/ThemeContext';
 import { useAppState, useAppDispatch, A } from './store/index.js';
+import { useExchangeRate } from './hooks/useExchangeRate';
 
 const STATUS_COLORS = { connected: '#22c55e', disconnected: '#ef4444', reconnecting: '#f59e0b' };
 const TIMEOUT_MS = 30000;
@@ -73,6 +76,9 @@ function App() {
   const [editingLabel, setEditingLabel] = useState(false);
   const [labelDraft, setLabelDraft] = useState('');
   const [showCelebration, setShowCelebration] = useState(false);
+  const [showTxLookup, setShowTxLookup] = useState(false);
+  const [deepLinkHash, setDeepLinkHash] = useState('');
+  const [lastWsMessage, setLastWsMessage] = useState(null);
   const { theme, isDark, toggleTheme } = useTheme();
   useRTL();
   const prefersReduced = useReducedMotion();
@@ -80,6 +86,7 @@ function App() {
   const tap = tapScale(prefersReduced);
 
   const handleWsMessage = useCallback((wsMsg) => {
+    setLastWsMessage(wsMsg);
     if (wsMsg.type === 'transaction') {
       const text = wsMsg.direction === 'received'
         ? `📥 Received ${wsMsg.amount} ${wsMsg.assetCode} — tx: ${wsMsg.hash?.slice(0, 8)}…`
@@ -91,6 +98,7 @@ function App() {
 
   const wsStatus = useWebSocket(account?.publicKey ?? null, handleWsMessage);
   const { status: networkStatus } = useNetworkStatus();
+  const xlmUsdRate = useExchangeRate(lastWsMessage);
 
   useEffect(() => {
     const onKeyDown = (e) => {
@@ -128,6 +136,15 @@ function App() {
     if (account?.publicKey && !accountLabel) loadLabel(account.publicKey);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [account?.publicKey]);
+
+  // Deep-link: open tx lookup when URL contains #tx=<hash>
+  useEffect(() => {
+    const match = window.location.hash.match(/^#tx=(.+)$/);
+    if (match) {
+      setDeepLinkHash(match[1]);
+      setShowTxLookup(true);
+    }
+  }, []);
 
   const resetForm = () => dispatch({ type: A.RESET_FORM });
   const clearForm = () => {
@@ -356,6 +373,15 @@ function App() {
               >
                 ⌨
               </button>
+              <button
+                type="button"
+                className="shortcuts-help-btn"
+                onClick={() => { setDeepLinkHash(''); setShowTxLookup(true); }}
+                aria-label="Look up transaction by hash"
+                title="Look up transaction by hash"
+              >
+                🔍
+              </button>
               <NetworkBadge status={networkStatus} />
               <motion.span
                 animate={{ opacity: [0.6, 1, 0.6] }}
@@ -481,6 +507,12 @@ function App() {
                   )}
                 </AnimatePresence>
                 <FeeDisplay amount={amount} visible={amountValid} />
+                {amountValid && xlmUsdRate && (
+                  <p className="rate-estimate" aria-live="polite">
+                    ≈ ${(parseFloat(amount) * xlmUsdRate).toFixed(2)} USD
+                    <span className="rate-source"> · live rate</span>
+                  </p>
+                )}
                 <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
                   <motion.button onClick={sendPayment} {...tap} disabled={!recipientValid || !amountValid || loading === 'send'}>
                     {loading === 'send' ? <Spinner label="Sending payment..." /> : 'Send'}
@@ -573,6 +605,10 @@ function App() {
                 <motion.section className="section" aria-labelledby="send-heading" variants={v.fadeSlide}>
                   <ErrorBoundary context="send-payment">
                     <h2 id="send-heading">Send Payment</h2>
+                    <AddressBook
+                      onSelect={(address) => dispatch({ type: A.SET_RECIPIENT, payload: address })}
+                      prefillAddress={recipient}
+                    />
                     <div className="input-wrap">
                       <label htmlFor="recipient-input" className="sr-only">Recipient public key</label>
                       <input
@@ -675,6 +711,12 @@ function App() {
                     </div>
 
                     <FeeDisplay amount={amount} visible={amountValid} />
+                    {amountValid && xlmUsdRate && (
+                      <p className="rate-estimate" aria-live="polite">
+                        ≈ ${(parseFloat(amount) * xlmUsdRate).toFixed(2)} USD
+                        <span className="rate-source"> · live rate</span>
+                      </p>
+                    )}
                     <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
                       <motion.button
                         onClick={() => setShowConfirm(true)}
@@ -792,6 +834,16 @@ function App() {
           onConfirm={() => { setShowConfirm(false); sendPayment(); }}
           onCancel={() => setShowConfirm(false)}
         />
+
+        <AnimatePresence>
+          {showTxLookup && (
+            <TxLookup
+              initialHash={deepLinkHash}
+              accountPublicKey={account?.publicKey ?? ''}
+              onClose={() => { setShowTxLookup(false); setDeepLinkHash(''); }}
+            />
+          )}
+        </AnimatePresence>
       </div>
     </>
   );

--- a/frontend/src/components/AddressBook.jsx
+++ b/frontend/src/components/AddressBook.jsx
@@ -1,16 +1,29 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+
+const STORAGE_KEY = 'stellar_address_book';
+
+function loadContacts() {
+  try { return JSON.parse(localStorage.getItem(STORAGE_KEY)) ?? []; } catch { return []; }
+}
+
+function saveContacts(contacts) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(contacts));
+}
 
 /**
  * AddressBook — manage saved recipients and select one.
- * Props: onSelect, contacts (array of { name, address })
+ * Props: onSelect, prefillAddress (string to pre-populate the new-contact address field)
  */
-export function AddressBook({ onSelect, contacts: initialContacts = [] }) {
-  const [contacts, setContacts] = useState(initialContacts);
+export function AddressBook({ onSelect, prefillAddress = '' }) {
+  const [contacts, setContacts] = useState(loadContacts);
   const [open, setOpen] = useState(false);
   const [newName, setNewName] = useState('');
-  const [newAddress, setNewAddress] = useState('');
+  const [newAddress, setNewAddress] = useState(prefillAddress);
   const [search, setSearch] = useState('');
+
+  // Sync prefillAddress into the new-contact form when it changes
+  useEffect(() => { if (prefillAddress) setNewAddress(prefillAddress); }, [prefillAddress]);
 
   const filtered = contacts.filter(c =>
     c.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -19,12 +32,18 @@ export function AddressBook({ onSelect, contacts: initialContacts = [] }) {
 
   const add = () => {
     if (!newName.trim() || !newAddress.trim()) return;
-    setContacts(prev => [...prev, { name: newName.trim(), address: newAddress.trim() }]);
+    const updated = [...contacts, { name: newName.trim(), address: newAddress.trim() }];
+    setContacts(updated);
+    saveContacts(updated);
     setNewName('');
     setNewAddress('');
   };
 
-  const remove = (address) => setContacts(prev => prev.filter(c => c.address !== address));
+  const remove = (address) => {
+    const updated = contacts.filter(c => c.address !== address);
+    setContacts(updated);
+    saveContacts(updated);
+  };
 
   return (
     <div>

--- a/frontend/src/components/FeeDisplay.jsx
+++ b/frontend/src/components/FeeDisplay.jsx
@@ -23,6 +23,8 @@ export function FeeDisplay({ amount, visible }) {
   const amtNum = parseFloat(amount) || 0;
   const feeXLM = parseFloat(fee.feeXLM);
   const total = (amtNum + feeXLM).toFixed(7).replace(/\.?0+$/, '');
+  const xlmUsd = fee.xlmUsd ? parseFloat(fee.xlmUsd) : null;
+  const totalUsd = xlmUsd ? ((amtNum + feeXLM) * xlmUsd).toFixed(2) : null;
   const savingsUsd = fee.feeUsd
     ? (fee.traditionalFeeUsd - parseFloat(fee.feeUsd)).toFixed(2)
     : null;
@@ -52,7 +54,10 @@ export function FeeDisplay({ amount, visible }) {
       {amtNum > 0 && (
         <div className="fee-row fee-total">
           <span className="fee-label">Total (amount + fee)</span>
-          <span className="fee-val">{total} XLM</span>
+          <span className="fee-val">
+            {total} XLM
+            {totalUsd && <span className="fee-usd"> ≈ ${totalUsd}</span>}
+          </span>
         </div>
       )}
 

--- a/frontend/src/components/TxLookup.jsx
+++ b/frontend/src/components/TxLookup.jsx
@@ -1,0 +1,154 @@
+import { useState, useEffect, useRef } from 'react';
+import axios from 'axios';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useFocusTrap } from '../hooks/useFocusTrap';
+import { isValidStellarAddress } from '../utils/validateStellarAddress';
+
+const TYPE_LABELS = { payment: 'Payment', create_account: 'Account Created', unknown: 'Other' };
+
+function fmt(dateStr) {
+  return new Date(dateStr).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+/**
+ * TxLookup — modal that fetches a transaction by hash and shows its details.
+ *
+ * Props:
+ *   initialHash      – pre-filled hash (e.g. from URL deep-link #tx=<hash>)
+ *   accountPublicKey – if an account is already loaded, skip the public-key field
+ *   onClose          – called when the user dismisses the modal
+ */
+export function TxLookup({ initialHash = '', accountPublicKey = '', onClose }) {
+  const [hash, setHash] = useState(initialHash);
+  const [publicKey, setPublicKey] = useState(accountPublicKey);
+  const [tx, setTx] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const modalRef = useRef(null);
+  useFocusTrap(modalRef, true);
+
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // Auto-fetch when opened with a pre-filled hash + known account
+  useEffect(() => {
+    if (initialHash && accountPublicKey) lookup(initialHash, accountPublicKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function lookup(h = hash, pk = publicKey) {
+    const trimH = h.trim();
+    const trimPk = pk.trim();
+    if (!trimH || !trimPk) return;
+    setLoading(true);
+    setError('');
+    setTx(null);
+    try {
+      const { data } = await axios.get(`/api/stellar/account/${trimPk}/transactions`, {
+        params: { hash: trimH, limit: 50 },
+      });
+      const found = data.records?.find(r => r.hash?.toLowerCase() === trimH.toLowerCase());
+      if (found) {
+        setTx(found);
+      } else {
+        setError('Transaction not found for this account.');
+      }
+    } catch (e) {
+      setError(e?.response?.data?.error ?? e?.message ?? 'Lookup failed.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const handleSubmit = (e) => { e.preventDefault(); lookup(); };
+
+  return (
+    <motion.div
+      className="tx-overlay"
+      onClick={onClose}
+      initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+    >
+      <motion.div
+        ref={modalRef}
+        className="tx-modal"
+        onClick={e => e.stopPropagation()}
+        initial={{ scale: 0.9, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.9, opacity: 0 }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="tx-lookup-title"
+      >
+        <div className="tx-modal-header">
+          <h3 id="tx-lookup-title">{tx ? 'Transaction Details' : 'Look Up Transaction'}</h3>
+          <button className="qr-close" onClick={onClose} aria-label="Close transaction lookup">✕</button>
+        </div>
+
+        {!tx ? (
+          <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {!accountPublicKey && (
+              <>
+                <label htmlFor="tl-pubkey" className="sr-only">Account public key</label>
+                <input
+                  id="tl-pubkey"
+                  type="text"
+                  placeholder="Account Public Key (G…)"
+                  value={publicKey}
+                  onChange={e => setPublicKey(e.target.value)}
+                  spellCheck={false}
+                  aria-label="Account public key"
+                  style={{ border: `2px solid ${publicKey && !isValidStellarAddress(publicKey) ? '#ef4444' : '#ccc'}` }}
+                />
+              </>
+            )}
+            <label htmlFor="tl-hash" className="sr-only">Transaction hash</label>
+            <input
+              id="tl-hash"
+              type="text"
+              placeholder="Transaction hash"
+              value={hash}
+              onChange={e => setHash(e.target.value)}
+              spellCheck={false}
+              aria-label="Transaction hash"
+              // eslint-disable-next-line jsx-a11y/no-autofocus
+              autoFocus={!initialHash}
+            />
+            {error && <p className="field-error" role="alert">{error}</p>}
+            <button
+              type="submit"
+              disabled={loading || !hash.trim() || !publicKey.trim()}
+              aria-busy={loading}
+            >
+              {loading ? 'Looking up…' : 'Look Up'}
+            </button>
+          </form>
+        ) : (
+          <>
+            <dl className="tx-detail-list">
+              <dt>Hash</dt><dd className="tx-hash">{tx.hash}</dd>
+              <dt>Type</dt><dd>{TYPE_LABELS[tx.type] ?? tx.type}</dd>
+              {tx.direction && <><dt>Direction</dt><dd>{tx.direction}</dd></>}
+              {tx.amount && <><dt>Amount</dt><dd>{tx.amount} {tx.asset}</dd></>}
+              {tx.counterparty && <><dt>Counterparty</dt><dd className="tx-hash">{tx.counterparty}</dd></>}
+              <dt>Date</dt><dd>{fmt(tx.date)}</dd>
+              <dt>Fee</dt><dd>{tx.fee} stroops</dd>
+              {tx.memo && <><dt>Memo</dt><dd>{tx.memo}</dd></>}
+              <dt>Status</dt><dd>{tx.successful ? '✓ Success' : '✗ Failed'}</dd>
+            </dl>
+            <button
+              type="button"
+              style={{ marginTop: 12 }}
+              onClick={() => setTx(null)}
+              aria-label="Look up another transaction"
+            >
+              ← Look up another
+            </button>
+          </>
+        )}
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/frontend/src/hooks/useExchangeRate.js
+++ b/frontend/src/hooks/useExchangeRate.js
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+/**
+ * Fetches the XLM/USD exchange rate on mount and keeps it fresh via
+ * rateChange WebSocket events (passed in as `wsMessage`).
+ *
+ * @param {object|null} wsMessage – latest message from useWebSocket's onMessage
+ * @returns {number|null} rate – XLM price in USD, or null while loading
+ */
+export function useExchangeRate(wsMessage) {
+  const [rate, setRate] = useState(null);
+
+  useEffect(() => {
+    axios.get('/api/stellar/exchange-rate/XLM/USD')
+      .then(({ data }) => setRate(data.rate))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (wsMessage?.type === 'rateChange' && wsMessage.from === 'XLM' && wsMessage.to === 'USD') {
+      setRate(wsMessage.rate);
+    }
+  }, [wsMessage]);
+
+  return rate;
+}

--- a/frontend/src/hooks/useWebSocket.js
+++ b/frontend/src/hooks/useWebSocket.js
@@ -21,11 +21,15 @@ export function useWebSocket(publicKey, onMessage) {
       attempts.current = 0;
       setStatus('connected');
       if (publicKey) socket.send(JSON.stringify({ type: 'subscribe', publicKey }));
+      // Also subscribe to the shared rates channel for rateChange events
+      socket.send(JSON.stringify({ type: 'subscribe', publicKey: 'rates' }));
     };
 
     socket.onmessage = (e) => {
       try {
-        onMessageRef.current?.(JSON.parse(e.data));
+        const parsed = JSON.parse(e.data);
+        // Broadcast messages are wrapped in { data, sig }; direct messages are not
+        onMessageRef.current?.(parsed.data ?? parsed);
       } catch (_) {}
     };
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -773,6 +773,16 @@ kbd {
   line-height: 1;
 }
 .fee-tip-btn:hover { background: none; color: #0284c7; }
+
+.rate-estimate {
+  margin: -4px 0 10px;
+  font-size: 13px;
+  color: #0369a1;
+  font-weight: 500;
+}
+.rate-source { color: #94a3b8; font-weight: 400; font-size: 11px; }
+[data-theme="dark"] .rate-estimate { color: #38bdf8; }
+[data-theme="dark"] .rate-source { color: #64748b; }
 .fee-tooltip {
   background: #fff;
   border: 1px solid #bae6fd;


### PR DESCRIPTION
## Summary

Closes #259 
Closes #260 
Closes #392 
Closes #263 

### Changes

#259 — Transaction detail deep-link
- New TxLookup modal: enter a hash (+ public key if no account loaded) to fetch and display full transaction details
- Auto-opens when the URL contains #tx=<hash> (shareable deep-link)
- 🔍 button in the header for manual lookup

#260 — Address book
- AddressBook component wired into the payment form above the recipient field
- Contacts persist to localStorage; clicking "Use" auto-fills the recipient input
- Current recipient address is pre-filled when opening the "Add Contact" form

#262 — Live exchange rate in payment form
- New useExchangeRate hook fetches GET /api/stellar/exchange-rate/XLM/USD on mount
- Updates in real-time when a rateChange WebSocket event arrives (subscribes to the rates channel)
- Displays ≈ $X.XX USD · live rate below the amount input when a valid amount is entered
- Fixed WS envelope unwrapping ({ data, sig } → inner payload) that was silently breaking all broadcast message handling

#263 — Fee estimate USD total
- FeeDisplay now shows the total cost (amount + fee) in USD alongside XLM, using the xlmUsd rate already returned by /api/stellar/fee-stats

### Testing
- No new test failures introduced (pre-existing failures unchanged)
- Build verified with vite build