### PR TITLE
docs: add stellar testnet setup guide and funding script #513

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,44 @@ Frontend runs on http://localhost:3000
 3. Check balance to see your XLM
 4. Send payments to other Stellar addresses
 
+## Testnet Setup
+
+### Friendbot
+
+Friendbot is Stellar's automated account-funding service for the testnet. It credits any new (or unfunded) Stellar public key with **10,000 test XLM** at no cost, letting you start testing payments immediately without real funds.
+
+Fund an account via the API directly:
+
+```bash
+curl "https://friendbot.stellar.org/?addr=YOUR_PUBLIC_KEY"
+```
+
+Or use the bundled helper script (see `scripts/fund-testnet-account.sh`):
+
+```bash
+bash scripts/fund-testnet-account.sh GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZWM9CQJHD9QDNHXHXN
+```
+
+The app calls Friendbot automatically when you click **Create Account** in the UI.
+
+### Testnet Limitations
+
+- **Quarterly resets** — the Stellar testnet is wiped roughly every three months. All accounts, balances, and transaction history are deleted. You must re-fund accounts after each reset.
+- Test XLM has no monetary value and cannot be transferred to mainnet.
+- Friendbot is only available on testnet; it does not exist on mainnet.
+
+### Testnet vs. Mainnet Configuration
+
+| Setting | Testnet | Mainnet |
+|---|---|---|
+| `STELLAR_NETWORK` | `testnet` | `mainnet` |
+| `HORIZON_URL` | `https://horizon-testnet.stellar.org` | `https://horizon.stellar.org` |
+| Network passphrase | `Test SDF Network ; September 2015` | `Public Global Stellar Network ; September 2015` |
+| Friendbot available | ✅ Yes | ❌ No |
+| Real funds | ❌ No | ✅ Yes |
+
+Set `STELLAR_NETWORK=testnet` (the default) in `backend/.env` for local development. Change to `mainnet` only for production deployments.
+
 ## Next Steps
 
 - Add stablecoin support (USDC)

--- a/scripts/fund-testnet-account.sh
+++ b/scripts/fund-testnet-account.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FRIENDBOT_URL="https://friendbot.stellar.org"
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <STELLAR_PUBLIC_KEY>" >&2
+  echo "Example: $0 GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZWM9CQJHD9QDNHXHXN" >&2
+  exit 1
+fi
+
+PUBLIC_KEY="$1"
+
+# Basic format check: Stellar public keys start with G and are 56 chars
+if [[ ! "$PUBLIC_KEY" =~ ^G[A-Z2-7]{55}$ ]]; then
+  echo "Error: '$PUBLIC_KEY' does not look like a valid Stellar public key." >&2
+  exit 1
+fi
+
+echo "Funding $PUBLIC_KEY via Friendbot..."
+
+HTTP_STATUS=$(curl -s -o /tmp/friendbot_response.json -w "%{http_code}" \
+  "${FRIENDBOT_URL}/?addr=${PUBLIC_KEY}")
+
+if [[ "$HTTP_STATUS" == "200" ]]; then
+  echo "Success: account funded with 10,000 test XLM."
+else
+  echo "Error: Friendbot returned HTTP $HTTP_STATUS." >&2
+  cat /tmp/friendbot_response.json >&2
+  exit 1
+fi


### PR DESCRIPTION

## Problem
New contributors to the repository frequently face friction when setting up their local development environments for Stellar integration. The existing documentation mentions the testnet but lacks details regarding how to acquire test XLM, the purpose of Friendbot, quarterly testnet resets, and structural configuration differences between testnet and mainnet environments.

## Solution
This PR introduces comprehensive documentation for the Stellar testnet workflow inside the primary README.md and provides an automated utility script to streamline developer onboarding.

### Changes Implemented
- **Documentation Updates (README.md):**
  - Added a dedicated "Testnet Setup" section.
  - Detailed the functionality of Friendbot and provided manual funding instructions.
  - Highlighted critical testnet limitations, including the standard quarterly network reset and data wipe.
  - Included a configuration matrix comparing Horizon URL endpoints and network passphrases for both Testnet and Mainnet environments.

- **Automation (scripts/fund-testnet-account.sh):**
  - Created a bash helper script that automates account funding by accepting a public key and hitting the Stellar Friendbot API.
  - Implemented input validation and error feedback loops within the script.

## Verification Steps
1. Checkout to the branch `feature/513-stellar-testnet-docs`.
2. Review the new "Testnet Setup" section in `README.md` to ensure clarity and accuracy.
3. Generate a new experimental Stellar public key.
4. Execute the script via terminal: `./scripts/fund-testnet-account.sh [YOUR_PUBLIC_KEY]`
5. Verify that the script successfully triggers the Friendbot API and returns a success response.

## Related Issues
Closes #513