### PR TITLE
feat(db): Prisma query logging in dev and PgBouncer support

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -49,6 +49,15 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 LOG_LEVEL=info
 DATABASE_URL=postgresql://user:password@localhost:5432/future_remittance
 
+# Optional: PgBouncer pooler URL (transaction pooling mode).
+# When set, Prisma connects through the pooler and prepared statements are
+# disabled automatically (?pgbouncer=true is appended if not already present).
+# DATABASE_POOL_URL=postgresql://user:password@pgbouncer:6432/future_remittance
+
+# Set to true to enable Prisma query logging outside of development mode.
+# In APP_ENV=development, query logging is always on.
+# PRISMA_QUERY_LOG=true
+
 # Database Sharding
 # Number of shards (default: 1 = no sharding, uses DATABASE_URL)
 DB_SHARD_COUNT=1

--- a/backend/CONFIGURATION.md
+++ b/backend/CONFIGURATION.md
@@ -47,3 +47,48 @@ You can store encrypted values using `ENC(<base64>)` or `enc:<base64>`, and prov
 
 The code uses AES-256-GCM with a SHA-256 derived key. See `backend/src/config/secrets.js`.
 
+## Database connection pooling (PgBouncer)
+
+For production deployments running multiple Node.js instances, a connection pooler prevents connection exhaustion.
+
+### Environment variables
+
+| Variable | Description |
+|---|---|
+| `DATABASE_URL` | Direct database URL (used for migrations and health checks) |
+| `DATABASE_POOL_URL` | PgBouncer pooler URL. When set, Prisma uses this for all queries |
+
+### PgBouncer setup
+
+1. Configure PgBouncer in **transaction pooling** mode (`pool_mode = transaction`).
+2. Set `DATABASE_POOL_URL` to the PgBouncer connection string, e.g.:
+   ```
+   DATABASE_POOL_URL=postgresql://user:password@pgbouncer:6432/future_remittance
+   ```
+3. The app automatically appends `?pgbouncer=true` to the pooler URL, which disables prepared statements — required for transaction pooling mode.
+4. Keep `DATABASE_URL` pointing at the primary Postgres instance so migrations (`prisma migrate deploy`) bypass the pooler.
+
+### PgBouncer configuration reference (`pgbouncer.ini`)
+
+```ini
+[databases]
+future_remittance = host=postgres port=5432 dbname=future_remittance
+
+[pgbouncer]
+pool_mode = transaction
+max_client_conn = 1000
+default_pool_size = 25
+server_reset_query =
+```
+
+> `server_reset_query` must be empty in transaction mode because connections are not owned by a single client between statements.
+
+## Prisma query logging
+
+| Variable | Behaviour |
+|---|---|
+| `APP_ENV=development` | Query logging always enabled |
+| `PRISMA_QUERY_LOG=true` | Enables query logging in any environment (useful for debugging in staging/production) |
+
+Query events are emitted at the `debug` log level and include the query text, bound parameters, and execution duration in milliseconds.
+

--- a/backend/src/db/client.js
+++ b/backend/src/db/client.js
@@ -6,26 +6,71 @@ import logger from '../config/logger.js';
 
 const { Pool } = pg;
 
+const appEnv = (process.env.APP_ENV || process.env.NODE_ENV || 'development').trim().toLowerCase();
+const isDev = appEnv === 'development';
+
+// Support PgBouncer via a dedicated pool URL (transaction pooling mode).
+// When DATABASE_POOL_URL is set, the pooler connection is used for the Prisma
+// adapter; DATABASE_URL is still used for direct migrations / health checks.
+const poolConnectionString = process.env.DATABASE_POOL_URL || process.env.DATABASE_URL;
+
+// Append ?pgbouncer=true when the connection string targets a PgBouncer
+// endpoint so Prisma disables prepared statements (required for transaction
+// pooling mode).
+function buildConnectionString(url) {
+  if (!url) return url;
+  try {
+    const parsed = new URL(url);
+    if (!parsed.searchParams.has('pgbouncer')) {
+      parsed.searchParams.set('pgbouncer', 'true');
+    }
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+const usePgBouncer = Boolean(process.env.DATABASE_POOL_URL);
+const adapterConnectionString = usePgBouncer
+  ? buildConnectionString(poolConnectionString)
+  : poolConnectionString;
+
 // Connection pool — reused across all requests
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  max: 10,
+  connectionString: adapterConnectionString,
+  max: parseInt(process.env.DB_POOL_MAX, 10) || 10,
   idleTimeoutMillis: 30_000,
   connectionTimeoutMillis: 5_000,
 });
 
 const adapter = new PrismaPg(pool);
 
+// Enable query-level logging in development or when PRISMA_QUERY_LOG=true.
+const queryLogEnabled = isDev || process.env.PRISMA_QUERY_LOG === 'true';
+
+const prismaLogConfig = [
+  { emit: 'event', level: 'error' },
+  { emit: 'event', level: 'warn' },
+  ...(queryLogEnabled ? [{ emit: 'event', level: 'query' }] : []),
+];
+
 const prisma = new PrismaClient({
   adapter,
-  log: [
-    { emit: 'event', level: 'error' },
-    { emit: 'event', level: 'warn' },
-  ],
+  log: prismaLogConfig,
 });
 
 prisma.$on('error', (e) => logger.error('db.error', { message: e.message, target: e.target }));
 prisma.$on('warn',  (e) => logger.warn('db.warn',  { message: e.message, target: e.target }));
+
+if (queryLogEnabled) {
+  prisma.$on('query', (e) => {
+    logger.debug('db.query', {
+      query: e.query,
+      params: e.params,
+      duration_ms: e.duration,
+    });
+  });
+}
 
 export async function connectDB() {
   await prisma.$connect();


### PR DESCRIPTION


closes #475  — Query logging
- Adds `{ emit: 'event', level: 'query' }` to Prisma log config when
  `APP_ENV=development` or `PRISMA_QUERY_LOG=true`
- Logs query text, params, and `duration_ms` at `debug` level
- Silent in production unless the flag is explicitly set

closes #476  — PgBouncer support
- New optional `DATABASE_POOL_URL` env var; Prisma adapter uses it when set
- `?pgbouncer=true` appended automatically — disables prepared statements
  for transaction pooling mode
- `DATABASE_URL` preserved for migrations and health checks
- PgBouncer setup guide + `pgbouncer.ini` reference added to CONFIGURATION.md