### PR TITLE
test: add e2e pagination, property-based, and mutation CI tests

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'frontend/src/utils/**'
       - 'frontend/tests/**'
+      - 'backend/src/services/**'
   pull_request:
     branches: [main, master]
     paths:
       - 'frontend/src/utils/**'
       - 'frontend/tests/**'
+      - 'backend/src/services/**'
   # Allow manual trigger
   workflow_dispatch:
 
@@ -32,8 +34,6 @@ jobs:
 
       - name: Run mutation tests
         run: npm run test:mutation
-        # Don't fail the job on Stryker threshold — tracker handles that
-        continue-on-error: true
 
       - name: Track score & detect regressions
         run: npm run test:mutation:track

--- a/e2e/tests/transaction-history.spec.js
+++ b/e2e/tests/transaction-history.spec.js
@@ -1,0 +1,208 @@
+/**
+ * Transaction History E2E Tests
+ *
+ * Covers: initial page load, cursor-based pagination, final page, empty state,
+ * and error state. API responses are mocked via Playwright route interception.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const PUBLIC_KEY = 'GBVIZQO6KGDPNQT5SFABR3YWILZQBIBOVP3LBXCM5UQATX6I7FVZPQ';
+const PAGE_SIZE = 20;
+
+function makeTx(index) {
+  return {
+    id: `tx-${index}`,
+    hash: `a${String(index).padStart(63, '0')}`,
+    type: 'payment',
+    direction: index % 2 === 0 ? 'sent' : 'received',
+    amount: `${index + 1}.0000000`,
+    asset: 'XLM',
+    counterparty: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGQKN24S3B43U2TC8NRTY1',
+    date: new Date(2025, 0, 1 + (index % 28)).toISOString(),
+    fee: '100',
+    successful: true,
+    memo: null,
+  };
+}
+
+function makePageData(start, count, nextCursor = null) {
+  return {
+    records: Array.from({ length: count }, (_, i) => makeTx(start + i)),
+    nextCursor,
+  };
+}
+
+// Seed the app state so we bypass the login form entirely.
+async function seedAccountState(page) {
+  await page.context().addInitScript((key) => {
+    localStorage.setItem(key, JSON.stringify({
+      _version: 1,
+      account: { publicKey: 'GBVIZQO6KGDPNQT5SFABR3YWILZQBIBOVP3LBXCM5UQATX6I7FVZPQ' },
+      accountLabel: 'Test Account',
+    }));
+  }, 'app_state_v2');
+}
+
+// Mock both internal API endpoints the component calls inside fetchPage.
+// The second route (/api/stellar/…) sets the final rendered list; the first
+// (/api/v1/…) drives the hasMore flag. Both must be consistent.
+async function mockTransactionRoutes(page, { page1, page2, page3 } = {}) {
+  let callCount = 0;
+
+  await page.route('**/api/v1/transactions/**', (route) => {
+    callCount++;
+    const page = callCount <= 1 ? page1 : callCount === 2 ? page2 : (page3 ?? page2);
+    route.fulfill({ json: page ?? makePageData(0, PAGE_SIZE, 'cursor1') });
+  });
+
+  let apiCallCount = 0;
+  await page.route('**/api/stellar/account/**/transactions', (route) => {
+    apiCallCount++;
+    const data = apiCallCount <= 1 ? page1 : apiCallCount === 2 ? page2 : (page3 ?? page2);
+    route.fulfill({ json: data ?? makePageData(0, PAGE_SIZE, 'cursor1') });
+  });
+}
+
+test.describe('Transaction History @pagination', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedAccountState(page);
+    await page.goto('/');
+  });
+
+  test('displays first page of transactions after clicking Load History', async ({ page }) => {
+    const p1 = makePageData(0, PAGE_SIZE, 'cursor1');
+    await page.route('**/api/v1/transactions/**', route => route.fulfill({ json: p1 }));
+    await page.route('**/api/stellar/account/**/transactions', route => route.fulfill({ json: p1 }));
+
+    await page.getByRole('button', { name: /load.*history/i }).click();
+
+    const rows = page.locator('.tx-row');
+    await expect(rows).toHaveCount(PAGE_SIZE);
+
+    // Each row shows type, amount, and asset
+    const firstRow = rows.first();
+    await expect(firstRow).toContainText('Payment');
+    await expect(firstRow).toContainText('XLM');
+
+    // No duplicate IDs — every row label should be unique
+    const labels = await rows.evaluateAll(els =>
+      els.map(el => el.getAttribute('aria-label'))
+    );
+    const unique = new Set(labels);
+    expect(unique.size).toBe(PAGE_SIZE);
+  });
+
+  test('loads next page on Next click and previous page on Back click', async ({ page }) => {
+    const p1 = makePageData(0, PAGE_SIZE, 'cursor1');
+    const p2 = makePageData(PAGE_SIZE, PAGE_SIZE, 'cursor2');
+
+    let callCount = 0;
+    await page.route('**/api/v1/transactions/**', route => {
+      callCount++;
+      route.fulfill({ json: callCount === 1 ? p1 : p2 });
+    });
+    let apiCount = 0;
+    await page.route('**/api/stellar/account/**/transactions', route => {
+      apiCount++;
+      route.fulfill({ json: apiCount === 1 ? p1 : p2 });
+    });
+
+    // Load page 1
+    await page.getByRole('button', { name: /load.*history/i }).click();
+    await expect(page.locator('.tx-row')).toHaveCount(PAGE_SIZE);
+
+    const firstPageFirstLabel = await page.locator('.tx-row').first().getAttribute('aria-label');
+
+    // Navigate to page 2
+    await page.getByRole('button', { name: /next/i }).click();
+    await expect(page.locator('.tx-row')).toHaveCount(PAGE_SIZE);
+
+    // Rows should be different from page 1
+    const secondPageFirstLabel = await page.locator('.tx-row').first().getAttribute('aria-label');
+    expect(secondPageFirstLabel).not.toBe(firstPageFirstLabel);
+
+    // Back button becomes active after advancing
+    const prevBtn = page.getByRole('button', { name: /prev/i });
+    await expect(prevBtn).not.toBeDisabled();
+  });
+
+  test('disables Next button on the final page', async ({ page }) => {
+    // Final page returns fewer records than PAGE_SIZE and no nextCursor
+    const finalPage = makePageData(40, 7, null);
+
+    await page.route('**/api/v1/transactions/**', route => route.fulfill({ json: finalPage }));
+    await page.route('**/api/stellar/account/**/transactions', route => route.fulfill({ json: finalPage }));
+
+    await page.getByRole('button', { name: /load.*history/i }).click();
+    await expect(page.locator('.tx-row')).toHaveCount(7);
+
+    await expect(page.getByRole('button', { name: /next/i })).toBeDisabled();
+  });
+
+  test('shows empty state when API returns zero transactions', async ({ page }) => {
+    const empty = { records: [], nextCursor: null };
+
+    await page.route('**/api/v1/transactions/**', route => route.fulfill({ json: empty }));
+    await page.route('**/api/stellar/account/**/transactions', route => route.fulfill({ json: empty }));
+
+    await page.getByRole('button', { name: /load.*history/i }).click();
+
+    await expect(page.locator('.tx-empty')).toBeVisible();
+    await expect(page.locator('.tx-row')).toHaveCount(0);
+
+    // No loading spinner remains
+    await expect(page.locator('[aria-busy="true"]')).toHaveCount(0);
+  });
+
+  test('shows error message and retry button on API failure', async ({ page }) => {
+    await page.route('**/api/v1/transactions/**', route => route.fulfill({ status: 503, json: {} }));
+    await page.route('**/api/stellar/account/**/transactions', route => route.fulfill({ status: 503, json: {} }));
+
+    await page.getByRole('button', { name: /load.*history/i }).click();
+
+    await expect(page.locator('.tx-error')).toBeVisible();
+    // Retry button is present
+    await expect(page.locator('.tx-error').getByRole('button')).toBeVisible();
+  });
+
+  test('pagination continuity — no duplicate transaction IDs across three pages', async ({ page }) => {
+    const pages = [
+      makePageData(0, PAGE_SIZE, 'cursor1'),
+      makePageData(PAGE_SIZE, PAGE_SIZE, 'cursor2'),
+      makePageData(PAGE_SIZE * 2, PAGE_SIZE, null),
+    ];
+
+    let v1Call = 0;
+    await page.route('**/api/v1/transactions/**', route => {
+      route.fulfill({ json: pages[Math.min(v1Call++, pages.length - 1)] });
+    });
+    let apiCall = 0;
+    await page.route('**/api/stellar/account/**/transactions', route => {
+      route.fulfill({ json: pages[Math.min(apiCall++, pages.length - 1)] });
+    });
+
+    const seenIds = new Set();
+
+    await page.getByRole('button', { name: /load.*history/i }).click();
+    await expect(page.locator('.tx-row')).toHaveCount(PAGE_SIZE);
+
+    const collectIds = async () => {
+      const labels = await page.locator('.tx-row').evaluateAll(els =>
+        els.map(el => el.getAttribute('aria-label'))
+      );
+      labels.forEach(l => seenIds.add(l));
+    };
+
+    await collectIds();
+    await page.getByRole('button', { name: /next/i }).click();
+    await expect(page.locator('.tx-row')).toHaveCount(PAGE_SIZE);
+    await collectIds();
+    await page.getByRole('button', { name: /next/i }).click();
+    await expect(page.locator('.tx-row')).toHaveCount(PAGE_SIZE);
+    await collectIds();
+
+    // All 60 rows across 3 pages must be unique
+    expect(seenIds.size).toBe(PAGE_SIZE * 3);
+  });
+});

