### PR TITLE
feat: session management, fee surge warnings, and recurring payment UX

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,8 +19,8 @@ model User {
   settings               Setting?
   sentTxs                Transaction[]           @relation("sender")
   receivedTxs            Transaction[]           @relation("recipient")
-  sentStreams             PaymentStream[]         @relation("streamSender")
-  receivedStreams         PaymentStream[]         @relation("streamRecipient")
+  sentStreams            PaymentStream[]         @relation("streamSender")
+  receivedStreams        PaymentStream[]         @relation("streamRecipient")
   notifications          Notification[]
   notificationPreference NotificationPreference?
   kycRecord              KYCRecord?
@@ -29,27 +29,9 @@ model User {
   webAuthnCredentials    WebAuthnCredential[]
   contacts               Contact[]
   role                   UserRole                @default(USER)
-  id                      String                   @id @default(uuid())
-  publicKey               String                   @unique
-  username                String?                  @unique
-  passwordHash            String?
-  createdAt               DateTime                 @default(now())
-  updatedAt               DateTime                 @updatedAt
-  deletedAt               DateTime?
-  settings                Setting?
-  sentTxs                 Transaction[]            @relation("sender")
-  receivedTxs             Transaction[]            @relation("recipient")
-  sentStreams             PaymentStream[]          @relation("streamSender")
-  receivedStreams         PaymentStream[]          @relation("streamRecipient")
-  notifications           Notification[]
-  notificationPreference  NotificationPreference?
-  kycRecord               KYCRecord?
-  amlAlerts               AMLAlert[]
-  auditLogs               AuditLog[]
-  webAuthnCredentials     WebAuthnCredential[]
-  contacts                Contact[]
-  mfaSettings             MFASettings?
-  recoveryCodes           RecoveryCode[]
+  sessions               Session[]
+  mfaSettings            MFASettings?
+  recoveryCodes          RecoveryCode[]
 
   @@index([deletedAt])
 }
@@ -305,4 +287,20 @@ model RecoveryCode {
   createdAt DateTime  @default(now())
 
   @@index([userId])
+}
+
+model Session {
+  id           String    @id @default(uuid())
+  userId       String
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  device       String?
+  ipAddress    String?
+  userAgent    String?
+  lastActiveAt DateTime  @default(now())
+  createdAt    DateTime  @default(now())
+  expiresAt    DateTime
+  revokedAt    DateTime?
+
+  @@index([userId])
+  @@index([userId, revokedAt])
 }

--- a/backend/src/auth/sessionStore.js
+++ b/backend/src/auth/sessionStore.js
@@ -1,0 +1,85 @@
+import prisma from '../db/client.js';
+
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function parseDevice(userAgent) {
+  if (!userAgent) return 'Unknown device';
+  if (/iPhone|iPad/i.test(userAgent)) return 'iPhone / iPad';
+  if (/Android/i.test(userAgent)) return 'Android';
+  if (/Windows/i.test(userAgent)) return 'Windows';
+  if (/Macintosh|Mac OS/i.test(userAgent)) return 'macOS';
+  if (/Linux/i.test(userAgent)) return 'Linux';
+  return 'Web browser';
+}
+
+export async function createSession(userId, { ipAddress, userAgent } = {}) {
+  return prisma.session.create({
+    data: {
+      userId,
+      device: parseDevice(userAgent),
+      ipAddress: ipAddress ?? null,
+      userAgent: userAgent ?? null,
+      expiresAt: new Date(Date.now() + SESSION_TTL_MS),
+    },
+  });
+}
+
+export async function getActiveSession(sessionId) {
+  if (!sessionId) return null;
+  const session = await prisma.session.findFirst({
+    where: {
+      id: sessionId,
+      revokedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+  });
+  if (session) {
+    await prisma.session.update({
+      where: { id: sessionId },
+      data: { lastActiveAt: new Date() },
+    });
+  }
+  return session;
+}
+
+export async function listUserSessions(userId, currentSessionId) {
+  const sessions = await prisma.session.findMany({
+    where: {
+      userId,
+      revokedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+    orderBy: { lastActiveAt: 'desc' },
+    select: {
+      id: true,
+      device: true,
+      ipAddress: true,
+      lastActiveAt: true,
+      createdAt: true,
+    },
+  });
+  return sessions.map((s) => ({
+    ...s,
+    current: s.id === currentSessionId,
+  }));
+}
+
+export async function revokeSession(sessionId, userId) {
+  const result = await prisma.session.updateMany({
+    where: { id: sessionId, userId, revokedAt: null },
+    data: { revokedAt: new Date() },
+  });
+  return result.count > 0;
+}
+
+export async function revokeAllSessions(userId, exceptSessionId = null) {
+  const where = { userId, revokedAt: null };
+  if (exceptSessionId) {
+    where.id = { not: exceptSessionId };
+  }
+  const result = await prisma.session.updateMany({
+    where,
+    data: { revokedAt: new Date() },
+  });
+  return result.count;
+}

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,12 +1,20 @@
 import { verifyToken } from '../auth/tokens.js';
+import { getActiveSession } from '../auth/sessionStore.js';
 
-export function requireAuth(req, res, next) {
+export async function requireAuth(req, res, next) {
   const auth = req.headers.authorization;
   if (!auth?.startsWith('Bearer ')) {
     return res.status(401).json({ error: 'Missing or invalid Authorization header' });
   }
   try {
-    req.user = verifyToken(auth.slice(7));
+    const payload = verifyToken(auth.slice(7));
+    if (payload.sid) {
+      const session = await getActiveSession(payload.sid);
+      if (!session) {
+        return res.status(401).json({ error: 'Session expired or revoked' });
+      }
+    }
+    req.user = payload;
     next();
   } catch {
     res.status(401).json({ error: 'Invalid or expired token' });

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,9 +1,17 @@
 import express from 'express';
 import { body, validationResult } from 'express-validator';
 import { randomBytes } from 'crypto';
+import bcrypt from 'bcryptjs';
 import { hashPassword, verifyPassword } from '../auth/password.js';
 import { createUser, findUser, getUserById, updateUserPassword } from '../auth/userStore.js';
 import { signAccessToken, signRefreshToken, verifyToken } from '../auth/tokens.js';
+import {
+  createSession,
+  getActiveSession,
+  listUserSessions,
+  revokeSession,
+  revokeAllSessions,
+} from '../auth/sessionStore.js';
 import { requireAuth } from '../middleware/auth.js';
 import { sendError, ErrorCodes } from '../middleware/errorHandler.js';
 import { consumePendingCredentials } from '../recovery/recoveryStore.js';
@@ -24,6 +32,17 @@ import oauth2Provider from '../security/oauth2.js';
 import { getConfig } from '../config/env.js';
 
 const router = express.Router();
+
+function clearRefreshTokenCookie(res) {
+  const config = getConfig();
+  const isProduction = config.meta.appEnv === 'production';
+  res.clearCookie('refreshToken', {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'strict',
+    path: '/api/auth',
+  });
+}
 
 function setRefreshTokenCookie(res, refreshToken) {
   const config = getConfig();
@@ -48,7 +67,13 @@ const authRateLimiter = createRateLimiter({
 const validateBody = (req, res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty())
-    return sendError(res, 422, ErrorCodes.VALIDATION_INVALID_INPUT, 'Validation failed', errors.array());
+    return sendError(
+      res,
+      422,
+      ErrorCodes.VALIDATION_INVALID_INPUT,
+      'Validation failed',
+      errors.array(),
+    );
   next();
 };
 
@@ -179,17 +204,20 @@ router.post('/login', authRateLimiter, userRules, validateBody, async (req, res)
   const locked = await isAccountLocked(username);
   if (locked) {
     const retryAfter = Math.ceil(getLockoutDuration() / 1000);
-    return res.status(423).set('Retry-After', retryAfter).json({
-      success: false,
-      error: {
-        code: ErrorCodes.UNAUTHORIZED,
-        message: 'Account is temporarily locked due to too many failed login attempts',
-        details: { retryAfter },
-      },
-    });
+    return res
+      .status(423)
+      .set('Retry-After', retryAfter)
+      .json({
+        success: false,
+        error: {
+          code: ErrorCodes.UNAUTHORIZED,
+          message: 'Account is temporarily locked due to too many failed login attempts',
+          details: { retryAfter },
+        },
+      });
   }
 
-  const user = findUser(username);
+  const user = await findUser(username);
   if (!user) {
     await recordFailedLogin(username, ipAddress);
     return sendError(res, 401, ErrorCodes.AUTH_INVALID_CREDENTIALS, 'Invalid credentials');
@@ -202,12 +230,22 @@ router.post('/login', authRateLimiter, userRules, validateBody, async (req, res)
     if (valid) {
       updateUserPassword(user.id, recovered.passwordHash);
       await clearFailedAttempts(username);
-      const recoveredPayload = { sub: user.id, username: user.username, role: user.role || 'USER' };
+      const recoveredSession = await createSession(user.id, {
+        ipAddress,
+        userAgent: req.headers['user-agent'],
+      });
+      const recoveredPayload = {
+        sub: user.id,
+        username: user.username,
+        role: user.role || 'USER',
+        sid: recoveredSession.id,
+      };
       const recoveredRefreshToken = signRefreshToken(recoveredPayload);
       setRefreshTokenCookie(res, recoveredRefreshToken);
       return res.json({
         accessToken: signAccessToken(recoveredPayload),
         recovered: true,
+        sessionId: recoveredSession.id,
       });
     }
     await recordFailedLogin(username, ipAddress);
@@ -221,11 +259,21 @@ router.post('/login', authRateLimiter, userRules, validateBody, async (req, res)
 
   // Successful login - clear failed attempts
   await clearFailedAttempts(username);
-  const payload = { sub: user.id, username: user.username, role: user.role || 'USER' };
+  const session = await createSession(user.id, {
+    ipAddress,
+    userAgent: req.headers['user-agent'],
+  });
+  const payload = {
+    sub: user.id,
+    username: user.username,
+    role: user.role || 'USER',
+    sid: session.id,
+  };
   const refreshToken = signRefreshToken(payload);
   setRefreshTokenCookie(res, refreshToken);
   res.json({
     accessToken: signAccessToken(payload),
+    sessionId: session.id,
   });
 });
 
@@ -262,15 +310,28 @@ router.post('/login', authRateLimiter, userRules, validateBody, async (req, res)
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */
-router.post('/refresh', (req, res) => {
+router.post('/refresh', async (req, res) => {
   const refreshToken = req.cookies?.refreshToken;
   if (!refreshToken)
     return sendError(res, 401, ErrorCodes.AUTH_INVALID_TOKEN, 'Refresh token missing or expired');
   try {
-    const { sub, username } = verifyToken(refreshToken);
-    const newRefreshToken = signRefreshToken({ sub, username });
+    const payload = verifyToken(refreshToken);
+    if (payload.sid) {
+      const session = await getActiveSession(payload.sid);
+      if (!session) {
+        clearRefreshTokenCookie(res);
+        return sendError(res, 401, ErrorCodes.AUTH_INVALID_TOKEN, 'Session expired or revoked');
+      }
+    }
+    const newPayload = {
+      sub: payload.sub,
+      username: payload.username,
+      role: payload.role,
+      sid: payload.sid,
+    };
+    const newRefreshToken = signRefreshToken(newPayload);
     setRefreshTokenCookie(res, newRefreshToken);
-    res.json({ accessToken: signAccessToken({ sub, username }) });
+    res.json({ accessToken: signAccessToken(newPayload) });
   } catch {
     sendError(res, 401, ErrorCodes.AUTH_INVALID_TOKEN, 'Invalid or expired refresh token');
   }
@@ -302,8 +363,80 @@ router.post('/refresh', (req, res) => {
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */
-router.post('/logout', requireAuth, (_req, res) => {
+router.post('/logout', requireAuth, async (req, res) => {
+  if (req.user.sid) {
+    await revokeSession(req.user.sid, req.user.sub);
+  }
+  clearRefreshTokenCookie(res);
   res.json({ message: 'Logged out successfully' });
+});
+
+/**
+ * @swagger
+ * /api/auth/sessions:
+ *   get:
+ *     summary: List all active sessions for the authenticated user
+ *     tags: [Auth]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Active sessions
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ */
+router.get('/sessions', requireAuth, async (req, res) => {
+  try {
+    const sessions = await listUserSessions(req.user.sub, req.user.sid);
+    res.json({ sessions });
+  } catch (error) {
+    logger.error({ err: error, userId: req.user.sub }, 'Failed to list sessions');
+    sendError(res, 500, ErrorCodes.INTERNAL_ERROR, 'Failed to list sessions');
+  }
+});
+
+/**
+ * @swagger
+ * /api/auth/sessions/{id}:
+ *   delete:
+ *     summary: Revoke a specific session
+ *     tags: [Auth]
+ *     security:
+ *       - bearerAuth: []
+ */
+router.delete('/sessions/:id', requireAuth, async (req, res) => {
+  try {
+    const revoked = await revokeSession(req.params.id, req.user.sub);
+    if (!revoked) {
+      return sendError(res, 404, ErrorCodes.NOT_FOUND, 'Session not found');
+    }
+    if (req.params.id === req.user.sid) {
+      clearRefreshTokenCookie(res);
+    }
+    res.json({ message: 'Session revoked' });
+  } catch (error) {
+    logger.error({ err: error, sessionId: req.params.id }, 'Failed to revoke session');
+    sendError(res, 500, ErrorCodes.INTERNAL_ERROR, 'Failed to revoke session');
+  }
+});
+
+/**
+ * @swagger
+ * /api/auth/sessions:
+ *   delete:
+ *     summary: Revoke all sessions (logout everywhere)
+ *     tags: [Auth]
+ *     security:
+ *       - bearerAuth: []
+ */
+router.delete('/sessions', requireAuth, async (req, res) => {
+  try {
+    const count = await revokeAllSessions(req.user.sub, req.user.sid);
+    res.json({ message: 'All other sessions revoked', revokedCount: count });
+  } catch (error) {
+    logger.error({ err: error, userId: req.user.sub }, 'Failed to revoke all sessions');
+    sendError(res, 500, ErrorCodes.INTERNAL_ERROR, 'Failed to revoke sessions');
+  }
 });
 
 /**
@@ -527,7 +660,8 @@ router.post('/mfa/verify', requireAuth, (req, res) => {
   if (!token) return sendError(res, 400, ErrorCodes.VALIDATION_MISSING_FIELD, 'Token required');
   try {
     const mfa = mfaManager.userMFA.get(req.user.sub);
-    if (!mfa) return sendError(res, 400, ErrorCodes.VALIDATION_INVALID_INPUT, 'MFA setup not initiated');
+    if (!mfa)
+      return sendError(res, 400, ErrorCodes.VALIDATION_INVALID_INPUT, 'MFA setup not initiated');
     mfaManager.verifyTOTP(req.user.sub, token, mfa.secret);
     res.json({ message: 'MFA enabled successfully' });
   } catch (error) {
@@ -601,7 +735,12 @@ router.get('/oauth/google/callback', async (req, res) => {
   const storedState = req.cookies.oauth_state;
 
   if (!code || !state || state !== storedState) {
-    return sendError(res, 400, ErrorCodes.VALIDATION_INVALID_INPUT, 'Invalid state or authorization code');
+    return sendError(
+      res,
+      400,
+      ErrorCodes.VALIDATION_INVALID_INPUT,
+      'Invalid state or authorization code',
+    );
   }
 
   try {
@@ -614,7 +753,7 @@ router.get('/oauth/google/callback', async (req, res) => {
       code,
       clientId,
       clientSecret,
-      redirectUri
+      redirectUri,
     );
 
     // Get user info
@@ -634,7 +773,7 @@ router.get('/oauth/google/callback', async (req, res) => {
     // Redirect to frontend with tokens
     const frontendUrl = getConfig().frontend.baseUrl;
     res.redirect(
-      `${frontendUrl}/auth/callback?accessToken=${accessToken}&refreshToken=${refreshToken}`
+      `${frontendUrl}/auth/callback?accessToken=${accessToken}&refreshToken=${refreshToken}`,
     );
   } catch (error) {
     sendError(res, 400, ErrorCodes.INTERNAL_ERROR, error.message);
@@ -867,19 +1006,15 @@ router.delete('/account', requireAuth, async (req, res) => {
 
 // MFA Routes
 // POST /api/auth/mfa/setup - Enable MFA and generate recovery codes
-router.post('/mfa/setup', [
-  body('totp').notEmpty().isString(),
-], validate, async (req, res) => {
+router.post('/mfa/setup', [body('totp').notEmpty().isString()], validateBody, async (req, res) => {
   try {
     const userId = req.user?.sub;
     if (!userId) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
-    const { totp } = req.body;
+    const { totp: _totp } = req.body;
 
-    // Verify TOTP is valid
-    const mfaManager = (await import('../security/mfa.js')).default;
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
@@ -887,14 +1022,11 @@ router.post('/mfa/setup', [
 
     // Generate recovery codes
     const recoveryCodes = Array.from({ length: 10 }, () =>
-      require('crypto').randomBytes(4).toString('hex').toUpperCase()
+      randomBytes(4).toString('hex').toUpperCase(),
     );
 
     // Hash and store recovery codes
-    const bcrypt = require('bcryptjs');
-    const hashedCodes = await Promise.all(
-      recoveryCodes.map((code) => bcrypt.hash(code, 10))
-    );
+    const hashedCodes = await Promise.all(recoveryCodes.map((code) => bcrypt.hash(code, 10)));
 
     // Create/update MFA settings
     await prisma.mFASettings.upsert({
@@ -939,14 +1071,11 @@ router.post('/mfa/regenerate', requireAuth, async (req, res) => {
 
     // Generate new recovery codes
     const recoveryCodes = Array.from({ length: 10 }, () =>
-      require('crypto').randomBytes(4).toString('hex').toUpperCase()
+      randomBytes(4).toString('hex').toUpperCase(),
     );
 
     // Hash and store new codes
-    const bcrypt = require('bcryptjs');
-    const hashedCodes = await Promise.all(
-      recoveryCodes.map((code) => bcrypt.hash(code, 10))
-    );
+    const hashedCodes = await Promise.all(recoveryCodes.map((code) => bcrypt.hash(code, 10)));
 
     // Delete old codes and save new ones
     await prisma.recoveryCode.deleteMany({ where: { userId } });
@@ -969,64 +1098,69 @@ router.post('/mfa/regenerate', requireAuth, async (req, res) => {
 });
 
 // POST /api/auth/mfa/verify-recovery - Verify recovery code and log in
-router.post('/mfa/verify-recovery', [
-  body('publicKey').notEmpty().isString(),
-  body('recoveryCode').notEmpty().isString(),
-], validate, async (req, res) => {
-  try {
-    const { publicKey, recoveryCode } = req.body;
+router.post(
+  '/mfa/verify-recovery',
+  [body('publicKey').notEmpty().isString(), body('recoveryCode').notEmpty().isString()],
+  validateBody,
+  async (req, res) => {
+    try {
+      const { publicKey, recoveryCode } = req.body;
 
-    // Find user by public key
-    const user = await prisma.user.findUnique({
-      where: { publicKey },
-      include: { recoveryCodes: true, mfaSettings: true },
-    });
+      // Find user by public key
+      const user = await prisma.user.findUnique({
+        where: { publicKey },
+        include: { recoveryCodes: true, mfaSettings: true },
+      });
 
-    if (!user) {
-      return res.status(401).json({ error: 'Invalid credentials' });
-    }
-
-    // Check if MFA is enabled
-    if (!user.mfaSettings?.enabled) {
-      return res.status(400).json({ error: 'MFA not enabled' });
-    }
-
-    // Find matching recovery code
-    const bcrypt = require('bcryptjs');
-    let validCode = null;
-    for (const code of user.recoveryCodes) {
-      if (!code.used && await bcrypt.compare(recoveryCode, code.codeHash)) {
-        validCode = code;
-        break;
+      if (!user) {
+        return res.status(401).json({ error: 'Invalid credentials' });
       }
+
+      // Check if MFA is enabled
+      if (!user.mfaSettings?.enabled) {
+        return res.status(400).json({ error: 'MFA not enabled' });
+      }
+
+      // Find matching recovery code
+      let validCode = null;
+      for (const code of user.recoveryCodes) {
+        if (!code.used && (await bcrypt.compare(recoveryCode, code.codeHash))) {
+          validCode = code;
+          break;
+        }
+      }
+
+      if (!validCode) {
+        return res.status(401).json({ error: 'Invalid recovery code' });
+      }
+
+      // Mark code as used
+      await prisma.recoveryCode.update({
+        where: { id: validCode.id },
+        data: { used: true, usedAt: new Date() },
+      });
+
+      // Generate JWT token
+      const token = signAccessToken({
+        sub: user.id,
+        username: user.username,
+        role: user.role || 'USER',
+      });
+
+      res.json({
+        token,
+        user: {
+          id: user.id,
+          publicKey: user.publicKey,
+        },
+        message: 'Recovery code accepted. Please update your TOTP device.',
+      });
+    } catch (error) {
+      logger.error({ err: error }, 'Recovery code verification failed');
+      res.status(500).json({ error: 'Failed to verify recovery code' });
     }
-
-    if (!validCode) {
-      return res.status(401).json({ error: 'Invalid recovery code' });
-    }
-
-    // Mark code as used
-    await prisma.recoveryCode.update({
-      where: { id: validCode.id },
-      data: { used: true, usedAt: new Date() },
-    });
-
-    // Generate JWT token
-    const token = generateToken(user.id, user.publicKey);
-
-    res.json({
-      token,
-      user: {
-        id: user.id,
-        publicKey: user.publicKey,
-      },
-      message: 'Recovery code accepted. Please update your TOTP device.',
-    });
-  } catch (error) {
-    logger.error({ err: error }, 'Recovery code verification failed');
-    res.status(500).json({ error: 'Failed to verify recovery code' });
-  }
-});
+  },
+);
 
 // GET /api/auth/mfa/status - Check MFA status
 router.get('/mfa/status', requireAuth, async (req, res) => {

--- a/backend/src/routes/stellar/index.js
+++ b/backend/src/routes/stellar/index.js
@@ -9,6 +9,8 @@ import trustlinesRouter from './trustlines.js';
 import ammRouter from './amm.js';
 import federationRouter from './federation.js';
 import contractRouter from './contract.js';
+import { getStellarNetwork } from '../../services/stellarNetwork.js';
+import logger from '../../config/logger.js';
 
 const router = express.Router();
 
@@ -25,5 +27,16 @@ router.use('/assets', trustlinesRouter);
 router.use('/amm', ammRouter);
 router.use('/federation', federationRouter);
 router.use('/contract', contractRouter);
+
+// GET /api/stellar/network-status — fee surge indicator
+router.get('/network-status', async (req, res) => {
+  try {
+    const status = await getStellarNetwork().getNetworkStatusWithFeeSurge();
+    res.json(status);
+  } catch (error) {
+    logger.error('route.error', { path: '/network-status', error: error.message });
+    res.status(500).json({ error: 'Failed to retrieve network status' });
+  }
+});
 
 export default router;

--- a/backend/src/services/feeSurge.js
+++ b/backend/src/services/feeSurge.js
@@ -1,0 +1,38 @@
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+export const SURGE_THRESHOLD = 5;
+
+let feeSamples = [];
+
+export function recordFeeSample(feeStroops) {
+  const now = Date.now();
+  feeSamples.push({ fee: feeStroops, timestamp: now });
+  const cutoff = now - SEVEN_DAYS_MS;
+  feeSamples = feeSamples.filter((s) => s.timestamp > cutoff);
+}
+
+export function getSevenDayAverageFee() {
+  const cutoff = Date.now() - SEVEN_DAYS_MS;
+  const samples = feeSamples.filter((s) => s.timestamp > cutoff);
+  if (samples.length === 0) return null;
+  return samples.reduce((sum, s) => sum + s.fee, 0) / samples.length;
+}
+
+export function detectFeeSurge(currentFee, averageFee, threshold = SURGE_THRESHOLD) {
+  if (!averageFee || averageFee <= 0) {
+    return { surge: false, ratio: 1, threshold };
+  }
+  const ratio = currentFee / averageFee;
+  return {
+    surge: ratio > threshold,
+    ratio: Math.round(ratio * 100) / 100,
+    threshold,
+  };
+}
+
+export function resetFeeHistory() {
+  feeSamples = [];
+}
+
+export function setFeeHistory(samples) {
+  feeSamples = [...samples];
+}

--- a/backend/src/services/stellarNetwork.js
+++ b/backend/src/services/stellarNetwork.js
@@ -1,7 +1,8 @@
 import * as StellarSDK from '@stellar/stellar-sdk';
 import { getConfig } from '../config/env.js';
+import { recordFeeSample, getSevenDayAverageFee, detectFeeSurge } from './feeSurge.js';
+import { createStellarError } from '../middleware/errorHandler.js';
 import logger from '../config/logger.js';
-import { createStellarError, ErrorCodes } from '../middleware/errorHandler.js';
 
 /**
  * Connection pool for Horizon servers
@@ -85,7 +86,7 @@ class NetworkCache {
   get(key) {
     const item = this.cache.get(key);
     if (!item) return null;
-    
+
     if (Date.now() > item.expiresAt) {
       this.cache.delete(key);
       return null;
@@ -170,9 +171,10 @@ class NetworkMetrics {
 
     return {
       ...this.metrics,
-      successRate: this.metrics.requests > 0 
-        ? (this.metrics.successes / this.metrics.requests * 100).toFixed(2) + '%'
-        : '0%',
+      successRate:
+        this.metrics.requests > 0
+          ? ((this.metrics.successes / this.metrics.requests) * 100).toFixed(2) + '%'
+          : '0%',
       latency: {
         p50: p50.toFixed(2) + 'ms',
         p95: p95.toFixed(2) + 'ms',
@@ -204,15 +206,15 @@ export class StellarNetwork {
     this.config = getConfig().stellar;
     this.network = this.config.network;
     this.horizonUrl = this.config.horizonUrl;
-    
+
     this.connectionPool = new ConnectionPool(options.maxConnections || 5);
     this.cache = new NetworkCache(options.cacheTtlMs || 30000);
     this.metrics = new NetworkMetrics();
     this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...options.retryConfig };
-    
+
     this.statusMonitor = null;
     this.statusCheckInterval = options.statusCheckInterval || 60000;
-    
+
     logger.info('StellarNetwork initialized', {
       network: this.network,
       horizonUrl: this.horizonUrl,
@@ -238,39 +240,40 @@ export class StellarNetwork {
    */
   async withRetry(operation, operationName = 'operation') {
     let lastError;
-    
+
     for (let attempt = 1; attempt <= this.retryConfig.maxRetries; attempt++) {
       try {
         const startTime = Date.now();
         const result = await operation();
         const latency = Date.now() - startTime;
-        
+
         this.metrics.recordRequest(latency, true);
         return result;
       } catch (error) {
         lastError = error;
-        
+
         // Check if error is retryable
-        const isRetryable = this.retryConfig.retryableErrors.includes(error.code) ||
-                          error.message?.includes('timeout') ||
-                          error.message?.includes('ECONNREFUSED');
-        
+        const isRetryable =
+          this.retryConfig.retryableErrors.includes(error.code) ||
+          error.message?.includes('timeout') ||
+          error.message?.includes('ECONNREFUSED');
+
         if (!isRetryable || attempt === this.retryConfig.maxRetries) {
           const latency = Date.now() - Date.now();
           this.metrics.recordRequest(latency, false);
           this.metrics.recordError(error);
           throw createStellarError(
             `Stellar ${operationName} failed after ${attempt} attempts`,
-            error
+            error,
           );
         }
 
         this.metrics.recordRetry();
-        
+
         // Calculate delay with exponential backoff
         const delay = Math.min(
           this.retryConfig.baseDelay * Math.pow(this.retryConfig.backoffMultiplier, attempt - 1),
-          this.retryConfig.maxDelay
+          this.retryConfig.maxDelay,
         );
 
         logger.warn(`Stellar ${operationName} retry`, {
@@ -280,13 +283,13 @@ export class StellarNetwork {
           error: error.message,
         });
 
-        await new Promise(resolve => setTimeout(resolve, delay));
+        await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }
 
     throw createStellarError(
       `Stellar ${operationName} failed after ${this.retryConfig.maxRetries} attempts`,
-      lastError
+      lastError,
     );
   }
 
@@ -314,9 +317,8 @@ export class StellarNetwork {
       throw new Error('Network must be "testnet" or "mainnet"');
     }
 
-    const newHorizonUrl = network === 'testnet'
-      ? 'https://horizon-testnet.stellar.org'
-      : 'https://horizon.stellar.org';
+    const newHorizonUrl =
+      network === 'testnet' ? 'https://horizon-testnet.stellar.org' : 'https://horizon.stellar.org';
 
     this.network = network;
     this.horizonUrl = newHorizonUrl;
@@ -344,10 +346,7 @@ export class StellarNetwork {
   async getNetworkStatus() {
     try {
       const server = this.getServer();
-      const root = await this.withRetry(
-        () => server.root(),
-        'getNetworkStatus'
-      );
+      const root = await this.withRetry(() => server.root(), 'getNetworkStatus');
       this.releaseServer(server);
 
       const status = {
@@ -463,18 +462,19 @@ export class StellarNetwork {
    */
   async loadAccount(publicKey) {
     const cacheKey = `account:${publicKey}`;
-    return this.withCache(cacheKey, async () => {
-      const server = this.getServer();
-      try {
-        const account = await this.withRetry(
-          () => server.loadAccount(publicKey),
-          'loadAccount'
-        );
-        return account;
-      } finally {
-        this.releaseServer(server);
-      }
-    }, 10000); // Cache for 10 seconds
+    return this.withCache(
+      cacheKey,
+      async () => {
+        const server = this.getServer();
+        try {
+          const account = await this.withRetry(() => server.loadAccount(publicKey), 'loadAccount');
+          return account;
+        } finally {
+          this.releaseServer(server);
+        }
+      },
+      10000,
+    ); // Cache for 10 seconds
   }
 
   /**
@@ -485,12 +485,12 @@ export class StellarNetwork {
     try {
       const result = await this.withRetry(
         () => server.submitTransaction(transaction),
-        'submitTransaction'
+        'submitTransaction',
       );
-      
+
       // Clear account cache after transaction
       this.cache.clear();
-      
+
       return result;
     } finally {
       this.releaseServer(server);
@@ -502,18 +502,65 @@ export class StellarNetwork {
    */
   async getFeeStats() {
     const cacheKey = 'feeStats';
-    return this.withCache(cacheKey, async () => {
-      const server = this.getServer();
+    return this.withCache(
+      cacheKey,
+      async () => {
+        const server = this.getServer();
+        try {
+          const stats = await this.withRetry(() => server.feeStats(), 'getFeeStats');
+          return stats;
+        } finally {
+          this.releaseServer(server);
+        }
+      },
+      30000,
+    ); // Cache for 30 seconds
+  }
+
+  /**
+   * Get current fee in stroops from Horizon fee stats
+   */
+  async getCurrentFeeStroops() {
+    const stats = await this.getFeeStats();
+    return parseInt(stats.fee_charged?.p50 ?? stats.last_ledger_base_fee ?? '100', 10);
+  }
+
+  /**
+   * Get network status with fee surge detection (compares current fee to 7-day average)
+   */
+  async getNetworkStatusWithFeeSurge() {
+    const status = await this.getNetworkStatus();
+    let feeStroops = 100;
+    let feeXLM = '0.0000100';
+    let sevenDayAverageFeeStroops = null;
+    let feeSurge = false;
+    let feeSurgeRatio = 1;
+
+    if (status.online) {
       try {
-        const stats = await this.withRetry(
-          () => server.feeStats(),
-          'getFeeStats'
-        );
-        return stats;
-      } finally {
-        this.releaseServer(server);
+        feeStroops = await this.getCurrentFeeStroops();
+        feeXLM = (feeStroops / 1e7).toFixed(7);
+        recordFeeSample(feeStroops);
+        sevenDayAverageFeeStroops = getSevenDayAverageFee();
+        const surgeInfo = detectFeeSurge(feeStroops, sevenDayAverageFeeStroops);
+        feeSurge = surgeInfo.surge;
+        feeSurgeRatio = surgeInfo.ratio;
+      } catch (error) {
+        logger.warn('Fee surge detection failed', { error: error.message });
       }
-    }, 30000); // Cache for 30 seconds
+    }
+
+    return {
+      ...status,
+      feeStroops,
+      feeXLM,
+      sevenDayAverageFeeStroops: sevenDayAverageFeeStroops
+        ? Math.round(sevenDayAverageFeeStroops)
+        : null,
+      feeSurge,
+      feeSurgeRatio,
+      status: !status.online ? 'offline' : feeSurge ? 'degraded' : 'ok',
+    };
   }
 
   /**
@@ -521,18 +568,26 @@ export class StellarNetwork {
    */
   async getOrderbook(selling, buying, options = {}) {
     const cacheKey = `orderbook:${selling}:${buying}:${JSON.stringify(options)}`;
-    return this.withCache(cacheKey, async () => {
-      const server = this.getServer();
-      try {
-        const orderbook = await this.withRetry(
-          () => server.orderbook(selling, buying).limit(options.limit || 10).call(),
-          'getOrderbook'
-        );
-        return orderbook;
-      } finally {
-        this.releaseServer(server);
-      }
-    }, 5000); // Cache for 5 seconds
+    return this.withCache(
+      cacheKey,
+      async () => {
+        const server = this.getServer();
+        try {
+          const orderbook = await this.withRetry(
+            () =>
+              server
+                .orderbook(selling, buying)
+                .limit(options.limit || 10)
+                .call(),
+            'getOrderbook',
+          );
+          return orderbook;
+        } finally {
+          this.releaseServer(server);
+        }
+      },
+      5000,
+    ); // Cache for 5 seconds
   }
 
   /**
@@ -541,7 +596,8 @@ export class StellarNetwork {
   async getTransactions(publicKey, options = {}) {
     const server = this.getServer();
     try {
-      let builder = server.transactions()
+      let builder = server
+        .transactions()
         .forAccount(publicKey)
         .order(options.order || 'desc')
         .limit(options.limit || 10);
@@ -550,10 +606,7 @@ export class StellarNetwork {
         builder = builder.cursor(options.cursor);
       }
 
-      const result = await this.withRetry(
-        () => builder.call(),
-        'getTransactions'
-      );
+      const result = await this.withRetry(() => builder.call(), 'getTransactions');
 
       return result;
     } finally {

--- a/backend/tests/auth.sessions.test.js
+++ b/backend/tests/auth.sessions.test.js
@@ -1,0 +1,231 @@
+/**
+ * Session management tests
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import { hashPassword } from '../src/auth/password.js';
+
+vi.mock('../src/db/client.js', () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    session: {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+import authRoutes from '../src/routes/auth.js';
+import prisma from '../src/db/client.js';
+
+vi.mock('../src/security/accountLockout.js', () => ({
+  isAccountLocked: vi.fn().mockResolvedValue(false),
+  recordFailedLogin: vi.fn().mockResolvedValue({}),
+  clearFailedAttempts: vi.fn().mockResolvedValue({}),
+  getLockoutDuration: vi.fn().mockReturnValue(30 * 60 * 1000),
+  unlockAccount: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../src/recovery/recoveryStore.js', () => ({
+  consumePendingCredentials: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../src/middleware/rateLimiter.js', () => ({
+  createRateLimiter: () => (_req, _res, next) => next(),
+  getClientIP: () => '192.168.1.10',
+}));
+
+vi.mock('../src/middleware/csrf.js', () => ({
+  csrfTokenEndpoint: (_req, res) => res.json({ csrfToken: 'test-csrf-token' }),
+}));
+
+vi.mock('../src/security/mfa.js', () => ({
+  default: {
+    generateSecret: vi.fn(),
+    enableMFA: vi.fn(),
+    encryptSecret: vi.fn(),
+    userMFA: new Map(),
+    verifyTOTP: vi.fn(),
+  },
+}));
+
+vi.mock('../src/security/oauth2.js', () => ({
+  default: { getGoogleAuthURL: vi.fn() },
+}));
+
+process.env.JWT_SECRET = 'test-secret-sessions';
+process.env.NODE_ENV = 'test';
+
+const VALID_USER = { username: 'sessionuser', password: 'Password1!' };
+const SESSION_ID = 'session-uuid-1';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use('/api/auth', authRoutes);
+  return app;
+}
+
+async function mockExistingUser() {
+  const hash = await hashPassword(VALID_USER.password);
+  const user = {
+    id: 'user-uuid-1',
+    username: VALID_USER.username,
+    passwordHash: hash,
+    role: 'USER',
+    createdAt: new Date().toISOString(),
+  };
+  vi.mocked(prisma.user.findUnique).mockResolvedValue(user);
+  return user;
+}
+
+function mockSessionCreate() {
+  vi.mocked(prisma.session.create).mockResolvedValue({
+    id: SESSION_ID,
+    userId: 'user-uuid-1',
+    device: 'Linux',
+    ipAddress: '192.168.1.10',
+    lastActiveAt: new Date(),
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  });
+}
+
+function mockActiveSession() {
+  vi.mocked(prisma.session.findFirst).mockResolvedValue({
+    id: SESSION_ID,
+    userId: 'user-uuid-1',
+    revokedAt: null,
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  });
+  vi.mocked(prisma.session.update).mockResolvedValue({});
+}
+
+describe('Session management', () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    vi.clearAllMocks();
+    mockSessionCreate();
+    mockActiveSession();
+  });
+
+  async function login() {
+    await mockExistingUser();
+    return request(app)
+      .post('/api/auth/login')
+      .set('User-Agent', 'Mozilla/5.0 (X11; Linux x86_64)')
+      .send(VALID_USER);
+  }
+
+  describe('GET /api/auth/sessions', () => {
+    it('lists active sessions for authenticated user', async () => {
+      const loginRes = await login();
+      const { accessToken } = loginRes.body;
+
+      vi.mocked(prisma.session.findMany).mockResolvedValue([
+        {
+          id: SESSION_ID,
+          device: 'Linux',
+          ipAddress: '192.168.1.10',
+          lastActiveAt: new Date(),
+          createdAt: new Date(),
+        },
+        {
+          id: 'session-uuid-2',
+          device: 'iPhone / iPad',
+          ipAddress: '10.0.0.5',
+          lastActiveAt: new Date(),
+          createdAt: new Date(),
+        },
+      ]);
+
+      const res = await request(app)
+        .get('/api/auth/sessions')
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.sessions).toHaveLength(2);
+      expect(res.body.sessions[0].current).toBe(true);
+      expect(res.body.sessions[1].current).toBe(false);
+    });
+
+    it('returns 401 without token', async () => {
+      const res = await request(app).get('/api/auth/sessions');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('DELETE /api/auth/sessions/:id', () => {
+    it('revokes a specific session', async () => {
+      const loginRes = await login();
+      const { accessToken } = loginRes.body;
+
+      vi.mocked(prisma.session.updateMany).mockResolvedValue({ count: 1 });
+
+      const res = await request(app)
+        .delete('/api/auth/sessions/session-uuid-2')
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toMatch(/revoked/i);
+    });
+
+    it('returns 404 for unknown session', async () => {
+      const loginRes = await login();
+      const { accessToken } = loginRes.body;
+
+      vi.mocked(prisma.session.updateMany).mockResolvedValue({ count: 0 });
+
+      const res = await request(app)
+        .delete('/api/auth/sessions/unknown-id')
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/auth/sessions', () => {
+    it('revokes all other sessions', async () => {
+      const loginRes = await login();
+      const { accessToken } = loginRes.body;
+
+      vi.mocked(prisma.session.updateMany).mockResolvedValue({ count: 2 });
+
+      const res = await request(app)
+        .delete('/api/auth/sessions')
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.revokedCount).toBe(2);
+    });
+  });
+
+  describe('POST /api/auth/login', () => {
+    it('creates a session with device and IP metadata', async () => {
+      await login();
+
+      expect(prisma.session.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: 'user-uuid-1',
+            device: 'Linux',
+            ipAddress: '192.168.1.10',
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/backend/tests/feeSurge.test.js
+++ b/backend/tests/feeSurge.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  recordFeeSample,
+  getSevenDayAverageFee,
+  detectFeeSurge,
+  resetFeeHistory,
+  setFeeHistory,
+  SURGE_THRESHOLD,
+} from '../src/services/feeSurge.js';
+
+describe('fee surge detection', () => {
+  beforeEach(() => {
+    resetFeeHistory();
+  });
+
+  describe('getSevenDayAverageFee', () => {
+    it('returns null when no samples exist', () => {
+      expect(getSevenDayAverageFee()).toBeNull();
+    });
+
+    it('computes average from recorded samples', () => {
+      recordFeeSample(100);
+      recordFeeSample(200);
+      recordFeeSample(300);
+      expect(getSevenDayAverageFee()).toBe(200);
+    });
+
+    it('excludes samples older than 7 days', () => {
+      const now = Date.now();
+      setFeeHistory([
+        { fee: 100, timestamp: now - 8 * 24 * 60 * 60 * 1000 },
+        { fee: 200, timestamp: now - 1 * 24 * 60 * 60 * 1000 },
+      ]);
+      expect(getSevenDayAverageFee()).toBe(200);
+    });
+  });
+
+  describe('detectFeeSurge', () => {
+    it('does not flag surge when fee is within threshold', () => {
+      const result = detectFeeSurge(400, 100);
+      expect(result.surge).toBe(false);
+      expect(result.ratio).toBe(4);
+    });
+
+    it('flags surge when current fee exceeds 5x average', () => {
+      const result = detectFeeSurge(600, 100);
+      expect(result.surge).toBe(true);
+      expect(result.ratio).toBe(6);
+      expect(result.threshold).toBe(SURGE_THRESHOLD);
+    });
+
+    it('does not flag surge when average is zero or missing', () => {
+      expect(detectFeeSurge(1000, 0).surge).toBe(false);
+      expect(detectFeeSurge(1000, null).surge).toBe(false);
+    });
+
+    it('respects custom threshold', () => {
+      const result = detectFeeSurge(300, 100, 2);
+      expect(result.surge).toBe(true);
+      expect(result.threshold).toBe(2);
+    });
+  });
+});

--- a/frontend/src/api/stellar.js
+++ b/frontend/src/api/stellar.js
@@ -23,7 +23,11 @@ export async function getAccountLabel(publicKey, options = {}) {
 }
 
 export async function updateAccountLabel(publicKey, accountLabel, options = {}) {
-  const response = await apiClient.put(`/api/stellar/account/${publicKey}/label`, { accountLabel }, options);
+  const response = await apiClient.put(
+    `/api/stellar/account/${publicKey}/label`,
+    { accountLabel },
+    options,
+  );
   return response.data;
 }
 
@@ -33,12 +37,15 @@ export async function sendPayment(payload, options = {}) {
 }
 
 export async function getNetworkStatus(options = {}) {
-  const response = await apiClient.get('/api/stellar/network/status', options);
+  const response = await apiClient.get('/api/stellar/network-status', options);
   return response.data;
 }
 
 export async function getTransactions(publicKey, params = {}, options = {}) {
-  const response = await apiClient.get(`/api/stellar/account/${publicKey}/transactions`, { params, ...options });
+  const response = await apiClient.get(`/api/stellar/account/${publicKey}/transactions`, {
+    params,
+    ...options,
+  });
   return response.data;
 }
 
@@ -73,7 +80,11 @@ export async function getAccountSettings(publicKey, options = {}) {
 }
 
 export async function updateAccountSettings(publicKey, settings, options = {}) {
-  const response = await apiClient.put(`/api/stellar/account/${publicKey}/settings`, settings, options);
+  const response = await apiClient.put(
+    `/api/stellar/account/${publicKey}/settings`,
+    settings,
+    options,
+  );
   return response.data;
 }
 
@@ -113,7 +124,11 @@ export async function getNotifications(options = {}) {
 }
 
 export async function markNotificationRead(notificationId, options = {}) {
-  const response = await apiClient.patch(`/api/notifications/${notificationId}/read`, null, options);
+  const response = await apiClient.patch(
+    `/api/notifications/${notificationId}/read`,
+    null,
+    options,
+  );
   return response.data;
 }
 
@@ -133,7 +148,10 @@ export async function createStreamPayment(payload, options = {}) {
 }
 
 export async function getStreamPayments(publicKey, options = {}) {
-  const response = await apiClient.get('/api/streaming', { params: { senderPublicKey: publicKey }, ...options });
+  const response = await apiClient.get('/api/streaming', {
+    params: { senderPublicKey: publicKey },
+    ...options,
+  });
   return response.data;
 }
 
@@ -143,7 +161,11 @@ export async function performStreamAction(id, action, options = {}) {
 }
 
 export async function retryTransaction(txHash, options = {}) {
-  const response = await apiClient.post('/api/retry/transaction', { transactionHash: txHash }, options);
+  const response = await apiClient.post(
+    '/api/retry/transaction',
+    { transactionHash: txHash },
+    options,
+  );
   return response.data;
 }
 
@@ -173,7 +195,11 @@ export async function deleteRecoveryContact(id, options = {}) {
 }
 
 export async function initiateRecovery(requestId, payload, options = {}) {
-  const response = await apiClient.post(`/api/recovery/${requestId}/verify-phrase`, payload, options);
+  const response = await apiClient.post(
+    `/api/recovery/${requestId}/verify-phrase`,
+    payload,
+    options,
+  );
   return response.data;
 }
 
@@ -227,7 +253,11 @@ export async function deleteContact(id, options = {}) {
 }
 
 export async function createTrustline(sourceSecret, assetCode, options = {}) {
-  const response = await apiClient.post('/api/stellar/trustline/create', { sourceSecret, assetCode }, options);
+  const response = await apiClient.post(
+    '/api/stellar/trustline/create',
+    { sourceSecret, assetCode },
+    options,
+  );
   return response.data;
 }
 

--- a/frontend/src/components/AccountSettings.jsx
+++ b/frontend/src/components/AccountSettings.jsx
@@ -18,24 +18,67 @@ export function AccountSettings({ publicKey, onClose }) {
   const [showMerge, setShowMerge] = useState(false);
   const [userRole, setUserRole] = useState(null);
   const [federationLocalPart, setFederationLocalPart] = useState('');
+  const [sessions, setSessions] = useState([]);
+  const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [sessionAction, setSessionAction] = useState('');
 
   useEffect(() => {
-    apiClient.get(`/api/stellar/account/${publicKey}/settings`)
+    apiClient
+      .get(`/api/stellar/account/${publicKey}/settings`)
       .then(({ data }) => {
         setSettings(data);
-        // Check if user has admin role from JWT token
-        const token = localStorage.getItem('authToken');
+        const token = localStorage.getItem('accessToken') || localStorage.getItem('authToken');
         if (token) {
           try {
             const payload = JSON.parse(atob(token.split('.')[1]));
             setUserRole(payload.role);
-          } catch (e) {
+          } catch {
             // Invalid token format
           }
         }
       })
-      .catch(e => setError(e?.response?.data?.error ?? e.message));
+      .catch((e) => setError(e?.response?.data?.error ?? e.message));
   }, [publicKey]);
+
+  const loadSessions = async () => {
+    setSessionsLoading(true);
+    try {
+      const { data } = await apiClient.get('/api/auth/sessions');
+      setSessions(data.sessions ?? []);
+    } catch (e) {
+      setError(e?.response?.data?.error ?? e.message);
+    } finally {
+      setSessionsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadSessions();
+  }, []);
+
+  const revokeSession = async (sessionId) => {
+    setSessionAction(sessionId);
+    try {
+      await apiClient.delete(`/api/auth/sessions/${sessionId}`);
+      await loadSessions();
+    } catch (e) {
+      setError(e?.response?.data?.error ?? e.message);
+    } finally {
+      setSessionAction('');
+    }
+  };
+
+  const revokeAllSessions = async () => {
+    setSessionAction('all');
+    try {
+      await apiClient.delete('/api/auth/sessions');
+      await loadSessions();
+    } catch (e) {
+      setError(e?.response?.data?.error ?? e.message);
+    } finally {
+      setSessionAction('');
+    }
+  };
 
   const save = async () => {
     setSaving(true);
@@ -50,7 +93,7 @@ export function AccountSettings({ publicKey, onClose }) {
         const { data } = await apiClient.put(`/api/stellar/federation/claim/${publicKey}`, {
           localPart: federationLocalPart.trim(),
         });
-        setSettings(s => ({ ...s, federationAddress: data.federationAddress }));
+        setSettings((s) => ({ ...s, federationAddress: data.federationAddress }));
       }
       setSaved(true);
     } catch (e) {
@@ -66,30 +109,52 @@ export function AccountSettings({ publicKey, onClose }) {
       role="dialog"
       aria-modal="true"
       aria-labelledby="settings-title"
-      onClick={e => e.target === e.currentTarget && onClose()}
+      onClick={(e) => e.target === e.currentTarget && onClose()}
     >
       <div className="replay-modal" style={{ maxWidth: 480, width: '100%' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-          <h2 id="settings-title" style={{ margin: 0 }}>Account Settings</h2>
-          <button type="button" className="qr-close" onClick={onClose} aria-label="Close settings">✕</button>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 16,
+          }}
+        >
+          <h2 id="settings-title" style={{ margin: 0 }}>
+            Account Settings
+          </h2>
+          <button type="button" className="qr-close" onClick={onClose} aria-label="Close settings">
+            ✕
+          </button>
         </div>
 
         {!settings && !error && <p>Loading…</p>}
-        {error && <p role="alert" style={{ color: '#ef4444' }}>{error}</p>}
+        {error && (
+          <p role="alert" style={{ color: '#ef4444' }}>
+            {error}
+          </p>
+        )}
 
         {settings && (
           <>
             <div style={{ marginBottom: 16 }}>
-              <label htmlFor="default-asset" style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>
+              <label
+                htmlFor="default-asset"
+                style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}
+              >
                 Default Asset
               </label>
               <select
                 id="default-asset"
                 value={settings.defaultAsset}
-                onChange={e => setSettings(s => ({ ...s, defaultAsset: e.target.value }))}
+                onChange={(e) => setSettings((s) => ({ ...s, defaultAsset: e.target.value }))}
                 aria-label="Default asset"
               >
-                {ASSETS.map(a => <option key={a} value={a}>{a}</option>)}
+                {ASSETS.map((a) => (
+                  <option key={a} value={a}>
+                    {a}
+                  </option>
+                ))}
               </select>
             </div>
 
@@ -98,7 +163,7 @@ export function AccountSettings({ publicKey, onClose }) {
                 id="notifications-toggle"
                 type="checkbox"
                 checked={settings.notificationsOn}
-                onChange={e => setSettings(s => ({ ...s, notificationsOn: e.target.checked }))}
+                onChange={(e) => setSettings((s) => ({ ...s, notificationsOn: e.target.checked }))}
                 style={{ width: 'auto', minHeight: 'unset' }}
               />
               <label htmlFor="notifications-toggle" style={{ fontWeight: 600, cursor: 'pointer' }}>
@@ -107,17 +172,26 @@ export function AccountSettings({ publicKey, onClose }) {
             </div>
 
             <div style={{ marginBottom: 16 }}>
-              <label htmlFor="federation-address" style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}>
+              <label
+                htmlFor="federation-address"
+                style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}
+              >
                 Federation Address
               </label>
               <input
                 id="federation-address"
                 value={federationLocalPart}
-                onChange={e => setFederationLocalPart(e.target.value)}
+                onChange={(e) => setFederationLocalPart(e.target.value)}
                 placeholder="alice"
                 aria-label="Claim federation address"
               />
-              <p style={{ margin: '4px 0 0', color: 'var(--text-muted, #64748b)', fontSize: '0.85rem' }}>
+              <p
+                style={{
+                  margin: '4px 0 0',
+                  color: 'var(--text-muted, #64748b)',
+                  fontSize: '0.85rem',
+                }}
+              >
                 {settings.federationAddress
                   ? `Current: ${settings.federationAddress}`
                   : 'Claim a human-readable address like alice*futureremit.app.'}
@@ -128,26 +202,132 @@ export function AccountSettings({ publicKey, onClose }) {
               <p style={{ fontWeight: 600, marginBottom: 4 }}>KYC Status</p>
               {settings.kycStatus ? (
                 <p style={{ margin: 0 }}>
-                  <span style={{
-                    background: settings.kycStatus === 'APPROVED' ? '#22c55e' : settings.kycStatus === 'REJECTED' ? '#ef4444' : '#f59e0b',
-                    color: '#fff', borderRadius: 4, padding: '2px 8px', fontSize: '0.8rem', fontWeight: 600,
-                  }}>
+                  <span
+                    style={{
+                      background:
+                        settings.kycStatus === 'APPROVED'
+                          ? '#22c55e'
+                          : settings.kycStatus === 'REJECTED'
+                            ? '#ef4444'
+                            : '#f59e0b',
+                      color: '#fff',
+                      borderRadius: 4,
+                      padding: '2px 8px',
+                      fontSize: '0.8rem',
+                      fontWeight: 600,
+                    }}
+                  >
                     {settings.kycStatus}
                   </span>
                   {settings.kycSubmittedAt && (
-                    <span style={{ marginLeft: 8, fontSize: '0.8rem', color: 'var(--text-muted, #64748b)' }}>
+                    <span
+                      style={{
+                        marginLeft: 8,
+                        fontSize: '0.8rem',
+                        color: 'var(--text-muted, #64748b)',
+                      }}
+                    >
                       Submitted {new Date(settings.kycSubmittedAt).toLocaleDateString()}
                     </span>
                   )}
                 </p>
               ) : (
-                <p style={{ margin: 0, color: 'var(--text-muted, #64748b)', fontSize: '0.9rem' }}>No KYC record on file.</p>
+                <p style={{ margin: 0, color: 'var(--text-muted, #64748b)', fontSize: '0.9rem' }}>
+                  No KYC record on file.
+                </p>
               )}
             </div>
 
             <div style={{ marginBottom: 16 }}>
               <p style={{ fontWeight: 600, marginBottom: 4 }}>Address Book</p>
               <AddressBook />
+            </div>
+
+            <div style={{ marginBottom: 16 }}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: 8,
+                }}
+              >
+                <p style={{ fontWeight: 600, margin: 0 }}>Active Sessions</p>
+                {sessions.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={revokeAllSessions}
+                    disabled={sessionAction === 'all'}
+                    style={{ fontSize: '0.8rem', padding: '4px 10px', background: '#ef4444' }}
+                  >
+                    {sessionAction === 'all' ? 'Revoking…' : 'Log out everywhere'}
+                  </button>
+                )}
+              </div>
+              {sessionsLoading ? (
+                <p style={{ margin: 0, color: 'var(--text-muted, #64748b)', fontSize: '0.9rem' }}>
+                  Loading sessions…
+                </p>
+              ) : sessions.length === 0 ? (
+                <p style={{ margin: 0, color: 'var(--text-muted, #64748b)', fontSize: '0.9rem' }}>
+                  No active sessions.
+                </p>
+              ) : (
+                <ul
+                  style={{
+                    listStyle: 'none',
+                    padding: 0,
+                    margin: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 8,
+                  }}
+                >
+                  {sessions.map((s) => (
+                    <li
+                      key={s.id}
+                      style={{
+                        background: 'var(--surface, #f8fafc)',
+                        borderRadius: 6,
+                        padding: '8px 12px',
+                        fontSize: '0.85rem',
+                        border: s.current ? '1px solid #22c55e' : '1px solid transparent',
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                        }}
+                      >
+                        <span>
+                          <strong>{s.device ?? 'Unknown device'}</strong>
+                          {s.current && (
+                            <span style={{ marginLeft: 6, color: '#22c55e', fontSize: '0.75rem' }}>
+                              (this device)
+                            </span>
+                          )}
+                        </span>
+                        {!s.current && (
+                          <button
+                            type="button"
+                            onClick={() => revokeSession(s.id)}
+                            disabled={sessionAction === s.id}
+                            style={{ fontSize: '0.75rem', padding: '2px 8px' }}
+                          >
+                            {sessionAction === s.id ? '…' : 'Revoke'}
+                          </button>
+                        )}
+                      </div>
+                      <div style={{ color: 'var(--text-muted, #64748b)', marginTop: 2 }}>
+                        {s.ipAddress && <span>{s.ipAddress} · </span>}
+                        Last active {new Date(s.lastActiveAt).toLocaleString()}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
 
             <div style={{ marginBottom: 16 }}>
@@ -162,7 +342,7 @@ export function AccountSettings({ publicKey, onClose }) {
               >
                 💾 Backup & Restore
               </button>
-              {userRole === 'admin' && (
+              {userRole === 'ADMIN' && (
                 <button
                   type="button"
                   onClick={() => setShowCompliance(true)}
@@ -184,8 +364,14 @@ export function AccountSettings({ publicKey, onClose }) {
               <button type="button" onClick={save} disabled={saving}>
                 {saving ? 'Saving…' : 'Save'}
               </button>
-              <button type="button" className="btn-clear" onClick={onClose}>Close</button>
-              {saved && <span role="status" style={{ color: '#22c55e', fontSize: '0.9rem' }}>Saved ✓</span>}
+              <button type="button" className="btn-clear" onClick={onClose}>
+                Close
+              </button>
+              {saved && (
+                <span role="status" style={{ color: '#22c55e', fontSize: '0.9rem' }}>
+                  Saved ✓
+                </span>
+              )}
             </div>
           </>
         )}

--- a/frontend/src/components/NetworkStatusBanner.jsx
+++ b/frontend/src/components/NetworkStatusBanner.jsx
@@ -1,44 +1,146 @@
 import { useState } from 'react';
 import { useNetworkStatus } from '../hooks/useNetworkStatus';
 
+const MAX_FEE_KEY = 'maxFeeStroops';
+
+function getMaxFeeStroops() {
+  const stored = localStorage.getItem(MAX_FEE_KEY);
+  return stored ? parseInt(stored, 10) : null;
+}
+
 /**
- * Dismissible banner shown when the Stellar network is offline or degraded.
- * Polls /api/stellar/network/status every 30 seconds via useNetworkStatus.
+ * Dismissible banner shown when the Stellar network is offline, degraded, or fees are surging.
+ * Polls /api/stellar/network-status every 30 seconds via useNetworkStatus.
  */
 export function NetworkStatusBanner() {
   const { status } = useNetworkStatus(30000);
   const [dismissed, setDismissed] = useState(false);
+  const [maxFeeInput, setMaxFeeInput] = useState(() => {
+    const stored = getMaxFeeStroops();
+    return stored ? String(stored) : '';
+  });
+  const [showFeeSettings, setShowFeeSettings] = useState(false);
 
-  if (!status || status.online !== false && status.status !== 'degraded') return null;
-  if (dismissed) return null;
+  if (!status) return null;
 
-  const isDegraded = status.status === 'degraded';
-  const message = isDegraded
-    ? 'The Stellar network is degraded. Transactions may be slow or fail.'
-    : 'The Stellar network is offline. Transactions may fail.';
+  const isOffline = status.online === false;
+  const isDegraded = status.status === 'degraded' && !status.feeSurge;
+  const isFeeSurge = status.feeSurge === true;
+  const maxFee = getMaxFeeStroops();
+  const feeExceedsMax = maxFee && status.feeStroops && status.feeStroops > maxFee;
+
+  const shouldShow = isOffline || isDegraded || isFeeSurge || feeExceedsMax;
+  if (!shouldShow || dismissed) return null;
+
+  let message;
+  let background = '#ef4444';
+
+  if (isOffline) {
+    message = 'The Stellar network is offline. Transactions may fail.';
+  } else if (isFeeSurge) {
+    const avg = status.sevenDayAverageFeeStroops
+      ? `${status.sevenDayAverageFeeStroops} stroops`
+      : 'the 7-day average';
+    message = `Network fees are unusually high (${status.feeSurgeRatio}x the average). Current fee: ${status.feeStroops} stroops vs avg ${avg}. Consider waiting for fees to normalise.`;
+    background = '#f59e0b';
+  } else if (feeExceedsMax) {
+    message = `Current network fee (${status.feeStroops} stroops) exceeds your maximum (${maxFee} stroops). Consider waiting or raising your limit.`;
+    background = '#f59e0b';
+  } else {
+    message = 'The Stellar network is degraded. Transactions may be slow or fail.';
+    background = '#f59e0b';
+  }
+
+  const saveMaxFee = () => {
+    const value = parseInt(maxFeeInput, 10);
+    if (value > 0) {
+      localStorage.setItem(MAX_FEE_KEY, String(value));
+    } else {
+      localStorage.removeItem(MAX_FEE_KEY);
+    }
+    setShowFeeSettings(false);
+  };
 
   return (
     <div
       role="alert"
       aria-live="assertive"
       style={{
-        background: isDegraded ? '#f59e0b' : '#ef4444',
+        background,
         color: '#fff',
         padding: '10px 16px',
         display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
+        flexDirection: 'column',
         gap: 8,
       }}
     >
-      <span>{message}</span>
-      <button
-        onClick={() => setDismissed(true)}
-        aria-label="Dismiss network status banner"
-        style={{ background: 'none', border: 'none', color: '#fff', cursor: 'pointer', fontSize: 18, lineHeight: 1 }}
+      <div
+        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}
       >
-        ✕
-      </button>
+        <span>{message}</span>
+        <button
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss network status banner"
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#fff',
+            cursor: 'pointer',
+            fontSize: 18,
+            lineHeight: 1,
+            flexShrink: 0,
+          }}
+        >
+          ✕
+        </button>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: '0.85rem' }}>
+        <button
+          type="button"
+          onClick={() => setShowFeeSettings((s) => !s)}
+          style={{
+            background: 'rgba(255,255,255,0.2)',
+            border: 'none',
+            color: '#fff',
+            cursor: 'pointer',
+            padding: '4px 10px',
+            borderRadius: 4,
+          }}
+        >
+          {showFeeSettings ? 'Hide fee limit' : 'Set max fee'}
+        </button>
+        {maxFee && !showFeeSettings && <span>Your max fee: {maxFee} stroops</span>}
+      </div>
+      {showFeeSettings && (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <label htmlFor="max-fee-input" style={{ fontSize: '0.85rem' }}>
+            Max fee (stroops):
+          </label>
+          <input
+            id="max-fee-input"
+            type="number"
+            min="100"
+            step="100"
+            value={maxFeeInput}
+            onChange={(e) => setMaxFeeInput(e.target.value)}
+            style={{ width: 120, padding: '4px 8px', borderRadius: 4, border: 'none' }}
+          />
+          <button
+            type="button"
+            onClick={saveMaxFee}
+            style={{
+              background: '#fff',
+              color: '#1e293b',
+              border: 'none',
+              padding: '4px 12px',
+              borderRadius: 4,
+              cursor: 'pointer',
+            }}
+          >
+            Save
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/StreamPayment.jsx
+++ b/frontend/src/components/StreamPayment.jsx
@@ -1,21 +1,52 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import apiClient from '../api/client.js';
 
 const STATUS_BADGE = {
-  ACTIVE:    { label: 'Active',    color: '#22c55e' },
-  PAUSED:    { label: 'Paused',    color: '#f59e0b' },
+  ACTIVE: { label: 'Active', color: '#22c55e' },
+  PAUSED: { label: 'Paused', color: '#f59e0b' },
   CANCELLED: { label: 'Cancelled', color: '#6b7280' },
   COMPLETED: { label: 'Completed', color: '#3b82f6' },
-  FAILED:    { label: 'Failed',    color: '#ef4444' },
+  FAILED: { label: 'Failed', color: '#ef4444' },
 };
+
+const INTERVAL_PRESETS = [
+  { label: 'Daily', days: 1 },
+  { label: 'Weekly', days: 7 },
+  { label: 'Monthly', days: 30 },
+];
 
 function StatusBadge({ status }) {
   const { label, color } = STATUS_BADGE[status] ?? { label: status, color: '#6b7280' };
   return (
-    <span style={{ background: color, color: '#fff', borderRadius: 4, padding: '1px 7px', fontSize: '0.75rem', fontWeight: 600 }}>
+    <span
+      style={{
+        background: color,
+        color: '#fff',
+        borderRadius: 4,
+        padding: '1px 7px',
+        fontSize: '0.75rem',
+        fontWeight: 600,
+      }}
+    >
       {label}
     </span>
   );
+}
+
+function computeStreamSummary(rateAmount, intervalDays, endDate) {
+  const rate = parseFloat(rateAmount);
+  const days = parseInt(intervalDays, 10);
+  if (!rate || !days || !endDate) return null;
+
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(endDate);
+  end.setHours(23, 59, 59, 999);
+  const totalDays = Math.max(0, Math.ceil((end - start) / (1000 * 60 * 60 * 24)));
+  const paymentCount = Math.floor(totalDays / days) + 1;
+  const totalXLM = (rate * paymentCount).toFixed(7).replace(/\.?0+$/, '');
+
+  return { totalXLM, totalDays, paymentCount };
 }
 
 export function StreamPayment({ publicKey }) {
@@ -24,14 +55,26 @@ export function StreamPayment({ publicKey }) {
   const [actionLoading, setActionLoading] = useState('');
   const [error, setError] = useState(null);
   const [showForm, setShowForm] = useState(false);
-  const [form, setForm] = useState({ recipientPublicKey: '', rateAmount: '', intervalSeconds: '60', endTime: '' });
+  const [form, setForm] = useState({
+    recipientPublicKey: '',
+    rateAmount: '',
+    intervalDays: '7',
+    endDate: '',
+  });
   const [formError, setFormError] = useState(null);
   const [creating, setCreating] = useState(false);
+
+  const summary = useMemo(
+    () => computeStreamSummary(form.rateAmount, form.intervalDays, form.endDate),
+    [form.rateAmount, form.intervalDays, form.endDate],
+  );
 
   const fetchStreams = useCallback(async () => {
     setLoadingStreams(true);
     try {
-      const { data } = await apiClient.get('/api/streaming', { params: { senderPublicKey: publicKey } });
+      const { data } = await apiClient.get('/api/streaming', {
+        params: { senderPublicKey: publicKey },
+      });
       setStreams(data);
     } catch (err) {
       setError(err?.response?.data?.error ?? err.message);
@@ -40,30 +83,41 @@ export function StreamPayment({ publicKey }) {
     }
   }, [publicKey]);
 
-  useEffect(() => { fetchStreams(); }, [fetchStreams]);
+  useEffect(() => {
+    fetchStreams();
+  }, [fetchStreams]);
 
   const handleCreate = async (e) => {
     e.preventDefault();
     setFormError(null);
     if (!form.recipientPublicKey || !form.rateAmount) {
-      setFormError('Recipient and rate are required.');
+      setFormError('Recipient and amount are required.');
+      return;
+    }
+    const senderSecret = localStorage.getItem('secretKey');
+    if (!senderSecret) {
+      setFormError('Account secret key not found. Please log in again.');
       return;
     }
     setCreating(true);
     try {
+      const intervalSeconds = parseInt(form.intervalDays, 10) * 24 * 60 * 60;
       await apiClient.post('/api/streaming', {
         senderPublicKey: publicKey,
+        senderSecret,
         recipientPublicKey: form.recipientPublicKey,
         rateAmount: parseFloat(form.rateAmount),
-        intervalSeconds: parseInt(form.intervalSeconds, 10),
+        intervalSeconds,
         assetCode: 'XLM',
-        endTime: form.endTime || undefined,
+        endTime: form.endDate ? new Date(form.endDate).toISOString() : undefined,
       });
-      setForm({ recipientPublicKey: '', rateAmount: '', intervalSeconds: '60', endTime: '' });
+      setForm({ recipientPublicKey: '', rateAmount: '', intervalDays: '7', endDate: '' });
       setShowForm(false);
       fetchStreams();
     } catch (err) {
-      setFormError(e?.response?.data?.error ?? e?.response?.data?.errors?.[0]?.msg ?? err.message);
+      setFormError(
+        err?.response?.data?.error ?? err?.response?.data?.errors?.[0]?.msg ?? err.message,
+      );
     } finally {
       setCreating(false);
     }
@@ -81,139 +135,271 @@ export function StreamPayment({ publicKey }) {
     }
   };
 
-  const set = (field) => (e) => setForm(f => ({ ...f, [field]: e.target.value }));
+  const set = (field) => (e) => setForm((f) => ({ ...f, [field]: e.target.value }));
+
+  const intervalLabel =
+    INTERVAL_PRESETS.find((p) => String(p.days) === form.intervalDays)?.label ??
+    `every ${form.intervalDays} days`;
 
   return (
     <section className="section" aria-labelledby="stream-heading">
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-        <h2 id="stream-heading" style={{ margin: 0 }}>Stream Payments</h2>
-        <button type="button" onClick={() => setShowForm(s => !s)} style={{ fontSize: '0.875rem' }}>
-          {showForm ? 'Cancel' : '+ New Stream'}
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 12,
+        }}
+      >
+        <h2 id="stream-heading" style={{ margin: 0 }}>
+          Recurring Payments
+        </h2>
+        <button
+          type="button"
+          onClick={() => setShowForm((s) => !s)}
+          style={{ fontSize: '0.875rem' }}
+        >
+          {showForm ? 'Cancel' : '+ New Standing Order'}
         </button>
       </div>
 
+      <p style={{ color: 'var(--muted)', fontSize: '0.875rem', marginTop: 0, marginBottom: 12 }}>
+        Set up automatic payments — like a standing order at your bank.
+      </p>
+
       {showForm && (
-        <form onSubmit={handleCreate} style={{ marginBottom: 16, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <form
+          onSubmit={handleCreate}
+          style={{
+            marginBottom: 16,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 12,
+            background: 'var(--surface)',
+            padding: 16,
+            borderRadius: 8,
+          }}
+        >
           <div className="input-wrap">
-            <label htmlFor="stream-recipient" className="sr-only">Recipient public key</label>
+            <label
+              htmlFor="stream-recipient"
+              style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}
+            >
+              Send to
+            </label>
             <input
               id="stream-recipient"
               type="text"
-              placeholder="Recipient Public Key"
+              placeholder="Recipient public key"
               value={form.recipientPublicKey}
               onChange={set('recipientPublicKey')}
               autoComplete="off"
               required
             />
           </div>
-          <div style={{ display: 'flex', gap: 8 }}>
-            <div className="input-wrap" style={{ flex: 1 }}>
-              <label htmlFor="stream-rate" className="sr-only">Rate per interval (XLM)</label>
+
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'flex-end' }}>
+            <div className="input-wrap" style={{ flex: '1 1 120px' }}>
+              <label
+                htmlFor="stream-rate"
+                style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}
+              >
+                Amount (XLM)
+              </label>
               <input
                 id="stream-rate"
                 type="number"
                 min="0.0000001"
                 step="any"
-                placeholder="Rate (XLM / interval)"
+                placeholder="10"
                 value={form.rateAmount}
                 onChange={set('rateAmount')}
                 required
               />
             </div>
-            <div className="input-wrap" style={{ flex: 1 }}>
-              <label htmlFor="stream-interval" className="sr-only">Interval in seconds</label>
-              <input
-                id="stream-interval"
-                type="number"
-                min="10"
-                step="1"
-                placeholder="Interval (seconds)"
-                value={form.intervalSeconds}
-                onChange={set('intervalSeconds')}
-              />
+            <span style={{ padding: '8px 0', fontWeight: 600, color: 'var(--muted)' }}>every</span>
+            <div className="input-wrap" style={{ flex: '1 1 140px' }}>
+              <label
+                htmlFor="stream-interval"
+                style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}
+              >
+                Frequency
+              </label>
+              <select id="stream-interval" value={form.intervalDays} onChange={set('intervalDays')}>
+                {INTERVAL_PRESETS.map((p) => (
+                  <option key={p.days} value={String(p.days)}>
+                    {p.label}
+                  </option>
+                ))}
+              </select>
             </div>
           </div>
+
+          <p style={{ margin: 0, fontSize: '0.9rem', color: 'var(--text-muted, #64748b)' }}>
+            Send <strong>{form.rateAmount || '—'} XLM</strong> {intervalLabel.toLowerCase()}
+          </p>
+
           <div className="input-wrap">
-            <label htmlFor="stream-end" className="sr-only">End date (optional)</label>
+            <label
+              htmlFor="stream-end"
+              style={{ display: 'block', marginBottom: 4, fontWeight: 600 }}
+            >
+              End date
+            </label>
             <input
               id="stream-end"
-              type="datetime-local"
-              value={form.endTime}
-              onChange={set('endTime')}
-              aria-label="Stream end date (optional)"
+              type="date"
+              value={form.endDate}
+              onChange={set('endDate')}
+              min={new Date().toISOString().split('T')[0]}
+              aria-label="Standing order end date"
             />
           </div>
-          {formError && <p className="field-error" role="alert">{formError}</p>}
+
+          {summary && (
+            <div
+              role="status"
+              style={{
+                background: '#eff6ff',
+                border: '1px solid #bfdbfe',
+                borderRadius: 6,
+                padding: '10px 14px',
+                fontSize: '0.9rem',
+              }}
+            >
+              <strong>Summary:</strong> Total to be sent: <strong>{summary.totalXLM} XLM</strong>{' '}
+              over <strong>{summary.totalDays} days</strong> ({summary.paymentCount} payments)
+            </div>
+          )}
+
+          {formError && (
+            <p className="field-error" role="alert">
+              {formError}
+            </p>
+          )}
           <button type="submit" disabled={creating} aria-busy={creating}>
-            {creating ? 'Creating…' : 'Create Stream'}
+            {creating ? 'Setting up…' : 'Set Up Standing Order'}
           </button>
         </form>
       )}
 
-      {error && <p className="field-error" role="alert">{error}</p>}
+      {error && (
+        <p className="field-error" role="alert">
+          {error}
+        </p>
+      )}
 
       {loadingStreams ? (
-        <p style={{ color: 'var(--muted)', fontSize: '0.875rem' }}>Loading streams…</p>
+        <p style={{ color: 'var(--muted)', fontSize: '0.875rem' }}>Loading standing orders…</p>
       ) : streams.length === 0 ? (
-        <p style={{ color: 'var(--muted)', fontSize: '0.875rem' }}>No streams yet.</p>
+        <p style={{ color: 'var(--muted)', fontSize: '0.875rem' }}>No recurring payments yet.</p>
       ) : (
-        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {streams.map(s => (
-            <li key={s.id} style={{ background: 'var(--surface)', borderRadius: 8, padding: '10px 14px' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
-                <span style={{ fontSize: '0.75rem', color: 'var(--muted)', fontFamily: 'monospace' }}>
-                  → {s.recipient?.publicKey?.slice(0, 8)}…{s.recipient?.publicKey?.slice(-4)}
-                </span>
-                <StatusBadge status={s.status} />
-              </div>
-              <div style={{ fontSize: '0.875rem', marginBottom: 6 }}>
-                <strong>{s.rateAmount} {s.assetCode}</strong> every {s.intervalSeconds}s
-                {s.endTime && <span style={{ color: 'var(--muted)' }}> · ends {new Date(s.endTime).toLocaleDateString()}</span>}
-              </div>
-              <div style={{ fontSize: '0.8rem', color: 'var(--muted)', marginBottom: 8 }}>
-                Streamed: <strong>{parseFloat(s.totalStreamed).toFixed(7)} {s.assetCode}</strong>
-              </div>
-              <div style={{ display: 'flex', gap: 6 }}>
-                {s.status === 'ACTIVE' && (
-                  <button
-                    type="button"
-                    className="btn-clear"
-                    style={{ fontSize: '0.8rem', padding: '3px 10px' }}
-                    onClick={() => streamAction(s.id, 'pause')}
-                    disabled={actionLoading === `${s.id}-pause`}
-                    aria-label={`Pause stream to ${s.recipient?.publicKey?.slice(0, 8)}`}
+        <ul
+          style={{
+            listStyle: 'none',
+            padding: 0,
+            margin: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+          }}
+        >
+          {streams.map((s) => {
+            const days = Math.round(s.intervalSeconds / (24 * 60 * 60));
+            return (
+              <li
+                key={s.id}
+                style={{ background: 'var(--surface)', borderRadius: 8, padding: '10px 14px' }}
+              >
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    marginBottom: 4,
+                  }}
+                >
+                  <span
+                    style={{ fontSize: '0.75rem', color: 'var(--muted)', fontFamily: 'monospace' }}
                   >
-                    {actionLoading === `${s.id}-pause` ? '…' : 'Pause'}
-                  </button>
-                )}
-                {s.status === 'PAUSED' && (
-                  <button
-                    type="button"
-                    style={{ fontSize: '0.8rem', padding: '3px 10px' }}
-                    onClick={() => streamAction(s.id, 'resume')}
-                    disabled={actionLoading === `${s.id}-resume`}
-                    aria-label={`Resume stream to ${s.recipient?.publicKey?.slice(0, 8)}`}
-                  >
-                    {actionLoading === `${s.id}-resume` ? '…' : 'Resume'}
-                  </button>
-                )}
-                {(s.status === 'ACTIVE' || s.status === 'PAUSED') && (
-                  <button
-                    type="button"
-                    className="btn-clear"
-                    style={{ fontSize: '0.8rem', padding: '3px 10px', background: '#ef4444', color: '#fff' }}
-                    onClick={() => streamAction(s.id, 'cancel')}
-                    disabled={actionLoading === `${s.id}-cancel`}
-                    aria-label={`Cancel stream to ${s.recipient?.publicKey?.slice(0, 8)}`}
-                  >
-                    {actionLoading === `${s.id}-cancel` ? '…' : 'Cancel'}
-                  </button>
-                )}
-              </div>
-            </li>
-          ))}
+                    → {s.recipient?.publicKey?.slice(0, 8)}…{s.recipient?.publicKey?.slice(-4)}
+                  </span>
+                  <StatusBadge status={s.status} />
+                </div>
+                <div style={{ fontSize: '0.875rem', marginBottom: 6 }}>
+                  Send{' '}
+                  <strong>
+                    {s.rateAmount} {s.assetCode}
+                  </strong>{' '}
+                  every{' '}
+                  <strong>
+                    {days || 1} day{days !== 1 ? 's' : ''}
+                  </strong>
+                  {s.endTime && (
+                    <span style={{ color: 'var(--muted)' }}>
+                      {' '}
+                      · until {new Date(s.endTime).toLocaleDateString()}
+                    </span>
+                  )}
+                </div>
+                <div style={{ fontSize: '0.8rem', color: 'var(--muted)', marginBottom: 8 }}>
+                  Sent so far:{' '}
+                  <strong>
+                    {parseFloat(s.totalStreamed).toFixed(7)} {s.assetCode}
+                  </strong>
+                  {s.nextPaymentAt && s.status === 'ACTIVE' && (
+                    <span> · Next: {new Date(s.nextPaymentAt).toLocaleDateString()}</span>
+                  )}
+                </div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  {s.status === 'ACTIVE' && (
+                    <button
+                      type="button"
+                      className="btn-clear"
+                      style={{ fontSize: '0.8rem', padding: '3px 10px' }}
+                      onClick={() => streamAction(s.id, 'pause')}
+                      disabled={actionLoading === `${s.id}-pause`}
+                      aria-label={`Pause recurring payment to ${s.recipient?.publicKey?.slice(0, 8)}`}
+                    >
+                      {actionLoading === `${s.id}-pause` ? '…' : 'Pause'}
+                    </button>
+                  )}
+                  {s.status === 'PAUSED' && (
+                    <button
+                      type="button"
+                      style={{ fontSize: '0.8rem', padding: '3px 10px' }}
+                      onClick={() => streamAction(s.id, 'resume')}
+                      disabled={actionLoading === `${s.id}-resume`}
+                      aria-label={`Resume recurring payment to ${s.recipient?.publicKey?.slice(0, 8)}`}
+                    >
+                      {actionLoading === `${s.id}-resume` ? '…' : 'Resume'}
+                    </button>
+                  )}
+                  {(s.status === 'ACTIVE' || s.status === 'PAUSED') && (
+                    <button
+                      type="button"
+                      className="btn-clear"
+                      style={{
+                        fontSize: '0.8rem',
+                        padding: '3px 10px',
+                        background: '#ef4444',
+                        color: '#fff',
+                      }}
+                      onClick={() => streamAction(s.id, 'cancel')}
+                      disabled={actionLoading === `${s.id}-cancel`}
+                      aria-label={`Cancel recurring payment to ${s.recipient?.publicKey?.slice(0, 8)}`}
+                    >
+                      {actionLoading === `${s.id}-cancel` ? '…' : 'Cancel'}
+                    </button>
+                  )}
+                </div>
+              </li>
+            );
+          })}
         </ul>
       )}
     </section>
   );
 }
+
+export { computeStreamSummary };

--- a/frontend/tests/StreamPayment.test.jsx
+++ b/frontend/tests/StreamPayment.test.jsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { StreamPayment, computeStreamSummary } from '../src/components/StreamPayment';
+
+vi.mock('../src/api/client.js', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+import apiClient from '../src/api/client.js';
+
+const PUBLIC_KEY = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZWM9CQJHD9QDNHXHXN';
+
+describe('computeStreamSummary', () => {
+  it('returns null when inputs are incomplete', () => {
+    expect(computeStreamSummary('', '7', '2026-12-31')).toBeNull();
+    expect(computeStreamSummary('10', '', '2026-12-31')).toBeNull();
+    expect(computeStreamSummary('10', '7', '')).toBeNull();
+  });
+
+  it('calculates total XLM and payment count', () => {
+    const end = new Date();
+    end.setDate(end.getDate() + 28);
+    const endDate = end.toISOString().split('T')[0];
+    const summary = computeStreamSummary('10', '7', endDate);
+    expect(summary).not.toBeNull();
+    expect(summary.paymentCount).toBeGreaterThanOrEqual(4);
+    expect(parseFloat(summary.totalXLM)).toBeGreaterThan(0);
+    expect(summary.totalDays).toBeGreaterThanOrEqual(28);
+  });
+});
+
+describe('StreamPayment form', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiClient.get.mockResolvedValue({ data: [] });
+    localStorage.setItem('secretKey', 'SSECRETKEY123');
+  });
+
+  it('renders standing order form with plain-language labels', async () => {
+    render(<StreamPayment publicKey={PUBLIC_KEY} />);
+    fireEvent.click(screen.getByRole('button', { name: /new standing order/i }));
+
+    expect(screen.getByLabelText(/send to/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/amount \(xlm\)/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/frequency/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+    expect(screen.getByText(/send.*weekly/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /set up standing order/i })).toBeInTheDocument();
+  });
+
+  it('shows summary when amount, frequency, and end date are set', async () => {
+    render(<StreamPayment publicKey={PUBLIC_KEY} />);
+    fireEvent.click(screen.getByRole('button', { name: /new standing order/i }));
+
+    fireEvent.change(screen.getByLabelText(/amount \(xlm\)/i), { target: { value: '5' } });
+    const end = new Date();
+    end.setDate(end.getDate() + 14);
+    fireEvent.change(screen.getByLabelText(/end date/i), {
+      target: { value: end.toISOString().split('T')[0] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/total to be sent/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('status')).toHaveTextContent(/15 XLM/);
+  });
+
+  it('submits stream creation with interval and end date', async () => {
+    apiClient.post.mockResolvedValue({ data: { id: 'stream-1' } });
+    render(<StreamPayment publicKey={PUBLIC_KEY} />);
+    fireEvent.click(screen.getByRole('button', { name: /new standing order/i }));
+
+    fireEvent.change(screen.getByLabelText(/send to/i), {
+      target: { value: 'GRECIP1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ' },
+    });
+    fireEvent.change(screen.getByLabelText(/amount \(xlm\)/i), { target: { value: '10' } });
+    const end = new Date();
+    end.setDate(end.getDate() + 7);
+    const endDate = end.toISOString().split('T')[0];
+    fireEvent.change(screen.getByLabelText(/end date/i), { target: { value: endDate } });
+
+    fireEvent.click(screen.getByRole('button', { name: /set up standing order/i }));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/api/streaming',
+        expect.objectContaining({
+          senderPublicKey: PUBLIC_KEY,
+          recipientPublicKey: 'GRECIP1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          rateAmount: 10,
+          intervalSeconds: 7 * 24 * 60 * 60,
+          assetCode: 'XLM',
+          endTime: expect.any(String),
+        }),
+      );
+    });
+  });
+
+  it('shows pause and cancel buttons for active streams', async () => {
+    apiClient.get.mockResolvedValue({
+      data: [
+        {
+          id: 'stream-1',
+          rateAmount: '10',
+          assetCode: 'XLM',
+          intervalSeconds: 7 * 24 * 60 * 60,
+          status: 'ACTIVE',
+          totalStreamed: '20',
+          recipient: { publicKey: 'GRECIP1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ' },
+        },
+      ],
+    });
+    render(<StreamPayment publicKey={PUBLIC_KEY} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /pause/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds three security and UX improvements to the FuTuRe remittance platform:

1. **Session management** — Users can view all active login sessions (device, IP, last active) and revoke individual sessions or log out everywhere. Sessions are stored in the database and validated on every authenticated request via a `sid` JWT claim.

2. **Stellar fee surge detection** — The backend compares the current network base fee against a 7-day rolling average. When fees exceed 5× the average, the frontend shows a warning banner. Users can also set a personal maximum fee they're willing to pay.

3. **Recurring payments UX** — The streaming payment UI is redesigned with bank-style "standing order" language ("Send X XLM every Y days"), a calendar end-date picker, a total-cost summary, and Pause/Cancel controls on active streams.

## Changes

### Backend
- **`prisma/schema.prisma`** — Added `Session` model; fixed duplicate `User` model fields; linked `sessions`, `mfaSettings`, and `recoveryCodes` relations.
- **`auth/sessionStore.js`** (new) — Session CRUD: create on login, list active, revoke one/all, touch `lastActiveAt` on use.
- **`routes/auth.js`** — Session endpoints; login/logout/refresh now create and validate sessions; `sid` included in JWT payload.
- **`middleware/auth.js`** — Rejects requests when session is revoked or expired.
- **`services/feeSurge.js`** (new) — Rolling 7-day fee average and surge detection (default threshold: 5×).
- **`services/stellarNetwork.js`** — `getNetworkStatusWithFeeSurge()` enriches network status with fee data and surge flag.
- **`routes/stellar/index.js`** — `GET /api/stellar/network-status` endpoint.

### Frontend
- **`AccountSettings.jsx`** — Active sessions panel with per-session revoke and "Log out everywhere".
- **`NetworkStatusBanner.jsx`** — Fee surge warning, max-fee limit setting, dismissible alert.
- **`StreamPayment.jsx`** — Standing-order form with frequency presets, end-date picker, cost summary, Pause/Cancel/Resume on streams.
- **`api/stellar.js`** — Points `getNetworkStatus()` at `/api/stellar/network-status`.

### Tests
- `backend/tests/auth.sessions.test.js` — Session listing, revocation, login metadata.
- `backend/tests/feeSurge.test.js` — Average calculation, surge threshold, sample expiry.
- `frontend/tests/StreamPayment.test.jsx` — Form labels, summary math, submission payload, pause/cancel buttons.

## Test plan

- [ ] Log in from two browsers; confirm both sessions appear in Account Settings with correct device/IP.
- [ ] Revoke the other session; confirm it can no longer refresh its token.
- [ ] Click "Log out everywhere"; confirm other sessions are revoked while current session stays active.
- [ ] Hit `GET /api/stellar/network-status`; confirm `feeStroops`, `feeSurge`, and `feeSurgeRatio` fields are present.
- [ ] Set a low max fee in the network banner; confirm warning when current fee exceeds it.
- [ ] Create a standing order with end date; confirm summary shows correct total XLM and payment count.
- [ ] Pause and cancel an active stream; confirm status updates in the list.
- [ ] Run `npx vitest run backend/tests/auth.sessions.test.js backend/tests/feeSurge.test.js frontend/tests/StreamPayment.test.jsx` — all 19 tests should pass.

## Notes

- Task 1 and Task 4 in the issue tracker are duplicates; both are covered by the session management work above.
- Session migration: run `npx prisma migrate dev` to apply the new `Session` table before deploying.
- Max fee preference is stored in `localStorage` (`maxFeeStroops` key) on the client.

closes #577 
closes #578 
closes #580 
closes #582