### PR TITLE
fix: debounce address validation, security headers test, full payment flow integration test

### DIFF
--- a/backend/tests/security.test.js
+++ b/backend/tests/security.test.js
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -12,6 +14,7 @@ import {
   penetrationTester,
   complianceReporter
 } from '../src/security/index.js';
+import { securityHeaders, helmetMiddleware, cspNonceMiddleware } from '../src/middleware/securityHeaders.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = path.join(__dirname, '../data');
@@ -248,5 +251,28 @@ describe('Security Features', () => {
       const reports = await complianceReporter.getLatestReports(1);
       expect(reports.length).toBeGreaterThan(0);
     });
+  });
+});
+
+const securedApp = express();
+securedApp.use(cspNonceMiddleware());
+securedApp.use(helmetMiddleware());
+securedApp.use(securityHeaders());
+securedApp.get('/ping', (_req, res) => res.json({ ok: true }));
+
+describe('Security headers middleware', () => {
+  it('sets X-Content-Type-Options: nosniff on API responses', async () => {
+    const res = await request(securedApp).get('/ping');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('sets X-Frame-Options: DENY on API responses', async () => {
+    const res = await request(securedApp).get('/ping');
+    expect(res.headers['x-frame-options']).toBe('DENY');
+  });
+
+  it('sets Strict-Transport-Security on API responses', async () => {
+    const res = await request(securedApp).get('/ping');
+    expect(res.headers['strict-transport-security']).toBeDefined();
   });
 });

--- a/backend/tests/stellar.integration.test.js
+++ b/backend/tests/stellar.integration.test.js
@@ -363,3 +363,41 @@ describe('POST /api/stellar/trustline', () => {
     expect(res.body.errors[0]).toHaveProperty('field', 'assetCode');
   });
 });
+
+describe('Full payment flow — create → balance → send → history', () => {
+  it('completes the happy path end-to-end', async () => {
+    // 1. Create two funded testnet accounts
+    const [sender, receiver] = await Promise.all([
+      createFundedTestAccount(),
+      createFundedTestAccount(),
+    ]);
+
+    // Wait for both to be indexed on Horizon
+    await Promise.all([
+      waitForAccount(sender.publicKey),
+      waitForAccount(receiver.publicKey),
+    ]);
+
+    // 2. Check sender balance via API — must have XLM
+    const balanceRes = await request(app).get(`/api/stellar/account/${sender.publicKey}`);
+    expect(balanceRes.status).toBe(200);
+    const xlm = balanceRes.body.balances.find((b) => b.asset === 'XLM');
+    expect(parseFloat(xlm.balance)).toBeGreaterThan(0);
+
+    // 3. Send payment via API
+    const sendRes = await request(app)
+      .post('/api/stellar/payment/send')
+      .send({ sourceSecret: sender.secretKey, destination: receiver.publicKey, amount: '1' });
+    expect(sendRes.status).toBe(200);
+    expect(sendRes.body.success).toBe(true);
+    const txHash = sendRes.body.hash;
+    expect(typeof txHash).toBe('string');
+    expect(txHash).toHaveLength(64);
+
+    // 4. Verify transaction appears in receiver's history
+    const historyRes = await request(app).get(`/api/stellar/account/${receiver.publicKey}/transactions`);
+    expect(historyRes.status).toBe(200);
+    expect(Array.isArray(historyRes.body.records)).toBe(true);
+    expect(historyRes.body.records.length).toBeGreaterThan(0);
+  }, 90_000);
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -290,7 +290,7 @@ function App() {
     } finally { dispatch({ type: A.SET_LOADING, payload: '' }); }
   };
 
-  const recipientValid = isValidStellarAddress(recipient);
+  const recipientValid = recipient.length === 56 && isValidStellarAddress(recipient);
   const recipientTouched = recipient.length > 0;
   const xlmBalance = balance?.balances?.find(b => b.asset === 'XLM')?.balance ?? null;
   const amountTouched = amount.length > 0;

--- a/frontend/tests/utils.test.js
+++ b/frontend/tests/utils.test.js
@@ -47,6 +47,23 @@ describe('validateAmount', () => {
   it('skips balance check when availableBalance is null', () => {
     expect(validateAmount('999999', null)).toBeNull();
   });
+
+  // Additional edge cases
+  it('rejects non-numeric strings', () => {
+    expect(validateAmount('abc', null)).toMatch(/positive/i);
+  });
+
+  it('rejects empty-ish non-numeric input like "."', () => {
+    expect(validateAmount('.', null)).toMatch(/positive/i);
+  });
+
+  it('accepts the minimum valid amount (0.0000001)', () => {
+    expect(validateAmount('0.0000001', null)).toBeNull();
+  });
+
+  it('rejects an amount just below the minimum reserve (0.00000009)', () => {
+    expect(validateAmount('0.00000009', null)).toMatch(/decimal/i);
+  });
 });
 
 // ── formatAmount ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

### #338 — Debounce recipient address validation
- `frontend/src/App.jsx`: `isValidStellarAddress` is now only called once the input reaches 56 characters (the exact length of a valid Stellar address). Partial keystrokes no longer trigger the ❌ error indicator or the invalid-address error message.

### #339 — Security headers middleware test
- `backend/tests/security.test.js`: added a `Security headers middleware` describe block. It builds a minimal Express app with `cspNonceMiddleware`, `helmetMiddleware`, and `securityHeaders` applied, then asserts that every response includes:
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY`
  - `Strict-Transport-Security` (present)

### #340 — Full payment flow integration test
- `backend/tests/stellar.integration.test.js`: added a `Full payment flow` describe block that exercises the complete happy path against the Stellar testnet:
  1. Create two funded accounts via Friendbot (`createFundedTestAccount`)
  2. Wait for both to be indexed on Horizon
  3. Check sender balance via `GET /api/stellar/account/:publicKey`
  4. Send 1 XLM via `POST /api/stellar/payment/send`
  5. Verify the transaction appears in the receiver's history via `GET /api/stellar/account/:publicKey/transactions`
  
    ### #341 — validateAmount edge case unit tests
  - \`frontend/tests/utils.test.js\`: added test cases for:
    - Non-numeric strings (e.g. \`'abc'\`)
    - Degenerate input (\`'.'\`)
    - Minimum valid amount (\`'0.0000001'\` — accepted)
    - Minimum reserve boundary (\`'0.00000009'\` — rejected, exceeds 7 decimal places)

## Files changed
- `frontend/src/App.jsx`
- `backend/tests/security.test.js`
- `backend/tests/stellar.integration.test.js`

Closes #338
Closes #339
Closes #340
Closes #341 