### PR TITLE
feat: add DELETE /trustline endpoint to remove trustlines

### DIFF
--- a/backend/src/middleware/validate.js
+++ b/backend/src/middleware/validate.js
@@ -138,6 +138,21 @@ export const rules = {
       .withMessage(`Unsupported asset. Supported non-native assets: ${SUPPORTED_ASSETS.filter(a => a !== 'XLM').join(', ')}`),
   ],
 
+  removeTrustline: [
+    body('sourceSecret')
+      .trim()
+      .matches(STELLAR_SECRET_KEY)
+      .withMessage('Invalid Stellar secret key'),
+    body('assetCode')
+      .trim()
+      .matches(ASSET_CODE)
+      .withMessage('Invalid asset code')
+      .custom(v => v !== 'XLM')
+      .withMessage('Cannot remove trustline for native XLM asset')
+      .isIn(SUPPORTED_ASSETS.filter(a => a !== 'XLM'))
+      .withMessage(`Unsupported asset. Supported non-native assets: ${SUPPORTED_ASSETS.filter(a => a !== 'XLM').join(', ')}`),
+  ],
+
   assetCodeParams: [
     param('from').trim().matches(ASSET_CODE).withMessage('Invalid source asset code'),
     param('to').trim().matches(ASSET_CODE).withMessage('Invalid target asset code'),

--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -403,6 +403,21 @@ router.post('/trustline', rules.createTrustline, validate, async (req, res) => {
   }
 });
 