--- a/property-tests/amountInput.property.test.js
+++ b/property-tests/amountInput.property.test.js
@@ -1,0 +1,219 @@
+/**
+ * Property-based tests for AmountInput validation behaviour.
+ *
+ * Tests the sanitization logic used by AmountInput.jsx and the display
+ * formatting rules that enforce Stellar's 7-decimal-place precision limit.
+ *
+ * Run with:  npm run test:property
+ * To see shrunk counter-examples add --reporter=verbose
+ */
+
+import * as fc from 'fast-check';
+import { describe, it, expect } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Pure functions mirrored from AmountInput.jsx
+// ---------------------------------------------------------------------------
+
+/** Strips non-numeric / non-period characters and collapses multiple dots. */
+function sanitize(raw) {
+  return raw.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');
+}
+
+/**
+ * Formats a numeric string the way AmountInput renders it when unfocused.
+ * Returns undefined / empty if value is falsy.
+ */
+function formatDisplay(value) {
+  if (!value) return value;
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 7,
+    useGrouping: false,
+  }).format(Number(value));
+}
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+const NUM_RUNS = 1000;
+
+/** Generates strings that contain only digits and at most one '.'. */
+const validDecimalString = fc.oneof(
+  fc.nat().map(String),
+  fc.tuple(fc.nat(), fc.nat({ max: 9_999_999 })).map(([i, d]) => `${i}.${d}`),
+);
+
+/** Generates valid Stellar amounts: non-negative, ≤ 7 decimal places, within max. */
+const STELLAR_MAX = 922337203685;
+const stellarAmount = fc.integer({ min: 0, max: STELLAR_MAX * 10_000_000 }).map(stroops => {
+  const whole = Math.floor(stroops / 10_000_000);
+  const frac = stroops % 10_000_000;
+  return frac === 0 ? String(whole) : `${whole}.${String(frac).padStart(7, '0')}`;
+});
+
+/** Generates strings that contain at least one character outside [0-9.]. */
+const stringWithInvalidChars = fc.tuple(
+  fc.string({ minLength: 0, maxLength: 10 }),
+  fc.stringMatching(/[^0-9.]/),
+  fc.string({ minLength: 0, maxLength: 10 }),
+).map(([a, bad, b]) => a + bad + b);
+
+/** Generates strings with two or more '.' characters. */
+const multiDotString = fc.tuple(
+  fc.nat().map(String),
+  fc.nat().map(String),
+  fc.nat().map(String),
+).map(([a, b, c]) => `${a}.${b}.${c}`);
+
+/** Generates negative number strings. */
+const negativeString = fc.integer({ min: 1 }).map(n => `-${n}`);
+
+// ---------------------------------------------------------------------------
+// sanitize() properties
+// ---------------------------------------------------------------------------
+
+describe('AmountInput — sanitize() properties', () => {
+  it('strings containing only digits and at most one dot are returned unchanged', () => {
+    fc.assert(
+      fc.property(validDecimalString, (s) => {
+        expect(sanitize(s)).toBe(s);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('output never contains characters outside [0-9.]', () => {
+    fc.assert(
+      fc.property(fc.string(), (s) => {
+        expect(sanitize(s)).toMatch(/^[0-9.]*$/);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('non-numeric characters (excluding ".") are always stripped', () => {
+    fc.assert(
+      fc.property(stringWithInvalidChars, (s) => {
+        const result = sanitize(s);
+        // No characters from the complement of [0-9.] survive
+        expect(/[^0-9.]/.test(result)).toBe(false);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('negative sign is stripped — negative amounts are not accepted', () => {
+    fc.assert(
+      fc.property(negativeString, (s) => {
+        const result = sanitize(s);
+        expect(result.startsWith('-')).toBe(false);
+        // The digit portion is preserved
+        expect(result).toBe(s.slice(1));
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('multiple decimal points are collapsed to a single separator', () => {
+    fc.assert(
+      fc.property(multiDotString, (s) => {
+        const result = sanitize(s);
+        const dotCount = (result.match(/\./g) ?? []).length;
+        expect(dotCount).toBeLessThanOrEqual(1);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('empty string sanitizes to empty string', () => {
+    expect(sanitize('')).toBe('');
+  });
+
+  it('digits before a second dot are not lost when multiple dots appear', () => {
+    fc.assert(
+      fc.property(multiDotString, (s) => {
+        const result = sanitize(s);
+        const digits = s.replace(/[^0-9]/g, '');
+        const resultDigits = result.replace(/[^0-9]/g, '');
+        // All original digits survive
+        expect(resultDigits).toBe(digits);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatDisplay() properties — enforces Stellar 7 d.p. display limit
+// ---------------------------------------------------------------------------
+
+describe('AmountInput — formatDisplay() properties', () => {
+  it('valid Stellar amounts display with at most 7 decimal places', () => {
+    fc.assert(
+      fc.property(stellarAmount, (s) => {
+        const display = formatDisplay(s);
+        const decimalPart = display?.split('.')[1] ?? '';
+        expect(decimalPart.length).toBeLessThanOrEqual(7);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('integer amounts display without a decimal point', () => {
+    fc.assert(
+      fc.property(fc.nat({ max: STELLAR_MAX }).map(String), (s) => {
+        const display = formatDisplay(s);
+        expect(display).not.toContain('.');
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('displaying a valid amount then parsing it back yields the same numeric value', () => {
+    fc.assert(
+      fc.property(stellarAmount, (s) => {
+        const display = formatDisplay(s);
+        expect(Number(display)).toBeCloseTo(Number(s), 7);
+      }),
+      { numRuns: NUM_RUNS },
+    );
+  });
+
+  it('falsy values are returned as-is without throwing', () => {
+    for (const v of ['', null, undefined, '0']) {
+      expect(() => formatDisplay(v)).not.toThrow();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stellar-specific boundary properties
+// ---------------------------------------------------------------------------
+
+describe('AmountInput — Stellar boundary properties', () => {
+  it('sanitize does not reject the Stellar maximum amount string', () => {
+    const maxStr = '922337203685.4775807';
+    expect(sanitize(maxStr)).toBe(maxStr);
+  });
+
+  it('sanitize does not reject zero', () => {
+    expect(sanitize('0')).toBe('0');
+    expect(sanitize('0.0000000')).toBe('0.0000000');
+  });
+
+  it('strings in scientific notation have the "e" character stripped', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 999 }).map(n => `${n}e${Math.floor(Math.random() * 5) + 1}`),
+        (s) => {
+          const result = sanitize(s);
+          expect(result).not.toContain('e');
+          expect(result).not.toContain('E');
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -16,6 +16,15 @@ export default {
     configFile: 'vitest.mutation.config.js',
   },
   coverageAnalysis: 'perTest',
+  // Thresholds rationale:
+  //   break: 50 — CI hard-fails below 50%; at this level more than half of all
+  //               mutations survive, indicating the suite is not meaningfully
+  //               exercising the mutated code paths.
+  //   low:   60 — Scores in [50, 60) are flagged as poor; reviewers should add
+  //               tests before merging new code in this range.
+  //   high:  80 — Target score; scores above this are considered acceptable for
+  //               the current critical-path scope (validation, formatting, services).
+  //               Raise incrementally as coverage improves.
   thresholds: {
     high: 80,
     low: 60,


### PR DESCRIPTION
## Summary


This PR adds the missing test coverage identified in the four open issues, keeping each change strictly within the scope described.

### closes #711 — E2E test for transaction history pagination

`e2e/tests/transaction-history.spec.js` (new, Playwright)

- Seeds app account state via `addInitScript` so tests run without a login form.
- Mocks both internal API endpoints (`/api/v1/transactions/*` and `/api/stellar/account/*/transactions`) with `page.route()` — no live Stellar network required.
- Five test cases: initial 20-row load with type/amount/asset assertions; next-page navigation confirming rows change; final-page Next-button disabled state; empty-state illustration visible with no spinner; 503 error showing the error panel and a retry button.
- Bonus continuity test: loads three pages of 20 and asserts all 60 row aria-labels are unique (no duplicate transaction IDs).

### closes #712 — Snapshot tests for all design-system components

`frontend/tests/snapshots.test.jsx` already covers every component in `frontend/src/design-system/` (Button — all 4 variants + 3 sizes + fullWidth + disabled + loading; Badge — all 5 variants; Card — header/footer/padding variants; Input — label/hint/error/fullWidth; Modal — all 3 sizes). The snapshot file is committed and CI runs `vitest` on every PR, so drift fails the build automatically. No code change needed; this issue is resolved by existing committed tests.

### closes #713 — Property-based tests for AmountInput validation

`property-tests/amountInput.property.test.js` (new, fast-check)

- Mirrors the two pure functions from `AmountInput.jsx`: `sanitize()` (the `handleChange` regex pipeline) and `formatDisplay()` (the `Intl.NumberFormat` formatter).
- 1000-run properties for: valid decimal strings pass through unchanged; output never contains non-`[0-9.]` characters; non-numeric chars are always stripped; negative sign is stripped (component rejects negative inputs); multiple dots collapse to one while preserving all digit characters; scientific-notation `e` is stripped.
- Display-formatter properties: at most 7 decimal places; integers display without a dot; round-trip parse matches original numeric value.
- Boundary cases: Stellar max (`922337203685.4775807`), zero, and `0.0000000` all sanitize correctly.

### closes #714 — Mutation test coverage in CI

`.github/workflows/mutation-testing.yml` — two changes:
1. Added `backend/src/services/**` to both `push` and `pull_request` path triggers (the stryker `mutate` scope already covers `backend/src/services/*.js`, but changes to those files were not triggering the job).
2. Removed `continue-on-error: true` from the "Run mutation tests" step so that a mutation score below the `break: 50` threshold now fails the CI job as intended.

`stryker.config.mjs` — added inline comments explaining the rationale for each threshold value (`break: 50`, `low: 60`, `high: 80`) per the acceptance criteria.

## Test plan

- [ ] `npx playwright test e2e/tests/transaction-history.spec.js --project=chromium` — all 5 specs green
- [ ] `npm run test:property` — `amountInput.property.test.js` passes all properties with 1000 runs
- [ ] Confirm mutation CI job triggers on a PR that touches `backend/src/services/` (previously it would not)
- [ ] Confirm mutation CI job fails when a mutation causes the score to drop below 50% (previously `continue-on-error` masked this)
- [ ] `npm run test` — existing snapshot tests in `frontend/tests/snapshots.test.jsx` continue to pass with committed snapshots