### PR TITLE
feat: complete UI tasks #269-#272 (path payments, settings, CSV export, webhook management)

### DIFF
--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -397,5 +397,53 @@ router.put('/account/:publicKey/label', rules.publicKeyParam, validate,
   }
 );
 
+// GET /api/stellar/account/:publicKey/settings
+router.get('/account/:publicKey/settings', rules.publicKeyParam, validate, async (req, res) => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { publicKey: req.params.publicKey },
+      include: { settings: true, kycRecord: { select: { status: true, submittedAt: true } } },
+    });
+    const settings = user?.settings ?? {};
+    res.json({
+      defaultAsset: settings.defaultAsset ?? 'XLM',
+      notificationsOn: settings.notificationsOn ?? true,
+      kycStatus: user?.kycRecord?.status ?? null,
+      kycSubmittedAt: user?.kycRecord?.submittedAt ?? null,
+    });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// PUT /api/stellar/account/:publicKey/settings
+router.put('/account/:publicKey/settings',
+  rules.publicKeyParam, validate,
+  body('defaultAsset').optional().isString().trim().isLength({ min: 1, max: 12 }),
+  body('notificationsOn').optional().isBoolean(),
+  validate,
+  async (req, res) => {
+    try {
+      const { defaultAsset, notificationsOn } = req.body;
+      const user = await prisma.user.upsert({
+        where: { publicKey: req.params.publicKey },
+        update: {},
+        create: { publicKey: req.params.publicKey },
+      });
+      const update = {};
+      if (defaultAsset !== undefined) update.defaultAsset = defaultAsset;
+      if (notificationsOn !== undefined) update.notificationsOn = notificationsOn;
+      const settings = await prisma.setting.upsert({
+        where: { userId: user.id },
+        update,
+        create: { userId: user.id, ...update },
+      });
+      res.json({ defaultAsset: settings.defaultAsset, notificationsOn: settings.notificationsOn });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  }
+);
+
 export default router;
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import { CopyButton } from './components/CopyButton';
 import { Spinner } from './components/Spinner';
 import { TransactionHistory } from './components/TransactionHistory';
 import { StreamPayment } from './components/StreamPayment';
+import { PathPayment } from './components/PathPayment';
 import { FeeDisplay } from './components/FeeDisplay';
 import { InlineConfirmation } from './components/InlineConfirmation';
 import { logError } from './utils/errorLogger';
@@ -811,6 +812,11 @@ function App() {
                 {/* Stream Payments */}
                 <motion.div variants={v.fadeSlide}>
                   <StreamPayment publicKey={account.publicKey} />
+                </motion.div>
+
+                {/* Path Payment */}
+                <motion.div variants={v.fadeSlide}>
+                  <PathPayment account={account} />
                 </motion.div>
 
               </motion.div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,7 @@ import { Spinner } from './components/Spinner';
 import { TransactionHistory } from './components/TransactionHistory';
 import { StreamPayment } from './components/StreamPayment';
 import { PathPayment } from './components/PathPayment';
+import { AccountSettings } from './components/AccountSettings';
 import { FeeDisplay } from './components/FeeDisplay';
 import { InlineConfirmation } from './components/InlineConfirmation';
 import { logError } from './utils/errorLogger';
@@ -70,6 +71,7 @@ function App() {
   const [showCelebration, setShowCelebration] = useState(false);
   const [showTxLookup, setShowTxLookup] = useState(false);
   const [deepLinkHash, setDeepLinkHash] = useState('');
+  const [showSettings, setShowSettings] = useState(false);
   const [lastWsMessage, setLastWsMessage] = useState(null);
   const { theme, isDark, toggleTheme } = useTheme();
   useRTL();
@@ -417,6 +419,17 @@ function App() {
               >
                 🔍
               </button>
+              {account && (
+                <button
+                  type="button"
+                  className="shortcuts-help-btn"
+                  onClick={() => setShowSettings(true)}
+                  aria-label="Account settings"
+                  title="Account settings"
+                >
+                  ⚙️
+                </button>
+              )}
               <NetworkBadge status={networkStatus} />
               <motion.span
                 animate={{ opacity: [0.6, 1, 0.6] }}
@@ -902,6 +915,13 @@ function App() {
             />
           )}
         </AnimatePresence>
+
+        {showSettings && account && (
+          <AccountSettings
+            publicKey={account.publicKey}
+            onClose={() => setShowSettings(false)}
+          />
+        )}
       </div>
     </>
   );

--- a/frontend/src/components/AccountSettings.jsx
+++ b/frontend/src/components/AccountSettings.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { AddressBook } from './AddressBook';
+import { WebhookManager } from './WebhookManager';
 
 const ASSETS = ['XLM', 'USDC', 'EURC'];
 
@@ -103,6 +104,10 @@ export function AccountSettings({ publicKey, onClose }) {
             <div style={{ marginBottom: 16 }}>
               <p style={{ fontWeight: 600, marginBottom: 4 }}>Address Book</p>
               <AddressBook />
+            </div>
+
+            <div style={{ marginBottom: 16 }}>
+              <WebhookManager accountId={publicKey} />
             </div>
 
             <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>

--- a/frontend/src/components/AccountSettings.jsx
+++ b/frontend/src/components/AccountSettings.jsx
@@ -1,0 +1,120 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { AddressBook } from './AddressBook';
+
+const ASSETS = ['XLM', 'USDC', 'EURC'];
+
+export function AccountSettings({ publicKey, onClose }) {
+  const [settings, setSettings] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    axios.get(`/api/stellar/account/${publicKey}/settings`)
+      .then(({ data }) => setSettings(data))
+      .catch(e => setError(e?.response?.data?.error ?? e.message));
+  }, [publicKey]);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      await axios.put(`/api/stellar/account/${publicKey}/settings`, {
+        defaultAsset: settings.defaultAsset,
+        notificationsOn: settings.notificationsOn,
+      });
+      setSaved(true);
+    } catch (e) {
+      setError(e?.response?.data?.error ?? e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="replay-modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="settings-title"
+      onClick={e => e.target === e.currentTarget && onClose()}
+    >
+      <div className="replay-modal" style={{ maxWidth: 480, width: '100%' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <h2 id="settings-title" style={{ margin: 0 }}>Account Settings</h2>
+          <button type="button" className="qr-close" onClick={onClose} aria-label="Close settings">✕</button>
+        </div>
+
+        {!settings && !error && <p>Loading…</p>}
+        {error && <p role="alert" style={{ color: '#ef4444' }}>{error}</p>}
+
+        {settings && (
+          <>
+            <div style={{ marginBottom: 16 }}>
+              <label htmlFor="default-asset" style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>
+                Default Asset
+              </label>
+              <select
+                id="default-asset"
+                value={settings.defaultAsset}
+                onChange={e => setSettings(s => ({ ...s, defaultAsset: e.target.value }))}
+                aria-label="Default asset"
+              >
+                {ASSETS.map(a => <option key={a} value={a}>{a}</option>)}
+              </select>
+            </div>
+
+            <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 10 }}>
+              <input
+                id="notifications-toggle"
+                type="checkbox"
+                checked={settings.notificationsOn}
+                onChange={e => setSettings(s => ({ ...s, notificationsOn: e.target.checked }))}
+                style={{ width: 'auto', minHeight: 'unset' }}
+              />
+              <label htmlFor="notifications-toggle" style={{ fontWeight: 600, cursor: 'pointer' }}>
+                Notifications enabled
+              </label>
+            </div>
+
+            <div style={{ marginBottom: 16 }}>
+              <p style={{ fontWeight: 600, marginBottom: 4 }}>KYC Status</p>
+              {settings.kycStatus ? (
+                <p style={{ margin: 0 }}>
+                  <span style={{
+                    background: settings.kycStatus === 'APPROVED' ? '#22c55e' : settings.kycStatus === 'REJECTED' ? '#ef4444' : '#f59e0b',
+                    color: '#fff', borderRadius: 4, padding: '2px 8px', fontSize: '0.8rem', fontWeight: 600,
+                  }}>
+                    {settings.kycStatus}
+                  </span>
+                  {settings.kycSubmittedAt && (
+                    <span style={{ marginLeft: 8, fontSize: '0.8rem', color: 'var(--text-muted, #64748b)' }}>
+                      Submitted {new Date(settings.kycSubmittedAt).toLocaleDateString()}
+                    </span>
+                  )}
+                </p>
+              ) : (
+                <p style={{ margin: 0, color: 'var(--text-muted, #64748b)', fontSize: '0.9rem' }}>No KYC record on file.</p>
+              )}
+            </div>
+
+            <div style={{ marginBottom: 16 }}>
+              <p style={{ fontWeight: 600, marginBottom: 4 }}>Address Book</p>
+              <AddressBook />
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <button type="button" onClick={save} disabled={saving}>
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+              <button type="button" className="btn-clear" onClick={onClose}>Close</button>
+              {saved && <span role="status" style={{ color: '#22c55e', fontSize: '0.9rem' }}>Saved ✓</span>}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PathPayment.jsx
+++ b/frontend/src/components/PathPayment.jsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+const ASSETS = [
+  { code: 'XLM', label: 'XLM (Stellar Lumens)' },
+  { code: 'USDC', label: 'USDC' },
+  { code: 'EURC', label: 'EURC' },
+];
+
+const DEFAULT_FORM = {
+  sourceAsset: 'XLM',
+  destAsset: 'USDC',
+  sendAmount: '',
+  destination: '',
+};
+
+export function PathPayment({ account }) {
+  const [form, setForm] = useState(DEFAULT_FORM);
+  const [paths, setPaths] = useState(null);
+  const [finding, setFinding] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const set = (key, val) => setForm(f => ({ ...f, [key]: val }));
+
+  const bestPath = paths?.[0] ?? null;
+
+  const findPaths = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setPaths(null);
+    setSuccess(null);
+    setShowConfirm(false);
+    if (!form.sendAmount || parseFloat(form.sendAmount) <= 0) {
+      setError('Enter a valid send amount.');
+      return;
+    }
+    if (form.sourceAsset === form.destAsset) {
+      setError('Source and destination assets must differ.');
+      return;
+    }
+    setFinding(true);
+    try {
+      const { data } = await axios.post('/api/path-payment/paths', {
+        sourceAsset: { code: form.sourceAsset },
+        sourceAmount: form.sendAmount,
+        destinationAsset: { code: form.destAsset },
+        destinationAccount: form.destination || undefined,
+      });
+      setPaths(data.paths);
+      if (!data.paths.length) setError('No paths found between these assets.');
+    } catch (e) {
+      setError(e?.response?.data?.error ?? e.message);
+    } finally {
+      setFinding(false);
+    }
+  };
+
+  const sendPayment = async () => {
+    if (!account?.secretKey || !bestPath) return;
+    setSending(true);
+    setError(null);
+    setShowConfirm(false);
+    try {
+      const { data } = await axios.post('/api/path-payment/send', {
+        sourceSecret: account.secretKey,
+        destination: form.destination,
+        sendAsset: { code: form.sourceAsset },
+        sendAmount: form.sendAmount,
+        destAsset: { code: form.destAsset },
+        path: bestPath.path.map(code => ({ code })),
+      });
+      setSuccess(`Sent! Hash: ${data.hash.slice(0, 8)}…`);
+      setForm(DEFAULT_FORM);
+      setPaths(null);
+    } catch (e) {
+      setError(e?.response?.data?.error ?? e.message);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <section className="section" aria-labelledby="path-payment-heading">
+      <h2 id="path-payment-heading">Path Payment (Cross-Asset)</h2>
+
+      <form onSubmit={findPaths} noValidate>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 8 }}>
+          <div>
+            <label htmlFor="pp-src-asset" className="sr-only">Source asset</label>
+            <select
+              id="pp-src-asset"
+              value={form.sourceAsset}
+              onChange={e => set('sourceAsset', e.target.value)}
+              aria-label="Source asset"
+            >
+              {ASSETS.map(a => <option key={a.code} value={a.code}>{a.label}</option>)}
+            </select>
+          </div>
+          <span style={{ alignSelf: 'center' }}>→</span>
+          <div>
+            <label htmlFor="pp-dst-asset" className="sr-only">Destination asset</label>
+            <select
+              id="pp-dst-asset"
+              value={form.destAsset}
+              onChange={e => set('destAsset', e.target.value)}
+              aria-label="Destination asset"
+            >
+              {ASSETS.map(a => <option key={a.code} value={a.code}>{a.label}</option>)}
+            </select>
+          </div>
+        </div>
+
+        <div className="input-wrap" style={{ marginBottom: 8 }}>
+          <label htmlFor="pp-amount" className="sr-only">Send amount</label>
+          <input
+            id="pp-amount"
+            type="text"
+            inputMode="decimal"
+            placeholder={`Amount (${form.sourceAsset})`}
+            value={form.sendAmount}
+            onChange={e => set('sendAmount', e.target.value.replace(/[^0-9.]/g, ''))}
+            aria-label={`Send amount in ${form.sourceAsset}`}
+          />
+        </div>
+
+        <div className="input-wrap" style={{ marginBottom: 8 }}>
+          <label htmlFor="pp-dest" className="sr-only">Destination account</label>
+          <input
+            id="pp-dest"
+            type="text"
+            placeholder="Destination Public Key (G…)"
+            value={form.destination}
+            onChange={e => set('destination', e.target.value.trim())}
+            aria-label="Destination public key"
+          />
+        </div>
+
+        <button type="submit" disabled={finding || !form.sendAmount || !form.destination}>
+          {finding ? 'Finding paths…' : 'Find Best Rate'}
+        </button>
+      </form>
+
+      {error && (
+        <p role="alert" style={{ color: '#ef4444', marginTop: 8 }}>{error}</p>
+      )}
+
+      {success && (
+        <p role="status" style={{ color: '#22c55e', marginTop: 8 }}>{success}</p>
+      )}
+
+      {bestPath && (
+        <div
+          style={{ marginTop: 12, padding: '10px 14px', background: 'var(--card-bg, #f8fafc)', borderRadius: 8, border: '1px solid var(--border, #e2e8f0)' }}
+          aria-label="Best path rate"
+        >
+          <p style={{ margin: '0 0 4px' }}>
+            <strong>Best rate:</strong>{' '}
+            {form.sendAmount} {form.sourceAsset} → <strong>{parseFloat(bestPath.destinationAmount).toFixed(7)} {form.destAsset}</strong>
+          </p>
+          {bestPath.path.length > 0 && (
+            <p style={{ margin: '0 0 8px', fontSize: '0.85rem', color: 'var(--text-muted, #64748b)' }}>
+              Via: {bestPath.path.join(' → ')}
+            </p>
+          )}
+
+          {!showConfirm ? (
+            <button
+              type="button"
+              onClick={() => setShowConfirm(true)}
+              disabled={sending || !account?.secretKey}
+              aria-label="Confirm and send path payment"
+            >
+              Send
+            </button>
+          ) : (
+            <span role="group" aria-label="Confirm path payment">
+              <span style={{ marginRight: 8 }}>Confirm send?</span>
+              <button type="button" onClick={sendPayment} disabled={sending} style={{ marginRight: 6 }}>
+                {sending ? 'Sending…' : 'Yes, send'}
+              </button>
+              <button type="button" className="btn-clear" onClick={() => setShowConfirm(false)}>Cancel</button>
+            </span>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/TransactionHistory.jsx
+++ b/frontend/src/components/TransactionHistory.jsx
@@ -11,6 +11,48 @@ function fmt(dateStr) {
   return new Date(dateStr).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
 }
 
+function csvEscape(val) {
+  const s = val == null ? '' : String(val);
+  return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+async function fetchAllTransactions(publicKey) {
+  const all = [];
+  let cursor = null;
+  do {
+    const params = { limit: 50, ...(cursor ? { cursor } : {}) };
+    const { data } = await axios.get(`/api/stellar/account/${publicKey}/transactions`, { params });
+    all.push(...(data.records ?? []));
+    cursor = data.nextCursor ?? null;
+  } while (cursor);
+  return all;
+}
+
+function downloadCsv(rows, filename) {
+  const COLS = ['date', 'type', 'direction', 'amount', 'asset', 'counterparty', 'hash', 'fee', 'status'];
+  const lines = [
+    COLS.join(','),
+    ...rows.map(tx => [
+      tx.date ? new Date(tx.date).toISOString() : '',
+      TYPE_LABELS[tx.type] ?? tx.type ?? '',
+      tx.direction ?? '',
+      tx.amount ?? '',
+      tx.asset ?? 'XLM',
+      tx.counterparty ?? '',
+      tx.hash ?? '',
+      tx.fee ?? '',
+      tx.successful ? 'success' : 'failed',
+    ].map(csvEscape).join(',')),
+  ];
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 function TxRow({ tx, onClick }) {
   const isReceived = tx.direction === 'received';
   const isSent = tx.direction === 'sent';
@@ -98,6 +140,20 @@ export function TransactionHistory({ publicKey }) {
   const [filters, setFilters] = useState({ type: '', dateFrom: '', dateTo: '', hash: '' });
   const [cursors, setCursors] = useState([]); // ring-buffer for back-pagination (max 50)
   const [error, setError] = useState(null);
+  const [exporting, setExporting] = useState(false);
+
+  const handleExportCsv = async () => {
+    setExporting(true);
+    try {
+      const all = await fetchAllTransactions(publicKey);
+      const date = new Date().toISOString().slice(0, 10);
+      downloadCsv(all, `transactions-${publicKey.slice(0, 8)}-${date}.csv`);
+    } catch (e) {
+      setError(e?.response?.data?.error ?? e.message);
+    } finally {
+      setExporting(false);
+    }
+  };
 
   const MAX_CURSOR_HISTORY = 50;
 
@@ -141,15 +197,27 @@ export function TransactionHistory({ publicKey }) {
     <section className="section" aria-labelledby="tx-history-heading">
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
         <h3 id="tx-history-heading">Transaction History</h3>
-        <motion.button
-          className="tx-load-btn"
-          onClick={handleLoad}
-          disabled={loading}
-          whileTap={{ scale: 0.97 }}
-          aria-label={loaded ? 'Refresh transaction history' : 'Load transaction history'}
-        >
-          {loading ? <Spinner label="Loading transactions…" /> : loaded ? '↺ Refresh' : 'Load History'}
-        </motion.button>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <motion.button
+            onClick={handleExportCsv}
+            disabled={exporting || loading}
+            whileTap={{ scale: 0.97 }}
+            aria-label="Export transaction history as CSV"
+            aria-busy={exporting}
+            style={{ background: '#16a34a' }}
+          >
+            {exporting ? <Spinner label="Exporting…" /> : '⬇ Export CSV'}
+          </motion.button>
+          <motion.button
+            className="tx-load-btn"
+            onClick={handleLoad}
+            disabled={loading}
+            whileTap={{ scale: 0.97 }}
+            aria-label={loaded ? 'Refresh transaction history' : 'Load transaction history'}
+          >
+            {loading ? <Spinner label="Loading transactions…" /> : loaded ? '↺ Refresh' : 'Load History'}
+          </motion.button>
+        </div>
       </div>
 
       <form className="tx-filters" onSubmit={applyFilters} aria-label="Filter transactions">

--- a/frontend/src/components/WebhookManager.jsx
+++ b/frontend/src/components/WebhookManager.jsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+
+const WEBHOOK_EVENTS = [
+  { value: 'payment_sent', label: 'payment_sent' },
+  { value: 'payment_received', label: 'payment_received' },
+];
+
+export function WebhookManager({ accountId }) {
+  const [webhooks, setWebhooks] = useState([]);
+  const [url, setUrl] = useState('');
+  const [secret, setSecret] = useState('');
+  const [selectedEvents, setSelectedEvents] = useState(WEBHOOK_EVENTS.map((e) => e.value));
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [notice, setNotice] = useState('');
+
+  const canSubmit = useMemo(() => {
+    return url.trim().length > 0 && selectedEvents.length > 0 && !submitting;
+  }, [url, selectedEvents, submitting]);
+
+  const loadWebhooks = async () => {
+    if (!accountId) return;
+    setLoading(true);
+    setError('');
+    try {
+      const { data } = await axios.get('/api/webhooks', { params: { accountId } });
+      setWebhooks(Array.isArray(data) ? data : []);
+    } catch (e) {
+      setError(e?.response?.data?.error ?? 'Failed to load webhooks');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadWebhooks();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accountId]);
+
+  const toggleEvent = (eventName) => {
+    setSelectedEvents((prev) => {
+      if (prev.includes(eventName)) return prev.filter((e) => e !== eventName);
+      return [...prev, eventName];
+    });
+  };
+
+  const registerWebhook = async (e) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    setSubmitting(true);
+    setError('');
+    setNotice('');
+
+    try {
+      await axios.post('/api/webhooks', {
+        url: url.trim(),
+        accountId,
+        events: selectedEvents,
+        secret: secret.trim() || undefined,
+      });
+      setUrl('');
+      setSecret('');
+      setSelectedEvents(WEBHOOK_EVENTS.map((item) => item.value));
+      setNotice('Webhook registered successfully.');
+      await loadWebhooks();
+    } catch (err) {
+      const message = err?.response?.data?.errors?.[0]?.msg ?? err?.response?.data?.error ?? 'Failed to register webhook';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const removeWebhook = async (id) => {
+    setError('');
+    setNotice('');
+    try {
+      await axios.delete(`/api/webhooks/${id}`);
+      setNotice('Webhook deleted.');
+      setWebhooks((prev) => prev.filter((w) => w.id !== id));
+    } catch (err) {
+      setError(err?.response?.data?.error ?? 'Failed to delete webhook');
+    }
+  };
+
+  return (
+    <section aria-labelledby="webhooks-title">
+      <p id="webhooks-title" style={{ fontWeight: 600, marginBottom: 4 }}>Webhooks</p>
+      <p style={{ margin: '0 0 12px', color: 'var(--text-muted, #64748b)', fontSize: '0.9rem' }}>
+        Register webhook URLs to receive account event notifications.
+      </p>
+
+      <form onSubmit={registerWebhook} style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 12, marginBottom: 12 }}>
+        <label htmlFor="webhook-url" style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>
+          Webhook URL
+        </label>
+        <input
+          id="webhook-url"
+          type="url"
+          value={url}
+          onChange={(evt) => setUrl(evt.target.value)}
+          placeholder="https://example.com/webhooks/stellar"
+          required
+          style={{ marginBottom: 8 }}
+        />
+
+        <label htmlFor="webhook-secret" style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>
+          Signing Secret (optional)
+        </label>
+        <input
+          id="webhook-secret"
+          type="text"
+          value={secret}
+          onChange={(evt) => setSecret(evt.target.value)}
+          placeholder="leave blank to auto-generate"
+          style={{ marginBottom: 8 }}
+        />
+
+        <fieldset style={{ border: 'none', padding: 0, marginBottom: 10 }}>
+          <legend style={{ fontWeight: 600, marginBottom: 6 }}>Events</legend>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+            {WEBHOOK_EVENTS.map((eventItem) => (
+              <label key={eventItem.value} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={selectedEvents.includes(eventItem.value)}
+                  onChange={() => toggleEvent(eventItem.value)}
+                  style={{ width: 'auto', minHeight: 'unset', margin: 0 }}
+                />
+                {eventItem.label}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <button type="submit" disabled={!canSubmit}>
+          {submitting ? 'Registering…' : 'Register webhook'}
+        </button>
+      </form>
+
+      {error && <p role="alert" style={{ color: '#ef4444', marginBottom: 8 }}>{error}</p>}
+      {notice && <p role="status" style={{ color: '#16a34a', marginBottom: 8 }}>{notice}</p>}
+
+      {loading ? (
+        <p>Loading registered webhooks…</p>
+      ) : webhooks.length === 0 ? (
+        <p style={{ color: 'var(--text-muted, #64748b)', fontSize: '0.9rem', marginBottom: 0 }}>
+          No webhooks registered for this account.
+        </p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: 8 }}>
+          {webhooks.map((webhook) => (
+            <li key={webhook.id} style={{ border: '1px solid var(--border)', borderRadius: 8, padding: 10 }}>
+              <div style={{ fontWeight: 600, overflowWrap: 'anywhere' }}>{webhook.url}</div>
+              <div style={{ marginTop: 4, fontSize: '0.85rem', color: 'var(--text-muted, #64748b)' }}>
+                Events: {(webhook.events ?? []).join(', ')}
+              </div>
+              <div style={{ marginTop: 4, fontSize: '0.8rem', color: 'var(--text-muted, #64748b)' }}>
+                Added: {webhook.createdAt ? new Date(webhook.createdAt).toLocaleString() : 'Unknown'}
+              </div>
+              <div style={{ marginTop: 8 }}>
+                <button
+                  type="button"
+                  className="btn-clear"
+                  onClick={() => removeWebhook(webhook.id)}
+                  style={{ width: 'auto' }}
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #269

closes #270

Closes #271

closes #272 

## Summary
This PR bundles the four related UI tasks into one reviewable change set:

1. #269 Path payment UI for cross-asset transfers
2. #270 Account settings modal and preferences support
3. #271 CSV export for transaction history
4. #272 Webhook management UI

## Task #272 Details
Added webhook management in the frontend settings flow:
- Register webhook URL for selected events (`payment_sent`, `payment_received`)
- Optional custom signing secret when registering
- View all registered webhooks for the active account
- Delete registered webhooks

## Files changed for #272
- frontend/src/components/WebhookManager.jsx
- frontend/src/components/AccountSettings.jsx

## Notes
- Webhook UI calls existing backend endpoints under `/api/webhooks`.
- Full frontend build currently fails due pre-existing syntax/state declaration issues in frontend/src/App.jsx that are unrelated to this task (duplicate declarations and JSX mismatch already present before these edits).