### PR TITLE
  feat: stream nextPaymentAt, KYC encryption, KYC audit log, account creation rate limit      

### DIFF
--- a/backend/src/compliance/kycCollector.js
+++ b/backend/src/compliance/kycCollector.js
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import prisma from '../db/client.js';
 import { encryptToEnvValue, decryptFromEnvValue } from '../config/secrets.js';
+import auditLogger from '../security/auditLogger.js';
 
 const KYC_STATUS = { PENDING: 'PENDING', APPROVED: 'APPROVED', REJECTED: 'REJECTED', UNDER_REVIEW: 'UNDER_REVIEW' };
 
@@ -90,6 +91,11 @@ class KYCCollector {
       where: { userId },
       data: { status },
     });
+    await auditLogger.logEvent('KYC_STATUS_CHANGED', userId, {
+      previousStatus: record.status,
+      newStatus: status,
+      note: note ?? null,
+    }, 'INFO');
     return decryptRecord(updated);
   }
 

--- a/backend/src/compliance/kycCollector.js
+++ b/backend/src/compliance/kycCollector.js
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import prisma from '../db/client.js';
+import { encryptToEnvValue, decryptFromEnvValue } from '../config/secrets.js';
 
 const KYC_STATUS = { PENDING: 'PENDING', APPROVED: 'APPROVED', REJECTED: 'REJECTED', UNDER_REVIEW: 'UNDER_REVIEW' };
 
@@ -14,12 +15,40 @@ const kycSchema = z.object({
   email:          z.string().email().optional(),
 });
 
