### PR TITLE
feat: Add loading skeleton components to replace spinner-only states

### DIFF
--- a/PR_DESCRIPTION_SKELETONS.md
+++ b/PR_DESCRIPTION_SKELETONS.md
@@ -1,0 +1,22 @@
+# PR Title: `feat: Add loading skeleton components to replace spinner-only states`
+
+## Description
+This pull request replaces the legacy, layout-shifting spinner-only loading states for **Account Balances** and **Transaction History** with custom loading skeleton components that match the exact shape of the content being loaded. This drastically improves the user experience by reducing layout shift.
+
+## Key Changes
+- **New Components**:
+  - `SkeletonText`: Reusable placeholder for lines of text, with customizable count and line widths.
+  - `SkeletonCard`: Custom block matching the structure of a transaction row.
+  - `SkeletonBalance`: Custom rows matching the layout of the account balance rows.
+- **Improved Accessibility**: Added `role="status"`, `aria-busy="true"`, and descriptive `aria-label` attributes to the new skeleton elements.
+- **Styling**: Appended `.skeleton-block` and associated shimmers to support light and dark modes in `index.css`.
+- **Integrations**:
+  - Replaced balance checking loading spinner with `<SkeletonBalance>` in `App.jsx`.
+  - Replaced transaction loading spinner and row loaders with `<SkeletonCard>` items in `TransactionHistory.jsx`.
+- **Storybook Stories**: Added CSF stories for all variants in `Skeleton.stories.jsx`.
+
+## Verification Instructions
+1. Navigate to the branch `feat/loading-skeletons`.
+2. Run Storybook: `npm run storybook`.
+3. Check the **Components/Skeleton** section to inspect the `Text`, `Card`, and `Balance` variants in both Light and Dark mode.
+4. Launch the app (`npm run dev`) and trigger balance updates and transaction history refreshes to verify layout alignment.

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -1,6 +1,9 @@
 /** @type { import('@storybook/react-vite').StorybookConfig } */
 const config = {
-  stories: ['../src/design-system/**/*.stories.@(js|jsx)'],
+  stories: [
+    '../src/design-system/**/*.stories.@(js|jsx)',
+    '../src/components/**/*.stories.@(js|jsx)'
+  ],
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import { NetworkStatusBanner } from './components/NetworkStatusBanner';
 import { StatusMessage } from './components/StatusMessage';
 import { CopyButton } from './components/CopyButton';
 import { Spinner } from './components/Spinner';
+import { SkeletonBalance } from './components/Skeleton';
 import { TransactionHistory } from './components/TransactionHistory';
 import { StreamPayment } from './components/StreamPayment';
 import { PathPayment } from './components/PathPayment';
@@ -707,11 +708,14 @@ function App() {
                     aria-busy={loading === 'balance'}
                     aria-label="Check account balance"
                   >
-                    {loading === 'balance' ? <Spinner label="Checking balance…" /> : 'Check Balance'}
+                    {loading === 'balance' ? 'Checking Balance…' : 'Check Balance'}
                   </motion.button>
-                  <AnimatePresence>
-                    {balance && (
+                  <AnimatePresence mode="wait">
+                    {loading === 'balance' ? (
+                      <SkeletonBalance key="loading-balance" />
+                    ) : balance ? (
                       <motion.div
+                        key="balance-list"
                         variants={v.pop} initial="hidden" animate="visible" exit="exit"
                         style={{ marginTop: 10 }}
                         aria-label="Account balances"

--- a/frontend/src/components/Skeleton.jsx
+++ b/frontend/src/components/Skeleton.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+
+/**
+ * SkeletonText — Placeholder for lines of text.
+ */
+export function SkeletonText({
+  lines = 3,
+  width = '100%',
+  height = '14px',
+  className = '',
+  ...props
+}) {
+  const getLineWidth = (index) => {
+    if (Array.isArray(width)) {
+      return width[index] || '100%';
+    }
+    // If it's a single value, we vary it slightly for the last line if lines > 1
+    if (lines > 1 && index === lines - 1 && width === '100%') {
+      return '65%';
+    }
+    return width;
+  };
+
+  return (
+    <div
+      className={`skeleton-text-container ${className}`}
+      role="status"
+      aria-busy="true"
+      aria-label="Loading content"
+      {...props}
+    >
+      {Array.from({ length: lines }).map((_, i) => (
+        <span
+          key={i}
+          className="skeleton-block skeleton-text-line"
+          style={{
+            display: 'block',
+            width: getLineWidth(i),
+            height,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * SkeletonCard — Placeholder matching the shape of a transaction item.
+ */
+export function SkeletonCard({ className = '', ...props }) {
+  return (
+    <div
+      className={`tx-row tx-skeleton ${className}`}
+      role="status"
+      aria-busy="true"
+      aria-label="Loading transaction"
+      style={{
+        display: 'flex',
+        gap: 12,
+        alignItems: 'center',
+        padding: '10px 0',
+        cursor: 'default',
+      }}
+      {...props}
+    >
+      <span className="skeleton-block" style={{ width: 16, height: 16, borderRadius: 4 }} />
+      <span className="skeleton-block" style={{ width: 80, height: 14, borderRadius: 4 }} />
+      <span className="skeleton-block" style={{ width: 100, height: 14, borderRadius: 4 }} />
+      <span className="skeleton-block" style={{ width: 120, height: 14, borderRadius: 4, marginLeft: 'auto' }} />
+      <span className="skeleton-block" style={{ width: 16, height: 16, borderRadius: 4 }} />
+    </div>
+  );
+}
+
+/**
+ * SkeletonBalance — Placeholder matching the shape of the account balances.
+ */
+export function SkeletonBalance({ rows = 2, className = '', ...props }) {
+  return (
+    <div
+      className={`skeleton-balance ${className}`}
+      role="status"
+      aria-busy="true"
+      aria-label="Loading account balances"
+      style={{
+        marginTop: 10,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+      {...props}
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="balance-row"
+          style={{
+            display: 'flex',
+            justify-content: 'space-between',
+            alignItems: 'center',
+            padding: '4px 0',
+            height: '29px',
+          }}
+        >
+          <span className="skeleton-block" style={{ width: 60, height: 14, borderRadius: 4 }} />
+          <span className="skeleton-block" style={{ width: 100, height: 14, borderRadius: 4 }} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/Skeleton.stories.jsx
+++ b/frontend/src/components/Skeleton.stories.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { SkeletonText, SkeletonCard, SkeletonBalance } from './Skeleton';
+
+export default {
+  title: 'Components/Skeleton',
+};
+
+export const Text = {
+  render: () => (
+    <div style={{ maxWidth: 400, padding: 16, background: 'var(--surface)', borderRadius: 8 }}>
+      <h4 style={{ marginBottom: 12, color: 'var(--text)' }}>SkeletonText Variant</h4>
+      <SkeletonText lines={3} />
+    </div>
+  ),
+};
+
+export const Card = {
+  render: () => (
+    <div style={{ maxWidth: 600, padding: 16, background: 'var(--surface)', borderRadius: 8 }}>
+      <h4 style={{ marginBottom: 12, color: 'var(--text)' }}>SkeletonCard Variant</h4>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+    </div>
+  ),
+};
+
+export const Balance = {
+  render: () => (
+    <div style={{ maxWidth: 300, padding: 16, background: 'var(--surface)', borderRadius: 8 }}>
+      <h4 style={{ marginBottom: 12, color: 'var(--text)' }}>SkeletonBalance Variant</h4>
+      <SkeletonBalance rows={3} />
+    </div>
+  ),
+};

--- a/frontend/src/components/TransactionHistory.jsx
+++ b/frontend/src/components/TransactionHistory.jsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import axios from 'axios';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { Spinner } from './Spinner';
+import { SkeletonCard } from './Skeleton';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { CopyButton } from './CopyButton';
 import { makeVariants, tapScale } from '../utils/animations';
@@ -18,17 +19,7 @@ function fmt(dateStr) {
   return new Date(dateStr).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
 }
 
-function TxSkeletonRow() {
-  return (
-    <div className="tx-row tx-skeleton" aria-hidden="true" style={{ display: 'flex', gap: 12, alignItems: 'center', padding: '10px 0' }}>
-      <span className="tx-skeleton-block" style={{ width: 16, height: 16, borderRadius: 4 }} />
-      <span className="tx-skeleton-block" style={{ width: 80, height: 14, borderRadius: 4 }} />
-      <span className="tx-skeleton-block" style={{ width: 100, height: 14, borderRadius: 4 }} />
-      <span className="tx-skeleton-block" style={{ width: 120, height: 14, borderRadius: 4, marginLeft: 'auto' }} />
-      <span className="tx-skeleton-block" style={{ width: 16, height: 16, borderRadius: 4 }} />
-    </div>
-  );
-}
+
 function csvEscape(val) {
   const s = val == null ? '' : String(val);
   return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s;
@@ -266,7 +257,7 @@ export function TransactionHistory({ publicKey }) {
             {...tap}
             aria-label={loaded ? 'Refresh transaction history' : 'Load transaction history'}
           >
-            {loading ? <Spinner label="Loading transactions…" /> : loaded ? '↺ Refresh' : 'Load History'}
+            {loading ? 'Loading transactions…' : loaded ? '↺ Refresh' : 'Load History'}
           </motion.button>
         </div>
       </div>
@@ -321,7 +312,7 @@ export function TransactionHistory({ publicKey }) {
         )}
         {!error && loading && (
           <motion.div key="skeleton" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} aria-label="Loading transactions" aria-busy="true">
-            {Array.from({ length: 5 }, (_, i) => <TxSkeletonRow key={i} />)}
+            {Array.from({ length: 5 }, (_, i) => <SkeletonCard key={i} />)}
           </motion.div>
         )}
         {!error && !loading && loaded && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2146,3 +2146,26 @@ kbd {
     padding: 3px 6px;
   }
 }
+
+/* Generic Skeleton Loading Styles */
+.skeleton-block {
+  display: inline-block;
+  background: linear-gradient(90deg, #e5e7eb 25%, #f3f4f6 50%, #e5e7eb 75%);
+  background-size: 800px 100%;
+  animation: tx-shimmer 1.4s infinite linear;
+}
+
+.theme-dark .skeleton-block,
+.dark .skeleton-block {
+  background: linear-gradient(90deg, #374151 25%, #4b5563 50%, #374151 75%);
+  background-size: 800px 100%;
+}
+
+.skeleton-text-line {
+  border-radius: 4px;
+  margin-bottom: 6px;
+}
+.skeleton-text-line:last-child {
+  margin-bottom: 0;
+}
+


### PR DESCRIPTION
## Description
This pull request replaces the legacy, layout-shifting spinner-only loading states for **Account Balances** and **Transaction History** with custom loading skeleton components that match the exact shape of the content being loaded. This drastically improves the user experience by reducing layout shift.

## Key Changes
- **New Components**:
  - `SkeletonText`: Reusable placeholder for lines of text, with customizable count and line widths.
  - `SkeletonCard`: Custom block matching the structure of a transaction row.
  - `SkeletonBalance`: Custom rows matching the layout of the account balance rows.
- **Improved Accessibility**: Added `role="status"`, `aria-busy="true"`, and descriptive `aria-label` attributes to the new skeleton elements.
- **Styling**: Appended `.skeleton-block` and associated shimmers to support light and dark modes in `index.css`.
- **Integrations**:
  - Replaced balance checking loading spinner with `<SkeletonBalance>` in `App.jsx`.
  - Replaced transaction loading spinner and row loaders with `<SkeletonCard>` items in `TransactionHistory.jsx`.
- **Storybook Stories**: Added CSF stories for all variants in `Skeleton.stories.jsx`.

## Verification Instructions
1. Navigate to the branch `feat/loading-skeletons`.
2. Run Storybook: `npm run storybook`.
3. Check the **Components/Skeleton** section to inspect the `Text`, `Card`, and `Balance` variants in both Light and Dark mode.
4. Launch the app (`npm run dev`) and trigger balance updates and transaction history refreshes to verify layout alignment.
closes #465 