+// DELETE /api/stellar/trustline - Remove a trustline (balance must be zero)
+router.delete('/trustline', rules.removeTrustline, validate, async (req, res) => {
+  try {
+    const { sourceSecret, assetCode } = req.body;
+    const result = await StellarService.removeTrustline(sourceSecret, assetCode);
+    res.json(result);
+  } catch (error) {
+    if (error.message.startsWith('Cannot remove trustline') || error.message.startsWith('No trustline found')) {
+      return res.status(400).json({ error: error.message });
+    }
+    logError(req, error, { assetCode: req.body.assetCode });
+    res.status(500).json({ error: 'Failed to remove trustline' });
+  }
+});
+
 router.get('/account/:publicKey/label', rules.publicKeyParam, validate, async (req, res) => {
   try {
     const user = await prisma.user.findUnique({

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -314,6 +314,57 @@ export async function createTrustline(sourceSecret, assetCode) {
   return { hash: result.hash, assetCode, issuer };
 }
 
+export async function removeTrustline(sourceSecret, assetCode) {
+  const issuer = getIssuer(assetCode);
+  if (!issuer) throw new Error(`Unknown asset or missing issuer for ${assetCode}`);
+
+  const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
+  const sourcePublicKey = sourceKeypair.publicKey();
+  logger.info('stellar.removeTrustline', { publicKey: sourcePublicKey, assetCode });
+
+  const sourceAccount = await getHorizonServer().loadAccount(sourcePublicKey);
+
+  const balance = sourceAccount.balances.find(
+    b => b.asset_code === assetCode && b.asset_issuer === issuer
+  );
+  if (!balance) {
+    throw new Error(`No trustline found for ${assetCode}`);
+  }
+  if (parseFloat(balance.balance) !== 0) {
+    throw new Error(`Cannot remove trustline: balance is non-zero (${balance.balance} ${assetCode})`);
+  }
+
+  const asset = new StellarSDK.Asset(assetCode, issuer);
+
+  const transaction = new StellarSDK.TransactionBuilder(sourceAccount, {
+    fee: StellarSDK.BASE_FEE,
+    networkPassphrase: isTestnet() ? StellarSDK.Networks.TESTNET : StellarSDK.Networks.PUBLIC,
+  })
+    .addOperation(StellarSDK.Operation.changeTrust({ asset, limit: '0' }))
+    .setTimeout(30)
+    .build();
+
+  transaction.sign(sourceKeypair);
+
+  let result;
+  try {
+    result = await getHorizonServer().submitTransaction(transaction);
+  } catch (err) {
+    logger.error('stellar.removeTrustline.failed', { publicKey: sourcePublicKey, assetCode, error: err.message });
+    throw err;
+  }
+
+  logger.info('stellar.removeTrustline.success', { publicKey: sourcePublicKey, assetCode, hash: result.hash });
+
+  await eventMonitor.publishEvent(sourcePublicKey, {
+    type: 'TrustlineRemoved',
+    data: { assetCode, issuer, hash: result.hash },
+    version: 1,
+  });
+
+  return { hash: result.hash, assetCode, issuer };
+}
+
 export async function getTransactions(publicKey, { cursor, limit = 10, type, dateFrom, dateTo } = {}) {
   let builder = getHorizonServer().transactions().forAccount(publicKey).order('desc').limit(limit);
   if (cursor) builder = builder.cursor(cursor);

--- a/backend/tests/stellar.unit.test.js
+++ b/backend/tests/stellar.unit.test.js
@@ -17,9 +17,9 @@ vi.mock('@stellar/stellar-sdk', () => ({
   Horizon: {
     Server: vi.fn(),
   },
-  Asset: {
-    native: vi.fn(),
-  },
+  Asset: Object.assign(vi.fn().mockImplementation(function (code, issuer) { return { code, issuer }; }), {
+    native: vi.fn().mockReturnValue({ code: 'XLM', issuer: null }),
+  }),
   TransactionBuilder: vi.fn(),
   Operation: {
     payment: vi.fn(),
@@ -181,9 +181,9 @@ describe('Stellar Service Unit Tests', () => {
     // Setup Stellar SDK mocks
     StellarSDK.Keypair.random.mockReturnValue(mockKeypair);
     StellarSDK.Keypair.fromSecret.mockReturnValue(mockKeypair);
-    StellarSDK.Horizon.Server.mockReturnValue(mockServer);
+    StellarSDK.Horizon.Server.mockImplementation(function () { return mockServer; });
     StellarSDK.Asset.native.mockReturnValue({ code: 'XLM', issuer: null });
-    StellarSDK.TransactionBuilder.mockReturnValue(mockTransactionBuilder);
+    StellarSDK.TransactionBuilder.mockImplementation(function () { return mockTransactionBuilder; });
     StellarSDK.Operation.payment.mockReturnValue({});
     StellarSDK.Operation.changeTrust.mockReturnValue({});
     
@@ -568,7 +568,7 @@ describe('Stellar Service Unit Tests', () => {
 
     it('should return null for invalid asset pair', async () => {
       mockServer.orderbook.mockReturnValueOnce({
-        call: vi.fn(() => Promise.reject(new Error('Invalid assets')),
+        call: vi.fn(() => Promise.reject(new Error('Invalid assets'))),
       });
       
       const result = await stellarService.getExchangeRate('INVALID', 'USDC');
@@ -578,7 +578,7 @@ describe('Stellar Service Unit Tests', () => {
 
     it('should handle orderbook fetch failure', async () => {
       mockServer.orderbook.mockReturnValueOnce({
-        call: vi.fn(() => Promise.reject(new Error('Orderbook unavailable')),
+        call: vi.fn(() => Promise.reject(new Error('Orderbook unavailable'))),
       });
       
       const result = await stellarService.getExchangeRate('XLM', 'USDC');
@@ -656,6 +656,102 @@ describe('Stellar Service Unit Tests', () => {
       await expect(
         stellarService.sendPayment(sourceSecret, destination, amount)
       ).rejects.toThrow('insufficient balance');
+    });
+  });
+
+  describe('removeTrustline', () => {
+    const USDC_TESTNET_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+    it('should remove a trustline with zero balance', async () => {
+      mockServer.loadAccount.mockResolvedValueOnce({
+        ...mockAccount,
+        balances: [
+          { asset_type: 'native', balance: '100.0000000' },
+          {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'USDC',
+            asset_issuer: USDC_TESTNET_ISSUER,
+            balance: '0.0000000',
+            limit: '922337203685.4775807',
+            is_authorized: true,
+          },
+        ],
+      });
+      const result = await stellarService.removeTrustline(
+        'SBZVMB74Z76QZ3ZVU4Z7YVCC5L7GXWCF7IXLMQVVXTNQRYUOP7HGHJH',
+        'USDC'
+      );
+      expect(result).toHaveProperty('hash');
+      expect(result).toHaveProperty('assetCode', 'USDC');
+    });
+
+    it('should reject when balance is non-zero', async () => {
+      mockServer.loadAccount.mockResolvedValueOnce({
+        ...mockAccount,
+        balances: [
+          { asset_type: 'native', balance: '100.0000000' },
+          {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'USDC',
+            asset_issuer: USDC_TESTNET_ISSUER,
+            balance: '50.0000000',
+            limit: '922337203685.4775807',
+            is_authorized: true,
+          },
+        ],
+      });
+      await expect(
+        stellarService.removeTrustline(
+          'SBZVMB74Z76QZ3ZVU4Z7YVCC5L7GXWCF7IXLMQVVXTNQRYUOP7HGHJH',
+          'USDC'
+        )
+      ).rejects.toThrow('Cannot remove trustline: balance is non-zero');
+    });
+
+    it('should reject when trustline does not exist', async () => {
+      mockServer.loadAccount.mockResolvedValueOnce({
+        ...mockAccount,
+        balances: [{ asset_type: 'native', balance: '100.0000000' }],
+      });
+      await expect(
+        stellarService.removeTrustline(
+          'SBZVMB74Z76QZ3ZVU4Z7YVCC5L7GXWCF7IXLMQVVXTNQRYUOP7HGHJH',
+          'USDC'
+        )
+      ).rejects.toThrow('No trustline found for USDC');
+    });
+
+    it('should reject for unknown asset', async () => {
+      await expect(
+        stellarService.removeTrustline(
+          'SBZVMB74Z76QZ3ZVU4Z7YVCC5L7GXWCF7IXLMQVVXTNQRYUOP7HGHJH',
+          'UNKNOWN'
+        )
+      ).rejects.toThrow('Unknown asset or missing issuer for UNKNOWN');
+    });
+
+    it('should propagate Horizon submission errors', async () => {
+      mockServer.loadAccount.mockResolvedValueOnce({
+        ...mockAccount,
+        balances: [
+          { asset_type: 'native', balance: '100.0000000' },
+          {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'USDC',
+            asset_issuer: USDC_TESTNET_ISSUER,
+            balance: '0.0000000',
+            limit: '922337203685.4775807',
+            is_authorized: true,
+          },
+        ],
+      });
+      mockServer.submitTransaction.mockRejectedValueOnce(new Error('tx_failed'));
+      await expect(
+        stellarService.removeTrustline(
+          'SBZVMB74Z76QZ3ZVU4Z7YVCC5L7GXWCF7IXLMQVVXTNQRYUOP7HGHJH',
+          'USDC'
+        )
+      ).rejects.toThrow('tx_failed');
     });
   });
 });


### PR DESCRIPTION
### Overview
This PR implements the trustline removal endpoint, allowing users to decommission assets by submitting a `changeTrust` operation with a zero limit.

### Core Changes
* **Endpoint:** Added `DELETE /api/stellar/trustline`.
* **Service Logic:** Implemented `removeTrustline` in `stellar.js`. It verifies asset existence via `getIssuer()` and performs a pre-flight check to ensure the asset balance is exactly zero before submission.
* **Validation:** Added `rules.removeTrustline` middleware to validate `sourceSecret` and `assetCode`, specifically rejecting native XLM or unsupported asset types.
* **Error Handling:** Returns clear 400 errors for non-zero balances or missing trustlines to prevent transaction failures.

### Fixes & Quality Assurance
* **Test Suite Maintenance:** Resolved three pre-existing bugs (parse errors and constructor mock issues) that were previously blocking the test suite.
* **Coverage:** Added 5 new tests covering successful removal, non-zero balance rejection, and missing trustline scenarios.
* **Verification:** All tests in the suite are now unblocked and passing.

Closes #288 