### PR TITLE
feat: password-reset rate limiting, ARIA labels, form label associations, keyboard navigation

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -66,6 +66,32 @@ const authRateLimiter = createRateLimiter({
   message: 'Too many login attempts, please try again later.',
 });
 
+// Per-IP rate limit for password reset (10 req/hour)
+const passwordResetIpLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+  message: 'Too many requests',
+});
+
+// Per-email rate limit store (3 req/hour per email)
+const passwordResetEmailStore = new Map();
+
+function checkEmailRateLimit(email) {
+  const now = Date.now();
+  const windowMs = 60 * 60 * 1000;
+  const max = 3;
+  const entry = passwordResetEmailStore.get(email) || { count: 0, resetAt: now + windowMs };
+  if (now > entry.resetAt) {
+    entry.count = 0;
+    entry.resetAt = now + windowMs;
+  }
+  entry.count += 1;
+  passwordResetEmailStore.set(email, entry);
+  return entry.count <= max;
+}
+
+const RESET_TOKEN_TTL_MS = 15 * 60 * 1000;
+
 const validateBody = (req, res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty())
@@ -1389,5 +1415,89 @@ router.post('/resend-verification', requireAuth, async (req, res) => {
     sendError(res, 500, ErrorCodes.INTERNAL_ERROR, 'Failed to resend verification email');
   }
 });
+
+// ── Password Reset ─────────────────────────────────────────────────────────────
+
+router.post(
+  '/password-reset',
+  passwordResetIpLimiter,
+  [body('email').isEmail().normalizeEmail()],
+  validateBody,
+  async (req, res) => {
+    const { email } = req.body;
+    // Enforce minimum response time to prevent timing-based enumeration
+    const minDelay = new Promise((r) => setTimeout(r, 200));
+
+    const withinEmailLimit = checkEmailRateLimit(email);
+
+    try {
+      if (withinEmailLimit) {
+        const user = await prisma.user.findFirst({
+          where: { OR: [{ username: email }, { email }] },
+        });
+
+        if (user) {
+          // Invalidate any previous unexpired tokens for this email
+          await prisma.user.updateMany({
+            where: { id: user.id, passwordResetExpires: { gt: new Date() } },
+            data: { passwordResetToken: null, passwordResetExpires: null },
+          });
+
+          const token = randomBytes(32).toString('hex');
+          await prisma.user.update({
+            where: { id: user.id },
+            data: {
+              passwordResetToken: token,
+              passwordResetExpires: new Date(Date.now() + RESET_TOKEN_TTL_MS),
+            },
+          });
+
+          const baseUrl = getConfig().server?.baseUrl || process.env.BASE_URL || 'http://localhost:3001';
+          await sendEmail(email, {
+            subject: 'Reset your password',
+            body: `Reset your password: ${baseUrl}/reset-password?token=${token}\nExpires in 15 minutes.`,
+          }).catch(() => {});
+        }
+      }
+
+      await minDelay;
+      // Always return the same response regardless of whether the email exists or rate limit triggered
+      res.json({ message: 'If that email is registered, a reset link has been sent.' });
+    } catch (error) {
+      await minDelay;
+      logger.error({ err: error }, 'password-reset failed');
+      res.json({ message: 'If that email is registered, a reset link has been sent.' });
+    }
+  },
+);
+
+router.post(
+  '/password-reset/confirm',
+  [body('token').notEmpty().isString(), body('password').isLength({ min: 8 })],
+  validateBody,
+  async (req, res) => {
+    const { token, password } = req.body;
+    try {
+      const user = await prisma.user.findFirst({
+        where: { passwordResetToken: token, passwordResetExpires: { gt: new Date() } },
+      });
+
+      if (!user) {
+        return sendError(res, 400, ErrorCodes.VALIDATION_INVALID_INPUT, 'Invalid or expired token');
+      }
+
+      const passwordHash = await hashPassword(password);
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { passwordHash, passwordResetToken: null, passwordResetExpires: null },
+      });
+
+      res.json({ message: 'Password updated successfully' });
+    } catch (error) {
+      logger.error({ err: error }, 'password-reset/confirm failed');
+      sendError(res, 500, ErrorCodes.INTERNAL_ERROR, 'Failed to reset password');
+    }
+  },
+);
 
 export default router;

