### PR TITLE
feat: accessibility improvements — skip link, WCAG AA dark mode contrast, focus rings, ARIA live regions

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1268,39 +1268,41 @@ function App() {
                     >
                       {loading === 'balance' ? 'Checking Balance…' : 'Check Balance'}
                     </motion.button>
-                    <AnimatePresence mode="wait">
-                      {loading === 'balance' ? (
-                        <SkeletonBalance key="loading-balance" />
-                      ) : balance ? (
-                        <motion.div
-                          key="balance-list"
-                          variants={v.pop}
-                          initial="hidden"
-                          animate="visible"
-                          exit="exit"
-                          style={{ marginTop: 10 }}
-                          aria-label="Account balances"
-                          role="list"
-                        >
-                          {balance.balances.map((b, i) => (
-                            <motion.p
-                              key={i}
-                              variants={v.fadeSlide}
-                              className="balance-row"
-                              role="listitem"
-                            >
-                              <span className="balance-asset">
-                                {b.asset}
-                                {b.asset === 'XLM' && <XLMInfoIcon />}
-                              </span>
-                              <span className="balance-amount">
-                                {formatBalanceWithAsset(b.balance, b.asset)}
-                              </span>
-                            </motion.p>
-                          ))}
-                        </motion.div>
-                      ) : null}
-                    </AnimatePresence>
+                    <div role="status" aria-label="Account balance" aria-live="polite" aria-atomic="false">
+                      <AnimatePresence mode="wait">
+                        {loading === 'balance' ? (
+                          <SkeletonBalance key="loading-balance" />
+                        ) : balance ? (
+                          <motion.div
+                            key="balance-list"
+                            variants={v.pop}
+                            initial="hidden"
+                            animate="visible"
+                            exit="exit"
+                            style={{ marginTop: 10 }}
+                            aria-label="Account balances"
+                            role="list"
+                          >
+                            {balance.balances.map((b, i) => (
+                              <motion.p
+                                key={i}
+                                variants={v.fadeSlide}
+                                className="balance-row"
+                                role="listitem"
+                              >
+                                <span className="balance-asset">
+                                  {b.asset}
+                                  {b.asset === 'XLM' && <XLMInfoIcon />}
+                                </span>
+                                <span className="balance-amount">
+                                  {formatBalanceWithAsset(b.balance, b.asset)}
+                                </span>
+                              </motion.p>
+                            ))}
+                          </motion.div>
+                        ) : null}
+                      </AnimatePresence>
+                    </div>
                   </motion.section>
 
                   {/* Send Payment */}

--- a/frontend/src/components/StatusMessage.jsx
+++ b/frontend/src/components/StatusMessage.jsx
@@ -9,13 +9,14 @@ const VARIANTS = {
 };
 
 function Message({ msg, onRemove, onRetry }) {
+  const isUrgent = msg.type === 'error' || msg.type === 'warning';
   return (
     <motion.div
       className={`sm-item sm-${msg.type}`}
       variants={VARIANTS}
       initial="hidden" animate="visible" exit="exit"
       layout
-      role="alert"
+      role={isUrgent ? 'alert' : 'status'}
       aria-atomic="true"
     >
       <span className="sm-icon" aria-hidden="true">{msg.icon}</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,7 +35,7 @@
     top: -100%;
     left: 0;
     background: var(--primary);
-    color: #fff;
+    color: var(--on-primary);
     padding: 8px 16px;
     font-weight: 600;
     z-index: 10000;
@@ -58,6 +58,11 @@
   --info: #0369a1;
   --link: #0b69d7;
   --shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+
+  /* ── Focus ring tokens (issue #741) ─────────────────────────────────────── */
+  --focus-ring-color: #2563eb;
+  --focus-ring-width: 2px;
+  --focus-ring-offset: 2px;
 }
 
 .theme-dark {
@@ -81,6 +86,8 @@
   --ws-disconnected: #f87171;
   --ws-reconnecting: #fbbf24;
   --ws-failed: #a78bfa;
+  /* Focus ring: #93c5fd on dark bg (#020617) → 11.4:1, passes WCAG AA */
+  --focus-ring-color: #93c5fd;
 }
 
 * {
@@ -217,7 +224,8 @@ input {
 }
 
 input:focus-visible {
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 0;
   border-color: var(--primary);
 }
 
@@ -489,7 +497,7 @@ select {
 
 .qr-pubkey {
   font-size: 10px;
-  color: #666;
+  color: var(--muted);
   word-break: break-all;
   text-align: center;
   max-width: 220px;
@@ -677,7 +685,7 @@ select {
 .sm-history-toggle {
   background: none;
   border: none;
-  color: #666;
+  color: var(--muted);
   font-size: 12px;
   cursor: pointer;
   padding: 4px 0;
@@ -1023,7 +1031,7 @@ select {
 }
 .balance-asset {
   font-weight: 600;
-  color: #555;
+  color: var(--muted);
 }
 .balance-amount {
   font-variant-numeric: tabular-nums;
@@ -1526,7 +1534,10 @@ kbd {
   transition:
     border-color 0.2s,
     background 0.2s;
-  outline: none;
+}
+.fu-dropzone:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 .fu-dropzone:hover,
 .fu-dropzone:focus-visible {


### PR DESCRIPTION
## Summary

Closes #739 
closes #740 
closes #741 
closes #742 

Implements all four Stellar Wave accessibility issues in a single PR.

---

## #739 — Skip-to-main-content link

The skip link (`<a href="#main-content" className="skip-link">`) was already rendered as the first DOM element in `App.jsx`, and `<main id="main-content">` was already in place. This PR fixes the skip link's `color` from the hardcoded `#fff` to `var(--on-primary)` so it remains WCAG-compliant in dark mode (`#0f172a` on `#60a5fa` → 7.3:1 ✓).

---

## #740 — WCAG AA colour contrast in dark mode

**Audit of `.theme-dark` CSS custom property pairs:**

| Pair | Contrast | Pass? |
|------|----------|-------|
| `--text` (#e2e8f0) on `--bg` (#020617) | 16.4:1 | ✓ AA |
| `--muted` (#94a3b8) on `--bg` (#020617) | 8.3:1 | ✓ AA |
| `--muted` (#94a3b8) on `--surface` (#111827) | 6.7:1 | ✓ AA |
| `--muted` (#94a3b8) on `--card` (#1f2937) | 5.3:1 | ✓ AA |
| `--primary` (#60a5fa) on `--bg` (#020617) | 8.8:1 | ✓ AA |
| `--on-primary` (#0f172a) on `--primary` (#60a5fa) | 7.3:1 | ✓ AA |
| `--danger` (#f87171) on `--bg` (#020617) | 7.6:1 | ✓ AA |
| `--danger` (#f87171) on `--card` (#1f2937) | 4.83:1 | ✓ AA |
| `--success` (#34d399) on `--bg` (#020617) | 10.7:1 | ✓ AA |
| `--warning` (#fbbf24) on `--bg` (#020617) | 12.3:1 | ✓ AA |
| `--info` (#38bdf8) on `--bg` (#020617) | 9.6:1 | ✓ AA |
| `--link` (#93c5fd) on `--bg` (#020617) | 11.4:1 | ✓ AA |

**Fixes for hardcoded colours that failed in dark mode:**

| Element | Before | After | Contrast on dark bg |
|---------|--------|-------|---------------------|
| `.balance-asset` | `#555` (3.0:1 ✗) | `var(--muted)` | 8.3:1 ✓ |
| `.qr-pubkey` | `#666` (3.8:1 ✗) | `var(--muted)` | 8.3:1 ✓ |
| `.sm-history-toggle` | `#666` (3.8:1 ✗) | `var(--muted)` | 8.3:1 ✓ |

---

## #741 — Focus-visible ring on all interactive elements

- Added focus ring CSS custom properties to `:root`: `--focus-ring-color: #2563eb`, `--focus-ring-width: 2px`, `--focus-ring-offset: 2px`
- Added dark mode override: `--focus-ring-color: #93c5fd` (11.4:1 on `#020617` ✓)
- **Fixed `input:focus-visible`**: was `outline: none` — now `outline: var(--focus-ring-width) solid var(--focus-ring-color)` while keeping `border-color` change
- **Fixed `.fu-dropzone`**: removed `outline: none` from the base rule; added explicit `.fu-dropzone:focus-visible` rule using ring tokens
- Global `:focus-visible` rule already applied `3px solid var(--primary)` to all other interactive elements

---

## #742 — ARIA live regions for async status updates

- **Balance updates**: wrapped balance `AnimatePresence` in `<div role="status" aria-live="polite">` so screen readers announce new balance values after transactions complete
- **StatusMessage roles**: changed `Message` component to use `role="alert"` (assertive) for `error`/`warning` types and `role="status"` (polite) for `success`/`info` — prevents disruptive interruptions for non-urgent notifications
- **Loading state**: `<div aria-live="polite" aria-atomic="true" className="sr-only">` was already present in `App.jsx`, announcing "Sending payment…", "Checking balance…", etc.
- **`aria-busy`**: already set on Create, Balance, and Send buttons

## Test plan

- [ ] Tab to the page — first focused element should be "Skip to main content"; pressing Enter should move focus to `<main>`
- [ ] Toggle dark mode; check `.balance-asset`, QR modal, and message history toggle text are readable
- [ ] Tab through all interactive elements in dark and light mode — every element should show a visible focus ring
- [ ] Submit a payment; verify screen reader announces "Sending payment…" (polite), then success/error message
- [ ] On payment success, the toast should be announced politely; on payment error, immediately (assertive)
- [ ] After checking balance, the new balance values should be announced

