### PR TITLE
feat: add GET /account/:publicKey/trustlines endpoint

### DIFF
--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -231,6 +231,35 @@ router.post('/payment/send', paymentRateLimiter, rules.sendPayment, validate, as
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
+/**
+ * @swagger
+ * /api/stellar/account/{publicKey}/trustlines:
+ *   get:
+ *     summary: Get trustlines for an account
+ *     description: Returns all non-native trustlines (asset code, issuer, balance, limit, authorized flag).
+ *     tags: [Stellar]
+ *     parameters:
+ *       - in: path
+ *         name: publicKey
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Trustlines retrieved successfully
+ *       500:
+ *         description: Server error
+ */
+router.get('/account/:publicKey/trustlines', rules.publicKeyParam, validate, async (req, res) => {
+  try {
+    const trustlines = await StellarService.getTrustlines(req.params.publicKey);
+    res.json({ trustlines });
+  } catch (error) {
+    logError(req, error, { publicKey: req.params.publicKey });
+    res.status(500).json({ error: 'Failed to retrieve trustlines' });
+  }
+});
+
 router.get('/account/:publicKey/transactions', rules.publicKeyParam, validate, async (req, res) => {
   try {
     const { cursor, limit, type, dateFrom, dateTo, hash } = req.query;

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -427,6 +427,20 @@ export async function getNetworkStatus() {
     };
   }
 }
+export async function getTrustlines(publicKey) {
+  logger.debug('stellar.getTrustlines', { publicKey });
+  const account = await getHorizonServer().loadAccount(publicKey);
+  return account.balances
+    .filter(b => b.asset_type !== 'native')
+    .map(b => ({
+      assetCode: b.asset_code,
+      issuer: b.asset_issuer,
+      balance: b.balance,
+      limit: b.limit,
+      authorized: b.is_authorized === true,
+    }));
+}
+
 export async function mergeAccount(sourceSecret, destination) {
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
   const sourcePublicKey = sourceKeypair.publicKey();

--- a/backend/tests/stellar.unit.test.js
+++ b/backend/tests/stellar.unit.test.js
@@ -181,7 +181,7 @@ describe('Stellar Service Unit Tests', () => {
     // Setup Stellar SDK mocks
     StellarSDK.Keypair.random.mockReturnValue(mockKeypair);
     StellarSDK.Keypair.fromSecret.mockReturnValue(mockKeypair);
-    StellarSDK.Horizon.Server.mockReturnValue(mockServer);
+    StellarSDK.Horizon.Server.mockImplementation(function () { return mockServer; });
     StellarSDK.Asset.native.mockReturnValue({ code: 'XLM', issuer: null });
     StellarSDK.TransactionBuilder.mockReturnValue(mockTransactionBuilder);
     StellarSDK.Operation.payment.mockReturnValue({});
@@ -568,7 +568,7 @@ describe('Stellar Service Unit Tests', () => {
 
     it('should return null for invalid asset pair', async () => {
       mockServer.orderbook.mockReturnValueOnce({
-        call: vi.fn(() => Promise.reject(new Error('Invalid assets')),
+        call: vi.fn(() => Promise.reject(new Error('Invalid assets'))),
       });
       
       const result = await stellarService.getExchangeRate('INVALID', 'USDC');
@@ -578,7 +578,7 @@ describe('Stellar Service Unit Tests', () => {
 
     it('should handle orderbook fetch failure', async () => {
       mockServer.orderbook.mockReturnValueOnce({
-        call: vi.fn(() => Promise.reject(new Error('Orderbook unavailable')),
+        call: vi.fn(() => Promise.reject(new Error('Orderbook unavailable'))),
       });
       
       const result = await stellarService.getExchangeRate('XLM', 'USDC');
@@ -620,6 +620,56 @@ describe('Stellar Service Unit Tests', () => {
       const result = await stellarService.getNetworkStatus();
       
       expect(result).toHaveProperty('network', 'mainnet');
+    });
+  });
+
+  describe('getTrustlines', () => {
+    it('should return only non-native balances', async () => {
+      const publicKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7IXLMQVVXTNQRYUOP7H';
+      const result = await stellarService.getTrustlines(publicKey);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.every(t => t.assetCode !== undefined)).toBe(true);
+    });
+
+    it('should map fields correctly', async () => {
+      mockServer.loadAccount.mockResolvedValueOnce({
+        balances: [
+          { asset_type: 'native', balance: '100.0000000' },
+          {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'USDC',
+            asset_issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            balance: '50.0000000',
+            limit: '922337203685.4775807',
+            is_authorized: true,
+          },
+        ],
+      });
+      const publicKey = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7IXLMQVVXTNQRYUOP7H';
+      const result = await stellarService.getTrustlines(publicKey);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        assetCode: 'USDC',
+        issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+        balance: '50.0000000',
+        limit: '922337203685.4775807',
+        authorized: true,
+      });
+    });
+
+    it('should return empty array when account has no trustlines', async () => {
+      mockServer.loadAccount.mockResolvedValueOnce({
+        balances: [{ asset_type: 'native', balance: '100.0000000' }],
+      });
+      const result = await stellarService.getTrustlines('GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7IXLMQVVXTNQRYUOP7H');
+      expect(result).toEqual([]);
+    });
+
+    it('should propagate errors from Horizon', async () => {
+      mockServer.loadAccount.mockRejectedValueOnce(new Error('Account not found'));
+      await expect(
+        stellarService.getTrustlines('GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7IXLMQVVXTNQRYUOP7H')
+      ).rejects.toThrow('Account not found');
     });
   });
 


### PR DESCRIPTION
### Overview
This PR implements the trustline discovery endpoint to allow the UI to verify asset support before processing path payments or transfers.

### Core Changes
* **Endpoint:** Added `GET /api/stellar/account/:publicKey/trustlines`.
* **Logic:** Implemented `getTrustlines` in `stellar.js` to fetch and filter Horizon balances, returning only non-native assets with mapped `authorized` flags.
* **Validation:** Integrated `rules.publicKeyParam` middleware for param integrity.

### Fixes & Quality Assurance
* **Test Suite Unblocked:** Fixed two syntax errors in `stellar.js` (Promise.reject parens) and refactored `Horizon.Server` mocks to `mockImplementation`. This resolved parse failures and fixed 15 pre-existing failing tests.
* **Coverage:** Added unit tests covering XLM filtering, field mapping, and error propagation.
* **Verification:** All 40+ tests passing.

Closes #287 