--- a/frontend/src/components/AddressBook.jsx
+++ b/frontend/src/components/AddressBook.jsx
@@ -69,7 +69,10 @@ export function AddressBook({ onSelect, prefillAddress = '' }) {
             style={{ overflow: 'hidden' }}
           >
             <div style={panelStyle}>
+              <label htmlFor="addr-book-search" className="sr-only">Search contacts</label>
               <input
+                id="addr-book-search"
+                aria-label="Search contacts"
                 placeholder="Search contacts…"
                 value={search}
                 onChange={e => setSearch(e.target.value)}
@@ -89,14 +92,16 @@ export function AddressBook({ onSelect, prefillAddress = '' }) {
                   <button type="button" onClick={() => { onSelect?.(c.address); setOpen(false); }} style={smBtn}>
                     Use
                   </button>
-                  <button type="button" onClick={() => remove(c)} style={{ ...smBtn, background: '#ef4444' }}>
+                  <button type="button" onClick={() => remove(c)} style={{ ...smBtn, background: '#ef4444' }} aria-label={`Remove ${c.name}`}>
                     ✕
                   </button>
                 </div>
               ))}
               <div style={{ borderTop: '1px solid #eee', paddingTop: 8, marginTop: 8 }}>
-                <input placeholder="Name" value={newName} onChange={e => setNewName(e.target.value)} style={{ marginBottom: 6 }} />
-                <input placeholder="Stellar Address" value={newAddress} onChange={e => setNewAddress(e.target.value)} style={{ marginBottom: 6 }} />
+                <label htmlFor="addr-book-new-name" className="sr-only">Contact name</label>
+                <input id="addr-book-new-name" aria-label="Contact name" placeholder="Name" value={newName} onChange={e => setNewName(e.target.value)} style={{ marginBottom: 6 }} />
+                <label htmlFor="addr-book-new-address" className="sr-only">Stellar address</label>
+                <input id="addr-book-new-address" aria-label="Stellar address" placeholder="Stellar Address" value={newAddress} onChange={e => setNewAddress(e.target.value)} style={{ marginBottom: 6 }} />
                 <button type="button" onClick={add}>+ Add Contact</button>
               </div>
             </div>