+function getEncryptionKey() {
+  const key = process.env.CONFIG_ENCRYPTION_KEY;
+  if (!key) throw new Error('CONFIG_ENCRYPTION_KEY is not set');
+  return key;
+}
+
+function encryptField(value) {
+  return encryptToEnvValue(value, getEncryptionKey());
+}
+
+function decryptField(value) {
+  if (!value) return value;
+  try {
+    return decryptFromEnvValue(value, getEncryptionKey());
+  } catch {
+    return value; // return as-is if not encrypted (migration safety)
+  }
+}
+
+function decryptRecord(record) {
+  if (!record) return record;
+  return {
+    ...record,
+    documentNumber: decryptField(record.documentNumber),
+    address: decryptField(record.address),
+  };
+}
+
 class KYCCollector {
   async submitKYC(userId, data) {
     const parsed = kycSchema.parse(data);
     const dob = new Date(parsed.dateOfBirth);
 
-    return prisma.kYCRecord.upsert({
+    const record = await prisma.kYCRecord.upsert({
       where: { userId },
       create: {
         userId,
@@ -28,8 +57,8 @@ class KYCCollector {
         dateOfBirth: dob,
         nationality: parsed.nationality,
         documentType: parsed.documentType,
-        documentNumber: parsed.documentNumber,
-        address: parsed.address,
+        documentNumber: encryptField(parsed.documentNumber),
+        address: encryptField(parsed.address),
         phoneNumber: parsed.phoneNumber ?? null,
         email: parsed.email ?? null,
       },
@@ -39,29 +68,33 @@ class KYCCollector {
         dateOfBirth: dob,
         nationality: parsed.nationality,
         documentType: parsed.documentType,
-        documentNumber: parsed.documentNumber,
-        address: parsed.address,
+        documentNumber: encryptField(parsed.documentNumber),
+        address: encryptField(parsed.address),
         phoneNumber: parsed.phoneNumber ?? null,
         email: parsed.email ?? null,
       },
     });
+
+    return decryptRecord(record);
   }
 
   async getKYCRecord(userId) {
-    return prisma.kYCRecord.findUnique({ where: { userId } });
+    const record = await prisma.kYCRecord.findUnique({ where: { userId } });
+    return decryptRecord(record);
   }
 
   async updateStatus(userId, status, note = null) {
-    const record = await this.getKYCRecord(userId);
+    const record = await prisma.kYCRecord.findUnique({ where: { userId } });
     if (!record) throw new Error(`KYC record not found for user ${userId}`);
-    return prisma.kYCRecord.update({
+    const updated = await prisma.kYCRecord.update({
       where: { userId },
       data: { status },
     });
+    return decryptRecord(updated);
   }
 
   async isVerified(userId) {
-    const record = await this.getKYCRecord(userId);
+    const record = await prisma.kYCRecord.findUnique({ where: { userId } });
     return record?.status === KYC_STATUS.APPROVED;
   }
 }

--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -50,7 +50,14 @@ function logError(req, error, context = {}) {
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-router.post('/account/create', async (req, res) => {
+// Stricter rate limit for account creation (5 req/hour per IP) to prevent Friendbot abuse
+const accountCreateRateLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  message: 'Too many account creation requests, please try again later.',
+});
+
+router.post('/account/create', accountCreateRateLimiter, async (req, res) => {
   try {
     const account = await StellarService.createAccount();
     res.json(account);

--- a/backend/src/routes/streaming.js
+++ b/backend/src/routes/streaming.js
@@ -6,6 +6,15 @@ import logger from '../config/logger.js';
 
 const router = express.Router();
 
+function withNextPaymentAt(stream) {
+  return {
+    ...stream,
+    nextPaymentAt: stream.status === 'ACTIVE'
+      ? new Date(new Date(stream.lastProcessedAt).getTime() + stream.intervalSeconds * 1000)
+      : null,
+  };
+}
+
 const validate = (req, res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -65,7 +74,7 @@ const streamRules = {
 router.post('/', streamRules.create, validate, async (req, res) => {
   try {
     const stream = await StreamingService.createStream(req.body);
-    res.status(201).json(stream);
+    res.status(201).json(withNextPaymentAt(stream));
   } catch (error) {
     logger.error('streaming.route.create.failed', { error: error.message });
     res.status(500).json({ error: error.message });
@@ -105,12 +114,7 @@ router.get('/', async (req, res) => {
       orderBy: { startTime: 'desc' },
     });
 
-    const enriched = streams.map(stream => ({
-      ...stream,
-      nextPaymentAt: stream.status === 'ACTIVE' 
-        ? new Date(new Date(stream.lastProcessedAt).getTime() + stream.intervalSeconds * 1000)
-        : null,
-    }));
+    const enriched = streams.map(withNextPaymentAt);
 
     res.json(enriched);
   } catch (error) {
@@ -166,7 +170,7 @@ router.get('/:id', streamRules.idParam, validate, async (req, res) => {
       include: { sender: true, recipient: true },
     });
     if (!stream) return res.status(404).json({ error: 'Stream not found' });
-    res.json(stream);
+    res.json(withNextPaymentAt(stream));
   } catch (error) {
     res.status(500).json({ error: error.message });
   }
@@ -192,7 +196,7 @@ router.get('/:id', streamRules.idParam, validate, async (req, res) => {
 router.post('/:id/pause', streamRules.idParam, validate, async (req, res) => {
   try {
     const stream = await StreamingService.pauseStream(req.params.id);
-    res.json(stream);
+    res.json(withNextPaymentAt(stream));
   } catch (error) {
     res.status(500).json({ error: error.message });
   }
@@ -218,7 +222,7 @@ router.post('/:id/pause', streamRules.idParam, validate, async (req, res) => {
 router.post('/:id/resume', streamRules.idParam, validate, async (req, res) => {
   try {
     const stream = await StreamingService.resumeStream(req.params.id);
-    res.json(stream);
+    res.json(withNextPaymentAt(stream));
   } catch (error) {
     res.status(500).json({ error: error.message });
   }
@@ -244,7 +248,7 @@ router.post('/:id/resume', streamRules.idParam, validate, async (req, res) => {
 router.post('/:id/cancel', streamRules.idParam, validate, async (req, res) => {
   try {
     const stream = await StreamingService.cancelStream(req.params.id);
-    res.json(stream);
+    res.json(withNextPaymentAt(stream));
   } catch (error) {
     res.status(500).json({ error: error.message });
   }
@@ -288,7 +292,7 @@ router.patch('/:id', streamRules.idParam, [
 ], validate, async (req, res) => {
   try {
     const stream = await StreamingService.updateStream(req.params.id, req.body);
-    res.json(stream);
+    res.json(withNextPaymentAt(stream));
   } catch (error) {
     const statusCode = error.message.includes('not found') ? 404 : 400;
     res.status(statusCode).json({ error: error.message });


### PR DESCRIPTION
  Closes #322                                                                                 
  Closes #323                                                                                 
  Closes #324                                                                                 
  Closes #325                                                                                 
                                                                                              
  ## Summary                                                                                  
                                                                                              
  This PR implements four improvements across the streaming payments and KYC compliance       
  subsystems, and adds abuse protection to the account creation endpoint.                     
                                                                                              
  ---                                                                                         
                                                                                              
  ## Changes                                                                                  
                                                                                              
  ### #322 — Add `nextPaymentAt` to all stream API responses                                  
                                                                                              
  **File:** `backend/src/routes/streaming.js`                                                 
                                                                                              
  Stream responses previously omitted the time of the next scheduled payment, making it       
  impossible for the UI to show a countdown. A `withNextPaymentAt` helper was added that      
  computes:                                                                                   
                                                                                              
  nextPaymentAt = lastProcessedAt + intervalSeconds (in ms)                                   
                                                                                              
  This field is now included in every stream API response:                                    
  - `POST /api/streaming` (create)                                                            
  - `GET /api/streaming` (list)                                                               
  - `GET /api/streaming/:id` (get by ID)                                                      
  - `PATCH /api/streaming/:id` (update)                                                       
  - `POST /api/streaming/:id/pause`                                                           
  - `POST /api/streaming/:id/resume`                                                          
  - `POST /api/streaming/:id/cancel`                                                          
                                                                                              
  `nextPaymentAt` is `null` for streams that are not in `ACTIVE` status.                      
                                                                                              
  ---                                                                                         
                                                                                              
  ### #323 — Encrypt sensitive KYC fields at rest                                             
                                                                                              
  **File:** `backend/src/compliance/kycCollector.js`                                          
                                                                                              
  `kycCollector.js` previously stored `documentNumber` and `address` as plaintext in          
  PostgreSQL. These fields now use AES-256-GCM encryption via the existing `encryptToEnvValue`
  / `decryptFromEnvValue` utilities from `config/secrets.js`, keyed by                        
  `CONFIG_ENCRYPTION_KEY`.                                                                    
                                                                                              
  - Fields are encrypted before every `upsert` (submit/update)                                
  - Fields are decrypted transparently on every read (`getKYCRecord`, `updateStatus`,         
  `submitKYC` return value)                                                                   
  - Existing unencrypted rows are returned as-is (migration safety — no data loss during      
  rollout)                                                                                    
                                                                                              
  ---                                                                                         
                                                                                              
  ### #324 — Audit log entries for KYC status changes                                         
                                                                                              
  **File:** `backend/src/compliance/kycCollector.js`                                          
                                                                                              
  When a KYC record's status changes (e.g. `PENDING → APPROVED`, `PENDING → REJECTED`), the   
  transition is now recorded in the security audit log via `auditLogger.logEvent`. Each entry 
  captures:                                                                                   
                                                                                              
  - `previousStatus` — the status before the change                                           
  - `newStatus` — the status after the change                                                 
  - `note` — optional reviewer note passed to `updateStatus`                                  
  - `userId`, `timestamp`, `severity` — standard audit fields                                 
                                                                                              
  This gives compliance officers a tamper-evident trail of every KYC status decision and when 
  it was made.                                                                                
                                                                                              
  ---                                                                                         
                                                                                              
  ### #325 — Rate limit `POST /api/stellar/account/create` (5 req/hour per IP)                
                                                                                              
  **File:** `backend/src/routes/stellar.js`                                                   
                                                                                              
  The account creation endpoint calls Friendbot on testnet, which has its own upstream rate   
  limits. A dedicated `accountCreateRateLimiter` (5 requests / hour / IP) is now applied      
  specifically to `POST /api/stellar/account/create`, independent of the global rate limiter. 
  Requests exceeding the limit receive a `429` response with a `retryAfter` value.            
                                                                                              
  ---                                                                                         
                                                                                              
  ## Testing                                                                                  
                                                                                              
  - Streaming: verify all stream endpoints return `nextPaymentAt` as an ISO timestamp for     
  `ACTIVE` streams and `null` otherwise.                                                      
  - KYC encryption: submit a KYC record and confirm `documentNumber` / `address` are stored as
  `ENC(...)` ciphertext in the database and returned as plaintext via the API.                
  - KYC audit: call `updateStatus` and confirm a `KYC_STATUS_CHANGED` entry appears in the    
  daily audit log file.                                                                       
  - Rate limit: send 6 rapid `POST /api/stellar/account/create` requests from the same IP and 
  confirm the 6th returns `429`.   