### PR TITLE
feat: accessibility and validation improvements (#334, #335, #336, #337)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -803,7 +803,7 @@ function App() {
                         style={{ border: `2px solid ${amountTouched ? (amountValid ? '#22c55e' : '#ef4444') : '#ccc'}` }}
                         aria-invalid={amountTouched && !!amountError}
                         aria-describedby={amountTouched && amountError ? 'amount-error' : undefined}
-                      />
+                        autoComplete="transaction-amount"
                       {amountTouched && <span className="input-icon" aria-hidden="true">{amountValid ? '✅' : '❌'}</span>}
                       <motion.button
                         type="button"

--- a/frontend/src/components/QRCodeModal.jsx
+++ b/frontend/src/components/QRCodeModal.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import QRCode from 'qrcode';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import { makeVariants } from '../utils/animations';
 
 function buildQRData(publicKey, amount) {
   if (amount && parseFloat(amount) > 0) {
@@ -15,6 +16,8 @@ export function QRCodeModal({ publicKey, onClose }) {
   const modalRef = useRef(null);
   const [amount, setAmount] = useState('');
   const [error, setError] = useState(null);
+  const prefersReduced = useReducedMotion();
+  const v = makeVariants(prefersReduced);
 
   useFocusTrap(modalRef, true);
 
@@ -45,18 +48,14 @@ export function QRCodeModal({ publicKey, onClose }) {
   return (
     <motion.div
       className="qr-overlay"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
+      variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit"
       onClick={onClose}
       aria-hidden="true"
     >
       <motion.div
         ref={modalRef}
         className="qr-modal"
-        initial={{ scale: 0.85, opacity: 0 }}
-        animate={{ scale: 1, opacity: 1 }}
-        exit={{ scale: 0.85, opacity: 0 }}
+        variants={v.pop}
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"

--- a/frontend/src/components/SecurityKeyWarning.jsx
+++ b/frontend/src/components/SecurityKeyWarning.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { makeVariants, tapScale } from '../utils/animations';
 
 /**
  * SecurityKeyWarning — displays when secret key is shown.
@@ -7,12 +8,13 @@ import { motion, AnimatePresence } from 'framer-motion';
  * Props: onAcknowledge
  */
 export function SecurityKeyWarning({ onAcknowledge }) {
+  const prefersReduced = useReducedMotion();
+  const v = makeVariants(prefersReduced);
+  const tap = tapScale(prefersReduced);
   return (
     <motion.div
       className="security-warning"
-      initial={{ opacity: 0, scale: 0.95 }}
-      animate={{ opacity: 1, scale: 1 }}
-      exit={{ opacity: 0, scale: 0.95 }}
+      variants={v.pop} initial="hidden" animate="visible" exit="exit"
     >
       <div className="security-warning__header">
         <span className="security-warning__icon">🔐</span>
@@ -48,8 +50,7 @@ export function SecurityKeyWarning({ onAcknowledge }) {
       <div className="security-warning__actions">
         <motion.button
           onClick={() => onAcknowledge?.()}
-          whileHover={{ scale: 1.02 }}
-          whileTap={{ scale: 0.98 }}
+          {...tap}
           className="security-warning__button"
         >
           I Understand the Risks
@@ -67,6 +68,9 @@ export function SecretKeyDisplay({ secretKey, publicKey }) {
   const [revealed, setRevealed] = useState(false);
   const [acknowledged, setAcknowledged] = useState(false);
   const [copied, setCopied] = useState(null);
+  const prefersReduced = useReducedMotion();
+  const v = makeVariants(prefersReduced);
+  const tap = tapScale(prefersReduced);
 
   const handleCopy = (text, label) => {
     navigator.clipboard.writeText(text).then(() => {
@@ -80,8 +84,7 @@ export function SecretKeyDisplay({ secretKey, publicKey }) {
   return (
     <motion.div
       className="secret-key-display"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
+      variants={v.fadeSlide} initial="hidden" animate="visible"
     >
       {!acknowledged && (
         <SecurityKeyWarning onAcknowledge={() => setAcknowledged(true)} />
@@ -90,9 +93,7 @@ export function SecretKeyDisplay({ secretKey, publicKey }) {
       <AnimatePresence>
         {acknowledged && (
           <motion.div
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -8 }}
+            variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit"
             style={{ marginBottom: 16 }}
           >
             <div className="secret-key-display__field">
@@ -101,8 +102,7 @@ export function SecretKeyDisplay({ secretKey, publicKey }) {
                 <code className="secret-key-display__code">{publicKey}</code>
                 <motion.button
                   onClick={() => handleCopy(publicKey, 'public')}
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
+                  {...tap}
                   className="secret-key-display__button"
                 >
                   {copied === 'public' ? '✓ Copied' : 'Copy'}
@@ -118,16 +118,14 @@ export function SecretKeyDisplay({ secretKey, publicKey }) {
                 </code>
                 <motion.button
                   onClick={() => setRevealed(!revealed)}
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
+                  {...tap}
                   className="secret-key-display__button secret-key-display__button--reveal"
                 >
                   {revealed ? '👁 Hide' : '👁 Show'}
                 </motion.button>
                 <motion.button
                   onClick={() => handleCopy(secretKey, 'secret')}
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
+                  {...tap}
                   disabled={!revealed}
                   className="secret-key-display__button secret-key-display__button--copy"
                 >
@@ -138,9 +136,7 @@ export function SecretKeyDisplay({ secretKey, publicKey }) {
 
             <motion.div
               className="secret-key-display__tip"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ delay: 0.3 }}
+              variants={v.fadeSlide} initial="hidden" animate="visible"
             >
               💡 <strong>Tip:</strong> Save both keys somewhere secure before leaving this page.
               They will not be displayed again.

--- a/frontend/src/components/TransactionHistory.jsx
+++ b/frontend/src/components/TransactionHistory.jsx
@@ -1,9 +1,10 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import axios from 'axios';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { Spinner } from './Spinner';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { CopyButton } from './CopyButton';
+import { makeVariants, tapScale } from '../utils/animations';
 
 function truncateKey(key) {
   if (!key || key.length <= 8) return key;
@@ -70,7 +71,9 @@ function downloadCsv(rows, filename) {
   URL.revokeObjectURL(url);
 }
 
-function TxRow({ tx, onClick }) {
+function TxRow({ tx, onClick, onRetry }) {
+  const prefersReduced = useReducedMotion();
+  const tap = tapScale(prefersReduced);
   const isReceived = tx.direction === 'received';
   const isSent = tx.direction === 'sent';
   const label = `${TYPE_LABELS[tx.type] ?? tx.type}, ${tx.direction ?? ''}, ${tx.amount ? `${tx.amount} ${tx.asset ?? 'XLM'}` : ''}, ${fmt(tx.date)}, ${tx.successful ? 'successful' : 'failed'}`;
@@ -80,7 +83,7 @@ function TxRow({ tx, onClick }) {
       className="tx-row"
       onClick={() => onClick(tx)}
       onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onClick(tx)}
-      whileTap={{ scale: 0.98 }}
+      {...tap}
       layout
       role="button"
       tabIndex={0}
@@ -113,6 +116,8 @@ function TxRow({ tx, onClick }) {
 function TxModal({ tx, onClose }) {
   const modalRef = useRef(null);
   useFocusTrap(modalRef, true);
+  const prefersReduced = useReducedMotion();
+  const v = makeVariants(prefersReduced);
 
   useEffect(() => {
     const onKey = (e) => { if (e.key === 'Escape') onClose(); };
@@ -124,15 +129,13 @@ function TxModal({ tx, onClose }) {
     <motion.div
       className="tx-overlay"
       onClick={onClose}
-      initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+      variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit"
     >
       <motion.div
         ref={modalRef}
         className="tx-modal"
         onClick={e => e.stopPropagation()}
-        initial={{ scale: 0.9, opacity: 0 }}
-        animate={{ scale: 1, opacity: 1 }}
-        exit={{ scale: 0.9, opacity: 0 }}
+        variants={v.pop}
         role="dialog"
         aria-modal="true"
         aria-labelledby="tx-modal-title"
@@ -176,6 +179,8 @@ export function TransactionHistory({ publicKey }) {
   const [error, setError] = useState(null);
   const [retrying, setRetrying] = useState({}); // { [txId]: 'pending' | 'success' | 'error' }
   const [exporting, setExporting] = useState(false);
+  const prefersReduced = useReducedMotion();
+  const tap = tapScale(prefersReduced);
 
   const handleExportCsv = async () => {
     setExporting(true);
@@ -247,7 +252,7 @@ export function TransactionHistory({ publicKey }) {
           <motion.button
             onClick={handleExportCsv}
             disabled={exporting || loading}
-            whileTap={{ scale: 0.97 }}
+            {...tap}
             aria-label="Export transaction history as CSV"
             aria-busy={exporting}
             style={{ background: '#16a34a' }}
@@ -258,7 +263,7 @@ export function TransactionHistory({ publicKey }) {
             className="tx-load-btn"
             onClick={handleLoad}
             disabled={loading}
-            whileTap={{ scale: 0.97 }}
+            {...tap}
             aria-label={loaded ? 'Refresh transaction history' : 'Load transaction history'}
           >
             {loading ? <Spinner label="Loading transactions…" /> : loaded ? '↺ Refresh' : 'Load History'}

--- a/frontend/src/utils/validateAmount.js
+++ b/frontend/src/utils/validateAmount.js
@@ -1,5 +1,7 @@
 const MIN = 0.0000001;
 const MAX_DECIMALS = 7;
+const BASE_FEE = 0.00001;
+const MIN_RESERVE = 1;
 
 export function validateAmount(value, availableBalance) {
   if (!value) return null;
@@ -9,7 +11,11 @@ export function validateAmount(value, availableBalance) {
   if (num < MIN) return `Minimum amount is ${MIN} XLM`;
   const decimals = value.includes('.') ? value.split('.')[1].length : 0;
   if (decimals > MAX_DECIMALS) return `Maximum ${MAX_DECIMALS} decimal places allowed`;
-  if (availableBalance !== null && num > availableBalance) return 'Amount exceeds available balance';
+  if (availableBalance !== null) {
+    if (num > availableBalance) return 'Amount exceeds available balance';
+    if (availableBalance - num - BASE_FEE < MIN_RESERVE)
+      return 'Insufficient balance: account must keep a 1 XLM minimum reserve';
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary

This PR addresses four issues in a single pass: reduced-motion support across all Framer Motion components, autocomplete attributes on payment inputs, a minimum Stellar reserve guard in amount validation, and confirmation that secret-key validation was already in place.

---

### #334 — Respect `useReducedMotion` in all Framer Motion components

**TransactionHistory**
- Imported `useReducedMotion`, `makeVariants`, and `tapScale` from `../utils/animations`.
- `TxRow` now derives its tap/hover scale from `tapScale(prefersReduced)` instead of a hard-coded `whileTap`.
- `TxModal` uses `v.fadeSlide` / `v.pop` variants instead of inline `initial`/`animate`/`exit` props.
- Export CSV and Load History buttons use `tapScale` spread.

**SecurityKeyWarning / SecretKeyDisplay**
- Imported `useReducedMotion`, `makeVariants`, `tapScale`.
- `SecurityKeyWarning` wrapper uses `v.pop` variants.
- `SecretKeyDisplay` wrapper uses `v.fadeSlide`; inner revealed block uses `v.fadeSlide`; tip uses `v.fadeSlide`.
- All three copy/reveal buttons use `tapScale` spread.

**QRCodeModal**
- Imported `useReducedMotion` and `makeVariants`.
- Overlay uses `v.fadeSlide`; modal panel uses `v.pop`.

---

### #335 — Autocomplete attributes on payment form inputs

- Recipient input already carried `autoComplete="off"` (Stellar addresses must not be auto-filled).
- Amount input: added `autoComplete="transaction-amount"` so browsers can offer relevant suggestions while keeping the field semantic.

---

### #336 — Minimum Stellar reserve check in `validateAmount`

Added two constants:
```js
const BASE_FEE    = 0.00001;
const MIN_RESERVE = 1;
```
After the existing balance check, a new guard returns an error when `balance - amount - BASE_FEE < 1`, preventing transactions that would drop the account below the required 1 XLM minimum reserve.

---

### #337 — Secret key validation in ImportAccountForm

`ImportAccountForm` already validates the secret key client-side using the `STELLAR_SECRET_KEY = /^S[A-Z2-7]{55}$/` regex, shows an inline error message when the input is touched and invalid, and disables the submit button until the key is valid. No changes were required.

---

## Files changed

| File | Change |
|------|--------|
| `frontend/src/components/TransactionHistory.jsx` | #334 reduced-motion support |
| `frontend/src/components/SecurityKeyWarning.jsx` | #334 reduced-motion support |
| `frontend/src/components/QRCodeModal.jsx` | #334 reduced-motion support |
| `frontend/src/App.jsx` | #335 `autoComplete="transaction-amount"` on amount input |
| `frontend/src/utils/validateAmount.js` | #336 minimum reserve guard |

Closes #334
Closes #335
Closes #336
Closes #337