--- a/frontend/src/components/AdvancedSearch.jsx
+++ b/frontend/src/components/AdvancedSearch.jsx
@@ -68,7 +68,9 @@ export default function AdvancedSearch({ onSearch, onSaveSearch, savedSearches =
 
       <div className="search-form">
         <div className="search-input-wrapper">
+          <label htmlFor="adv-search-query" className="sr-only">Search transactions</label>
           <input
+            id="adv-search-query"
             type="text"
             placeholder="Search transactions..."
             value={searchCriteria.query}
@@ -95,7 +97,10 @@ export default function AdvancedSearch({ onSearch, onSaveSearch, savedSearches =
         </div>
 
         <div className="filter-row">
+          <label htmlFor="adv-search-type" className="sr-only">Transaction type</label>
           <select
+            id="adv-search-type"
+            aria-label="Transaction type"
             value={searchCriteria.type}
             onChange={(e) => setSearchCriteria({ ...searchCriteria, type: e.target.value })}
           >
@@ -105,7 +110,10 @@ export default function AdvancedSearch({ onSearch, onSaveSearch, savedSearches =
             <option value="path_payment">Path Payment</option>
           </select>
 
+          <label htmlFor="adv-search-status" className="sr-only">Transaction status</label>
           <select
+            id="adv-search-status"
+            aria-label="Transaction status"
             value={searchCriteria.status}
             onChange={(e) => setSearchCriteria({ ...searchCriteria, status: e.target.value })}
           >
@@ -118,15 +126,19 @@ export default function AdvancedSearch({ onSearch, onSaveSearch, savedSearches =
 
         <div className="filter-row">
           <div className="date-range">
-            <label>From:</label>
+            <label htmlFor="adv-search-date-from">From:</label>
             <input
+              id="adv-search-date-from"
               type="date"
+              aria-label="Filter from date"
               value={searchCriteria.dateFrom}
               onChange={(e) => setSearchCriteria({ ...searchCriteria, dateFrom: e.target.value })}
             />
-            <label>To:</label>
+            <label htmlFor="adv-search-date-to">To:</label>
             <input
+              id="adv-search-date-to"
               type="date"
+              aria-label="Filter to date"
               value={searchCriteria.dateTo}
               onChange={(e) => setSearchCriteria({ ...searchCriteria, dateTo: e.target.value })}
             />
@@ -135,17 +147,22 @@ export default function AdvancedSearch({ onSearch, onSaveSearch, savedSearches =
 
         <div className="filter-row">
           <div className="amount-range">
-            <label>Amount:</label>
+            <label htmlFor="adv-search-amount-min">Amount:</label>
             <input
+              id="adv-search-amount-min"
               type="number"
               placeholder="Min"
+              aria-label="Minimum amount"
               value={searchCriteria.amountMin}
               onChange={(e) => setSearchCriteria({ ...searchCriteria, amountMin: e.target.value })}
             />
-            <span>-</span>
+            <span aria-hidden="true">-</span>
+            <label htmlFor="adv-search-amount-max" className="sr-only">Maximum amount</label>
             <input
+              id="adv-search-amount-max"
               type="number"
               placeholder="Max"
+              aria-label="Maximum amount"
               value={searchCriteria.amountMax}
               onChange={(e) => setSearchCriteria({ ...searchCriteria, amountMax: e.target.value })}
             />
@@ -153,9 +170,12 @@ export default function AdvancedSearch({ onSearch, onSaveSearch, savedSearches =
         </div>
 
         <div className="filter-row">
+          <label htmlFor="adv-search-address" className="sr-only">Filter by address</label>
           <input
+            id="adv-search-address"
             type="text"
             placeholder="Filter by address..."
+            aria-label="Filter by address"
             value={searchCriteria.address}
             onChange={(e) => setSearchCriteria({ ...searchCriteria, address: e.target.value })}
           />

--- a/frontend/src/components/FormField.jsx
+++ b/frontend/src/components/FormField.jsx
@@ -1,18 +1,37 @@
 import { AnimatePresence, motion } from 'framer-motion';
+import { Children, cloneElement, useId } from 'react';
 
 /**
  * FormField — labelled input wrapper with validation state.
- * Props: label, error, touched, children
+ * Props: label, error, touched, children, required
+ * Automatically associates the label with the child input via htmlFor/id.
  */
 export function FormField({ label, error, touched, children, required }) {
+  const autoId = useId();
+
+  const child =
+    label && Children.count(children) === 1
+      ? cloneElement(Children.only(children), {
+          id: Children.only(children).props?.id ?? autoId,
+        })
+      : children;
+
+  const inputId =
+    label && Children.count(children) === 1
+      ? (Children.only(children).props?.id ?? autoId)
+      : undefined;
+
   return (
     <div style={{ marginBottom: 12 }}>
       {label && (
-        <label style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 4, color: '#555' }}>
+        <label
+          htmlFor={inputId}
+          style={{ display: 'block', fontSize: 13, fontWeight: 600, marginBottom: 4, color: '#555' }}
+        >
           {label}{required && <span style={{ color: '#ef4444', marginLeft: 2 }}>*</span>}
         </label>
       )}
-      {children}
+      {child}
       <AnimatePresence>
         {touched && error && (
           <motion.p

--- a/frontend/src/components/SearchableSelect.jsx
+++ b/frontend/src/components/SearchableSelect.jsx
@@ -1,15 +1,18 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useId } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 
 /**
  * SearchableSelect — searchable dropdown for asset/option selection.
- * Props: value, onChange, options ([{ value, label, description? }]), placeholder
+ * Props: value, onChange, options ([{ value, label, description? }]), placeholder, aria-label
  */
-export function SearchableSelect({ value, onChange, options = [], placeholder = 'Select…' }) {
+export function SearchableSelect({ value, onChange, options = [], placeholder = 'Select…', 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledby }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(-1);
   const ref = useRef(null);
   const inputRef = useRef(null);
+  const listboxId = useId();
+  const getOptionId = (index) => `${listboxId}-option-${index}`;
 
   const filtered = options.filter(o =>
     o.label.toLowerCase().includes(query.toLowerCase()) ||
@@ -24,10 +27,16 @@ export function SearchableSelect({ value, onChange, options = [], placeholder = 
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
+  // Reset active index when dropdown opens or query changes
+  useEffect(() => {
+    setActiveIndex(filtered.length > 0 ? 0 : -1);
+  }, [open, query]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const pick = (opt) => {
     onChange?.(opt.value);
     setOpen(false);
     setQuery('');
+    inputRef.current?.blur();
   };
 
   const openDropdown = () => {
@@ -35,19 +44,75 @@ export function SearchableSelect({ value, onChange, options = [], placeholder = 
     setTimeout(() => inputRef.current?.focus(), 50);
   };
 
+  const handleKeyDown = (e) => {
+    if (!open) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openDropdown();
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex(i => Math.min(i + 1, filtered.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        if (activeIndex <= 0) {
+          setOpen(false);
+          inputRef.current?.blur();
+        } else {
+          setActiveIndex(i => i - 1);
+        }
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(filtered.length - 1);
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (activeIndex >= 0 && filtered[activeIndex]) {
+          pick(filtered[activeIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        setQuery('');
+        break;
+      case 'Tab':
+        setOpen(false);
+        setQuery('');
+        break;
+    }
+  };
+
   return (
     <div ref={ref} style={{ position: 'relative' }}>
       <button
         type="button"
         onClick={openDropdown}
+        onKeyDown={handleKeyDown}
         style={triggerStyle}
+        role="combobox"
         aria-haspopup="listbox"
         aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-activedescendant={open && activeIndex >= 0 ? getOptionId(activeIndex) : undefined}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledby}
+        aria-autocomplete="list"
       >
         <span style={{ flex: 1, textAlign: 'left', color: selected ? '#333' : '#999' }}>
           {selected ? selected.label : placeholder}
         </span>
-        <span style={{ color: '#888', fontSize: 12 }}>{open ? '▲' : '▼'}</span>
+        <span style={{ color: '#888', fontSize: 12 }} aria-hidden="true">{open ? '▲' : '▼'}</span>
       </button>
       <AnimatePresence>
         {open && (
@@ -59,25 +124,43 @@ export function SearchableSelect({ value, onChange, options = [], placeholder = 
             style={dropdownStyle}
           >
             <div style={{ padding: '6px 8px', borderBottom: '1px solid #eee' }}>
+              <label htmlFor={`${listboxId}-search`} className="sr-only">Search options</label>
               <input
                 ref={inputRef}
+                id={`${listboxId}-search`}
                 value={query}
-                onChange={e => setQuery(e.target.value)}
+                onChange={e => { setQuery(e.target.value); setActiveIndex(0); }}
+                onKeyDown={handleKeyDown}
                 placeholder="Search…"
+                aria-label="Search options"
+                aria-controls={listboxId}
+                aria-autocomplete="list"
                 style={{ margin: 0, fontSize: 13, minHeight: 'unset', padding: '6px 8px' }}
               />
             </div>
-            <ul role="listbox" style={{ listStyle: 'none', margin: 0, padding: 0, maxHeight: 180, overflowY: 'auto' }}>
+            <ul
+              id={listboxId}
+              role="listbox"
+              aria-label={ariaLabel || placeholder}
+              style={{ listStyle: 'none', margin: 0, padding: 0, maxHeight: 180, overflowY: 'auto' }}
+            >
               {filtered.length === 0 && (
-                <li style={{ padding: '10px 12px', fontSize: 13, color: '#888' }}>No results</li>
+                <li role="option" aria-selected={false} aria-disabled="true" style={{ padding: '10px 12px', fontSize: 13, color: '#888' }}>No results</li>
               )}
-              {filtered.map(opt => (
+              {filtered.map((opt, index) => (
                 <li
                   key={opt.value}
+                  id={getOptionId(index)}
                   role="option"
                   aria-selected={opt.value === value}
                   onMouseDown={() => pick(opt)}
-                  style={{ ...itemStyle, background: opt.value === value ? '#e8f0fe' : 'white' }}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  style={{
+                    ...itemStyle,
+                    background: index === activeIndex ? '#dbeafe' : opt.value === value ? '#e8f0fe' : 'white',
+                    outline: index === activeIndex ? '2px solid #2563eb' : 'none',
+                    outlineOffset: -2,
+                  }}
                 >
                   <span style={{ fontWeight: 600 }}>{opt.label}</span>
                   {opt.description && <span style={{ fontSize: 12, color: '#888', marginLeft: 6 }}>{opt.description}</span>}

--- a/frontend/src/pages/AccountDashboardPage.jsx
+++ b/frontend/src/pages/AccountDashboardPage.jsx
@@ -91,8 +91,11 @@ export function AccountDashboardPage() {
           <label style={{ display: 'block', fontSize: 12, color: '#666', marginBottom: 4 }}>Label</label>
           {editingLabel ? (
             <div style={{ display: 'flex', gap: 8 }}>
+              <label htmlFor="account-label-edit" className="sr-only">Account label</label>
               <input
+                id="account-label-edit"
                 type="text"
+                aria-label="Account label"
                 value={labelDraft}
                 onChange={(e) => setLabelDraft(e.target.value)}
                 style={{ flex: 1, padding: '8px 12px', border: '1px solid #d1d5db', borderRadius: 4 }}


### PR DESCRIPTION
## Summary

- **Closes #735** — Added `POST /auth/password-reset` with per-IP (10 req/hr) and per-email (3 req/hr) rate limits, a 200ms minimum response delay to prevent timing-based enumeration, previous-token invalidation, 15-min token TTL, and an identical response body regardless of whether the email is registered. Also adds `/auth/password-reset/confirm` to complete the flow.
- **Closes #736** — Added `aria-label` to the icon-only ✕ remove-contact button in `AddressBook.jsx`. Confirmed all other icon-only buttons (QR close, copy, notification bell, settings gear) already carried labels.
- **Closes #737** — Updated `FormField.jsx` to use React `useId` + `cloneElement` to automatically inject `id` into child inputs and wire `htmlFor` on the wrapping `<label>`, fixing label associations for every `FormField` usage (KYCForm, NotificationPreferences, etc.). Also added explicit `id`/`aria-label` to all unlabeled inputs in `AdvancedSearch`, `AddressBook`, and the account-label edit field in `AccountDashboardPage`.
- **Closes #738** — Rewrote `SearchableSelect.jsx` with the ARIA combobox pattern: `role="combobox"`, `aria-expanded`, `aria-controls`, `aria-activedescendant`, `role="listbox"`, `role="option"`. Keyboard support: `ArrowDown`/`ArrowUp` to move highlight, `Home`/`End` for first/last, `Enter` to select, `Escape` to dismiss, `Tab` to close. Visual highlight tracks active index.

## Test plan

- [ ] `POST /auth/password-reset` with the same email 4+ times within an hour returns 429 after the 3rd call, but the response body matches the success body
- [ ] 11+ requests from the same IP within an hour result in 429
- [ ] Timing: even for unknown emails the response takes ≥200ms
- [ ] `FormField`-wrapped inputs are announced with their label in a screen reader or axe audit
- [ ] `SearchableSelect` can be fully operated with keyboard alone (open → navigate → select → close)
- [ ] `AddressBook` remove buttons announce "Remove [name]" to a screen reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)