### PR TITLE
refactor(kyc): replace manual validation with zod schema

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "swagger-ui-express": "^5.0.0",
     "winston": "^3.19.0",
     "winston-daily-rotate-file": "^5.0.0",
-    "ws": "^8.20.0"
+    "ws": "^8.20.0",
+    "zod": "^3.24.4"
   }
 }

--- a/backend/src/compliance/kycCollector.js
+++ b/backend/src/compliance/kycCollector.js
@@ -1,40 +1,48 @@
+import { z } from 'zod';
 import prisma from '../db/client.js';
 
 const KYC_STATUS = { PENDING: 'PENDING', APPROVED: 'APPROVED', REJECTED: 'REJECTED', UNDER_REVIEW: 'UNDER_REVIEW' };
 
+const kycSchema = z.object({
+  fullName:       z.string().min(1),
+  dateOfBirth:    z.string().date(),
+  nationality:    z.string().min(1),
+  documentType:   z.enum(['PASSPORT', 'NATIONAL_ID', 'DRIVERS_LICENSE', 'RESIDENCE_PERMIT']),
+  documentNumber: z.string().min(1),
+  address:        z.string().min(1),
+  phoneNumber:    z.string().regex(/^\+[1-9]\d{1,14}$/).optional(),
+  email:          z.string().email().optional(),
+});
+
 class KYCCollector {
   async submitKYC(userId, data) {
-    const required = ['fullName', 'dateOfBirth', 'nationality', 'documentType', 'documentNumber', 'address'];
-    const missing = required.filter(f => !data[f]);
-    if (missing.length) throw new Error(`Missing required KYC fields: ${missing.join(', ')}`);
-
-    const dob = new Date(data.dateOfBirth);
-    if (isNaN(dob.getTime())) throw new Error('dateOfBirth must be a valid date');
+    const parsed = kycSchema.parse(data);
+    const dob = new Date(parsed.dateOfBirth);
 
     return prisma.kYCRecord.upsert({
       where: { userId },
       create: {
         userId,
         status: KYC_STATUS.PENDING,
-        fullName: data.fullName,
+        fullName: parsed.fullName,
         dateOfBirth: dob,
-        nationality: data.nationality,
-        documentType: data.documentType,
-        documentNumber: data.documentNumber,
-        address: data.address,
-        phoneNumber: data.phoneNumber ?? null,
-        email: data.email ?? null,
+        nationality: parsed.nationality,
+        documentType: parsed.documentType,
+        documentNumber: parsed.documentNumber,
+        address: parsed.address,
+        phoneNumber: parsed.phoneNumber ?? null,
+        email: parsed.email ?? null,
       },
       update: {
         status: KYC_STATUS.PENDING,
-        fullName: data.fullName,
+        fullName: parsed.fullName,
         dateOfBirth: dob,
-        nationality: data.nationality,
-        documentType: data.documentType,
-        documentNumber: data.documentNumber,
-        address: data.address,
-        phoneNumber: data.phoneNumber ?? null,
-        email: data.email ?? null,
+        nationality: parsed.nationality,
+        documentType: parsed.documentType,
+        documentNumber: parsed.documentNumber,
+        address: parsed.address,
+        phoneNumber: parsed.phoneNumber ?? null,
+        email: parsed.email ?? null,
       },
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,17 @@
         "swagger-ui-express": "^5.0.0",
         "winston": "^3.19.0",
         "winston-daily-rotate-file": "^5.0.0",
-        "ws": "^8.20.0"
+        "ws": "^8.20.0",
+        "zod": "^3.24.4"
+      }
+    },
+    "backend/node_modules/zod": {
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
+      "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "frontend": {


### PR DESCRIPTION
Replace manual KYC validation with Zod schema
  
  Replaces the hand-rolled required-field check and date guard in kycCollector.submitKYC with a Zod schema that
  validates:
  
  - dateOfBirth — ISO 8601 date string (YYYY-MM-DD)
  - documentType — enum: PASSPORT, NATIONAL_ID, DRIVERS_LICENSE, RESIDENCE_PERMIT
  - phoneNumber — E.164 format (optional)
  - email — valid email address (optional)
  
  Validation errors now surface as structured ZodError with per-field detail instead of a single generic message.

closes #309 