### PR TITLE
feat: server-side pagination, Redis balance cache, lazy routes, rate memoization

### DIFF
--- a/backend/src/cache/balanceCache.js
+++ b/backend/src/cache/balanceCache.js
@@ -1,0 +1,49 @@
+import { RedisBackend } from './redis.js';
+import logger from '../config/logger.js';
+
+const TTL = parseInt(process.env.BALANCE_CACHE_TTL_SECONDS ?? '10', 10);
+
+let _backend = null;
+function backend() {
+  if (!_backend) _backend = new RedisBackend(process.env.REDIS_URL ?? null);
+  return _backend;
+}
+
+/**
+ * Return a cached balance for accountId, or call fetchFn to populate it.
+ * Falls open on Redis errors — balance fetch is never blocked by cache failure.
+ */
+export async function getCachedBalance(accountId, fetchFn) {
+  const key = `balance:${accountId}`;
+  try {
+    const cached = await backend().get(key);
+    if (cached !== null) {
+      logger.debug('cache.balance.hit', { accountId });
+      return cached;
+    }
+  } catch {
+    // Redis unavailable — fall through to live fetch
+  }
+
+  const value = await fetchFn();
+
+  try {
+    await backend().set(key, value, TTL);
+  } catch {
+    // Non-critical — serve the value even if caching fails
+  }
+
+  return value;
+}
+
+/**
+ * Invalidate the cached balance for accountId.
+ * Called immediately after a successful transaction so the next balance fetch is live.
+ */
+export async function invalidateBalanceCache(accountId) {
+  try {
+    await backend().delete(`balance:${accountId}`);
+  } catch {
+    // Non-critical
+  }
+}

--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -492,9 +492,18 @@ router.get('/account/:publicKey/trustlines', rules.publicKeyParam, validate, asy
 router.get('/account/:publicKey/transactions', rules.publicKeyParam, validate, async (req, res) => {
   try {
     const { cursor, limit, type, dateFrom, dateTo, hash } = req.query;
+
+    let parsedLimit = 20;
+    if (limit !== undefined) {
+      parsedLimit = parseInt(limit, 10);
+      if (isNaN(parsedLimit) || parsedLimit < 1 || parsedLimit > 100) {
+        return res.status(400).json({ error: 'limit must be an integer between 1 and 100' });
+      }
+    }
+
     const result = await StellarService.getTransactions(req.params.publicKey, {
       cursor,
-      limit: limit ? Math.min(parseInt(limit), 50) : 10,
+      limit: parsedLimit,
       type,
       dateFrom,
       dateTo,
@@ -1016,28 +1025,24 @@ router.post(
       ]);
 
       if (senderScreen.hit) {
-        return res
-          .status(403)
-          .json({
-            error: {
-              code: 'SANCTIONS_MATCH',
-              message: 'Sanctions screening failed',
-              reason: senderScreen.reason,
-            },
-          });
+        return res.status(403).json({
+          error: {
+            code: 'SANCTIONS_MATCH',
+            message: 'Sanctions screening failed',
+            reason: senderScreen.reason,
+          },
+        });
       }
 
       for (const screen of recipientScreens) {
         if (screen.hit) {
-          return res
-            .status(403)
-            .json({
-              error: {
-                code: 'SANCTIONS_MATCH',
-                message: 'Recipient sanctions screening failed',
-                reason: screen.reason,
-              },
-            });
+          return res.status(403).json({
+            error: {
+              code: 'SANCTIONS_MATCH',
+              message: 'Recipient sanctions screening failed',
+              reason: screen.reason,
+            },
+          });
         }
       }
 

--- a/backend/src/services/assetConverter.js
+++ b/backend/src/services/assetConverter.js
@@ -7,6 +7,13 @@ class AssetConverterService {
   constructor(horizonUrl, networkPassphrase) {
     this.server = new StellarSdk.Horizon.Server(horizonUrl);
     this.networkPassphrase = networkPassphrase;
+    this._rateCache = new Map();
+    this._rateTtl = parseInt(process.env.RATE_CACHE_TTL_SECONDS ?? '30', 10);
+    if (this._rateTtl < 5) {
+      console.warn(
+        `[assetConverter] RATE_CACHE_TTL_SECONDS=${this._rateTtl}s is very low — possible misconfiguration`,
+      );
+    }
   }
 
   /**
@@ -17,17 +24,15 @@ class AssetConverterService {
       const source = this.parseAsset(sourceAsset);
       const dest = this.parseAsset(destAsset);
 
-      const paths = await this.server
-        .strictSendPaths(source, amount.toString(), [dest])
-        .call();
+      const paths = await this.server.strictSendPaths(source, amount.toString(), [dest]).call();
 
-      return paths.records.map(path => ({
+      return paths.records.map((path) => ({
         sourceAmount: path.source_amount,
         destAmount: path.destination_amount,
-        path: path.path.map(p => ({
+        path: path.path.map((p) => ({
           code: p.asset_code || 'XLM',
-          issuer: p.asset_issuer || null
-        }))
+          issuer: p.asset_issuer || null,
+        })),
       }));
     } catch (error) {
       console.error('Find conversion path error:', error);
@@ -48,7 +53,7 @@ class AssetConverterService {
 
       const transaction = new StellarSdk.TransactionBuilder(account, {
         fee: StellarSdk.BASE_FEE,
-        networkPassphrase: this.networkPassphrase
+        networkPassphrase: this.networkPassphrase,
       })
         .addOperation(
           StellarSdk.Operation.pathPaymentStrictSend({
@@ -56,8 +61,8 @@ class AssetConverterService {
             sendAmount: amount.toString(),
             destination: sourceKeypair.publicKey(),
             destAsset: dest,
-            destMin: destMin.toString()
-          })
+            destMin: destMin.toString(),
+          }),
         )
         .setTimeout(30)
         .build();
@@ -71,7 +76,7 @@ class AssetConverterService {
         sourceAsset,
         destAsset,
         sourceAmount: amount,
-        destAmount: destMin
+        destAmount: destMin,
       };
     } catch (error) {
       console.error('Asset conversion error:', error);
@@ -80,23 +85,32 @@ class AssetConverterService {
   }
 
   /**
-   * Get conversion rate
+   * Get conversion rate, memoized within the current TTL window.
+   * All calls for the same pair within RATE_CACHE_TTL_SECONDS share one Horizon fetch.
    */
   async getConversionRate(sourceAsset, destAsset) {
+    const intervalKey = Math.floor(Date.now() / (this._rateTtl * 1000));
+    const cacheKey = `${sourceAsset}:${destAsset}:${intervalKey}`;
+
+    if (this._rateCache.has(cacheKey)) {
+      return this._rateCache.get(cacheKey);
+    }
+
+    // Evict expired entries
+    for (const key of this._rateCache.keys()) {
+      const storedInterval = parseInt(key.slice(key.lastIndexOf(':') + 1), 10);
+      if (storedInterval < intervalKey) {
+        this._rateCache.delete(key);
+      }
+    }
+
     try {
       const source = this.parseAsset(sourceAsset);
       const dest = this.parseAsset(destAsset);
-
-      const orderbook = await this.server
-        .orderbook(source, dest)
-        .call();
-
-      if (orderbook.bids.length === 0) {
-        return null;
-      }
-
-      const bestBid = orderbook.bids[0];
-      return parseFloat(bestBid.price);
+      const orderbook = await this.server.orderbook(source, dest).call();
+      const rate = orderbook.bids.length > 0 ? parseFloat(orderbook.bids[0].price) : null;
+      this._rateCache.set(cacheKey, rate);
+      return rate;
     } catch (error) {
       console.error('Get conversion rate error:', error);
       return null;
@@ -108,7 +122,7 @@ class AssetConverterService {
    */
   async calculateConversion(sourceAsset, destAsset, amount) {
     const rate = await this.getConversionRate(sourceAsset, destAsset);
-    
+
     if (!rate) {
       return null;
     }
@@ -119,7 +133,7 @@ class AssetConverterService {
       sourceAmount: amount,
       destAmount: amount * rate,
       rate,
-      timestamp: new Date()
+      timestamp: new Date(),
     };
   }
 
@@ -140,16 +154,14 @@ class AssetConverterService {
    */
   async getBestConversionPath(sourceAsset, destAsset, amount) {
     const paths = await this.findConversionPath(sourceAsset, destAsset, amount);
-    
+
     if (paths.length === 0) {
       return null;
     }
 
     // Find path with best destination amount
     return paths.reduce((best, current) => {
-      return parseFloat(current.destAmount) > parseFloat(best.destAmount)
-        ? current
-        : best;
+      return parseFloat(current.destAmount) > parseFloat(best.destAmount) ? current : best;
     });
   }
 }

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -5,6 +5,7 @@ import { getIssuer } from '../config/assets.js';
 import logger, { withContext } from '../config/logger.js';
 import prisma from '../db/client.js';
 import { callWithCircuitBreaker } from './circuitBreaker.js';
+import { getCachedBalance, invalidateBalanceCache } from '../cache/balanceCache.js';
 
 /**
  * Retrieve aggregate fee-bump statistics from the database.
@@ -131,7 +132,13 @@ function isTransientHorizonError(err) {
   if (status === 429 || status === 503) return true;
   if (err.isTimeout) return true;
   const code = err?.code;
-  if (code === 'ECONNREFUSED' || code === 'ENOTFOUND' || code === 'ETIMEDOUT' || code === 'ECONNRESET') return true;
+  if (
+    code === 'ECONNREFUSED' ||
+    code === 'ENOTFOUND' ||
+    code === 'ETIMEDOUT' ||
+    code === 'ECONNRESET'
+  )
+    return true;
   return false;
 }
 
@@ -240,15 +247,15 @@ export async function createAccount(correlationId = null) {
  */
 export async function getBalance(publicKey, correlationId = null) {
   logger.debug('stellar.getBalance', { publicKey, correlationId });
-  const account = await withHorizonRetry(() => getHorizonServer().loadAccount(publicKey));
-  const balances = account.balances.map((b) => ({
-    asset: b.asset_type === 'native' ? 'XLM' : `${b.asset_code}:${b.asset_issuer}`,
-    balance: b.balance,
-  }));
-
-  logger.info('stellar.balanceFetched', { publicKey, balances, correlationId });
-
-  return { publicKey, balances };
+  return getCachedBalance(publicKey, async () => {
+    const account = await withHorizonRetry(() => getHorizonServer().loadAccount(publicKey));
+    const balances = account.balances.map((b) => ({
+      asset: b.asset_type === 'native' ? 'XLM' : `${b.asset_code}:${b.asset_issuer}`,
+      balance: b.balance,
+    }));
+    logger.info('stellar.balanceFetched', { publicKey, balances, correlationId });
+    return { publicKey, balances };
+  });
 }
 
 /**
@@ -397,6 +404,8 @@ export async function sendPayment(
     memoType,
     correlationId,
   });
+
+  await invalidateBalanceCache(sourcePublicKey);
 
   await eventMonitor.publishEvent(sourcePublicKey, {
     type: 'PaymentSent',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,7 +38,6 @@ import { SkeletonBalance } from './components/Skeleton';
 import { TransactionHistory } from './components/TransactionHistory';
 import { StreamPayment } from './components/StreamPayment';
 import { PathPayment } from './components/PathPayment';
-import { AccountSettings } from './components/AccountSettings';
 import { FeeDisplay } from './components/FeeDisplay';
 import { InlineConfirmation } from './components/InlineConfirmation';
 import { logError } from './utils/errorLogger';
@@ -55,7 +54,6 @@ import { InstallBanner } from './components/InstallBanner';
 import { useTheme } from './contexts/ThemeContext';
 import { useAppState, useAppDispatch, A } from './store/index.js';
 import { useExchangeRate } from './hooks/useExchangeRate';
-import { useBalance, useSendPayment, useCreateAccount, useImportAccount, useKycStatus, useSaveAccountLabel, useNetworkStatusQuery } from './hooks/useQueryHooks';
 import {
   useBalance,
   useSendPayment,
@@ -65,27 +63,29 @@ import {
   useSaveAccountLabel,
   useNetworkStatusQuery,
 } from './hooks/useQueryHooks';
-import { AMMPoolBrowser } from './components/AMMPoolBrowser';
 import { ConvertWidget } from './components/ConvertWidget';
 import { XLMInfoIcon } from './components/XLMInfoIcon';
 import { AdminDashboard } from './components/AdminDashboard';
 
 // Heavy components loaded on-demand to keep the initial bundle small
 const AMMPoolBrowser = lazy(() =>
-  import('./components/AMMPoolBrowser').then((m) => ({ default: m.AMMPoolBrowser }))
+  import('./components/AMMPoolBrowser').then((m) => ({ default: m.AMMPoolBrowser })),
 );
 const AccountRecovery = lazy(() =>
-  import('./components/AccountRecovery').then((m) => ({ default: m.AccountRecovery }))
+  import('./components/AccountRecovery').then((m) => ({ default: m.AccountRecovery })),
 );
 const MultiSigTransactions = lazy(() =>
-  import('./components/MultiSigTransactions').then((m) => ({ default: m.MultiSigTransactions }))
+  import('./components/MultiSigTransactions').then((m) => ({ default: m.MultiSigTransactions })),
 );
 const KYCForm = lazy(() => import('./components/KYCForm').then((m) => ({ default: m.KYCForm })));
 const ComplianceDashboard = lazy(() =>
-  import('./components/ComplianceDashboard').then((m) => ({ default: m.ComplianceDashboard }))
+  import('./components/ComplianceDashboard').then((m) => ({ default: m.ComplianceDashboard })),
 );
 const BackupSettings = lazy(() =>
-  import('./components/BackupSettings').then((m) => ({ default: m.BackupSettings }))
+  import('./components/BackupSettings').then((m) => ({ default: m.BackupSettings })),
+);
+const AccountSettings = lazy(() =>
+  import('./components/AccountSettings').then((m) => ({ default: m.AccountSettings })),
 );
 
 const KYC_LARGE_TRANSACTION_LIMIT = 1000;
@@ -171,7 +171,7 @@ function App() {
         if (wsMsg.balance) dispatch({ type: A.SET_BALANCE, payload: { balances: wsMsg.balance } });
       }
     },
-    [msg, dispatch]
+    [msg, dispatch],
   );
 
   const wsStatus = useWebSocket(account?.publicKey ?? null, handleWsMessage);
@@ -181,7 +181,8 @@ function App() {
   const [fiatCurrency, setFiatCurrency] = useState('USD');
   useEffect(() => {
     if (!account?.publicKey) return;
-    apiClient.get(`/api/stellar/account/${account.publicKey}/settings`)
+    apiClient
+      .get(`/api/stellar/account/${account.publicKey}/settings`)
       .then(({ data }) => {
         const asset = data?.defaultAsset;
         // Use defaultAsset as fiat currency if it's not a Stellar asset (XLM/USDC/etc.)
@@ -189,7 +190,9 @@ function App() {
         if (asset && !STELLAR_ASSETS.has(asset)) setFiatCurrency(asset);
         else if (asset === 'EURC') setFiatCurrency('EUR');
       })
-      .catch(() => { /* use USD default */ });
+      .catch(() => {
+        /* use USD default */
+      });
   }, [account?.publicKey]);
 
   const { rate: xlmFiatRate, loading: rateLoading } = useExchangeRate(lastWsMessage, fiatCurrency);
@@ -295,12 +298,6 @@ function App() {
     }
   };
 
-  const loadLabel = useCallback(async (publicKey) => {
-    try {
-      const fetchedLabel = await getAccountLabel(publicKey);
-      dispatch({ type: A.SET_LABEL, payload: fetchedLabel });
-    } catch { /* non-critical */ }
-  }, [dispatch]);
   const loadLabel = useCallback(
     async (publicKey) => {
       try {
@@ -310,7 +307,7 @@ function App() {
         /* non-critical */
       }
     },
-    [dispatch]
+    [dispatch],
   );
 
   const fetchKycStatus = useCallback(async () => {
@@ -372,9 +369,6 @@ function App() {
     } catch (error) {
       logError(error, { context: 'createAccount' });
       msg.error(getFriendlyError(error), { retry: createAccount });
-    } finally { dispatch({ type: A.SET_LOADING, payload: '' }); }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  // eslint-disable-next-line react-hooks/exhaustive-deps
     } finally {
       dispatch({ type: A.SET_LOADING, payload: '' });
     }
@@ -406,9 +400,6 @@ function App() {
     } catch (error) {
       logError(error, { context: 'checkBalance' });
       msg.error(getFriendlyError(error), { retry: checkBalance });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    } finally { dispatch({ type: A.SET_LOADING, payload: '' }); }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
     } finally {
       dispatch({ type: A.SET_LOADING, payload: '' });
     }
@@ -421,10 +412,16 @@ function App() {
   const selectedBalance = balance?.balances?.find((b) => b.asset === assetCode)?.balance ?? null;
   const xlmBalance = balance?.balances?.find((b) => b.asset === 'XLM')?.balance ?? null;
   const amountTouched = amount.length > 0;
-  const amountError = validateAmount(amount, selectedBalance !== null ? parseFloat(selectedBalance) : null);
+  const amountError = validateAmount(
+    amount,
+    selectedBalance !== null ? parseFloat(selectedBalance) : null,
+  );
   const amountValid = amountTouched && !amountError;
   const largeTransactionBlocked =
-    amountValid && kycStatus !== 'APPROVED' && assetCode === 'XLM' && parseFloat(amount) > KYC_LARGE_TRANSACTION_LIMIT;
+    amountValid &&
+    kycStatus !== 'APPROVED' &&
+    assetCode === 'XLM' &&
+    parseFloat(amount) > KYC_LARGE_TRANSACTION_LIMIT;
 
   useEffect(() => {
     if (!recipientLooksFederated) {
@@ -443,7 +440,9 @@ function App() {
           setFederationStatus(`Resolved ${data.stellar_address}`);
         }
       } catch (error) {
-        setFederationStatus(error?.normalized?.message || error.message || 'Federation address not found');
+        setFederationStatus(
+          error?.normalized?.message || error.message || 'Federation address not found',
+        );
       }
     }, 500);
 
@@ -464,9 +463,13 @@ function App() {
 
   const confirmPayment = async () => {
     if (!account || !recipientValid || !amountValid) return;
-    if (assetCode === 'XLM' && kycStatus !== 'APPROVED' && parseFloat(amount) > KYC_LARGE_TRANSACTION_LIMIT) {
+    if (
+      assetCode === 'XLM' &&
+      kycStatus !== 'APPROVED' &&
+      parseFloat(amount) > KYC_LARGE_TRANSACTION_LIMIT
+    ) {
       msg.error(
-        `Large transactions above ${KYC_LARGE_TRANSACTION_LIMIT} XLM require approved KYC.`
+        `Large transactions above ${KYC_LARGE_TRANSACTION_LIMIT} XLM require approved KYC.`,
       );
       return;
     }
@@ -490,7 +493,7 @@ function App() {
               ...b,
               balance: String((parseFloat(b.balance) - parseFloat(amount) - fee).toFixed(7)),
             }
-          : b
+          : b,
       );
       dispatch({ type: A.SET_BALANCE_OPTIMISTIC, payload: { balances: optimisticBalances } });
     }
@@ -503,9 +506,12 @@ function App() {
       setShowPaymentConfirmation(false);
     } catch (error) {
       dispatch({ type: A.REVERT_BALANCE });
-      if (error?.response?.data?.error?.code === 'KYC_REQUIRED' || error?.response?.data?.error === 'KYC_REQUIRED') {
+      if (
+        error?.response?.data?.error?.code === 'KYC_REQUIRED' ||
+        error?.response?.data?.error === 'KYC_REQUIRED'
+      ) {
         msg.error(
-          `Large transactions above ${KYC_LARGE_TRANSACTION_LIMIT} XLM require approved KYC.`
+          `Large transactions above ${KYC_LARGE_TRANSACTION_LIMIT} XLM require approved KYC.`,
         );
         setShowPaymentConfirmation(false);
         setActiveSettingsSection('kyc');
@@ -517,7 +523,7 @@ function App() {
           assetCode: payload.assetCode,
         });
         msg.info(
-          "You are offline. Payment queued — you'll be prompted to re-enter your secret key when back online."
+          "You are offline. Payment queued — you'll be prompted to re-enter your secret key when back online.",
         );
       } else {
         logError(error, { context: 'sendPayment' });
@@ -530,7 +536,7 @@ function App() {
 
   const handleCreateTrustline = async () => {
     if (!account || !trustlineAsset) return;
-    
+
     setTrustlineLoading(true);
     try {
       await createTrustline(account.secretKey, trustlineAsset);
@@ -547,7 +553,7 @@ function App() {
 
   const handleAssetChange = async (newAssetCode) => {
     dispatch({ type: A.SET_ASSET_CODE, payload: newAssetCode });
-    
+
     // Check if non-native asset requires trustline
     if (newAssetCode !== 'XLM') {
       const hasTrustline = balance?.balances?.some((b) => b.asset === newAssetCode);
@@ -570,7 +576,7 @@ function App() {
 
   const confirmBatchPayment = async () => {
     if (!account || batchRecipients.length === 0) return;
-    
+
     dispatch({ type: A.SET_LOADING, payload: 'send' });
     const payload = {
       sourceSecret: account.secretKey,
@@ -598,7 +604,7 @@ function App() {
       const data = await batchPayment(payload);
       msg.success(
         `Batch payment sent to ${batchRecipients.length} recipients! Hash: ${data.hash.slice(0, 8)}…`,
-        { hash: data.hash }
+        { hash: data.hash },
       );
       setBatchRecipients([]);
       setBatchMode(false);
@@ -616,7 +622,7 @@ function App() {
 
   const handleRecoveryCodeSubmit = async () => {
     if (!account) return;
-    
+
     setShowRecoveryCodeEntry(false);
     try {
       const result = await verifyRecoveryCode(account.publicKey, recoveryCode);
@@ -905,7 +911,10 @@ function App() {
                     }}
                     aria-hidden="true"
                   />
-                  <span aria-hidden="true" className={wsStatus === 'failed' ? 'ws-status-failed' : ''}>
+                  <span
+                    aria-hidden="true"
+                    className={wsStatus === 'failed' ? 'ws-status-failed' : ''}
+                  >
                     {wsStatus === 'failed' ? 'Connection lost' : wsStatus}
                   </span>
                 </motion.span>
@@ -1057,18 +1066,33 @@ function App() {
                         animate="visible"
                         exit="exit"
                       >
-                        Invalid Stellar address format (must start with G and be 56 characters) or federation address
+                        Invalid Stellar address format (must start with G and be 56 characters) or
+                        federation address
                       </motion.p>
                     )}
                   </AnimatePresence>
                   {federationStatus && (
-                    <p style={{ color: federationStatus.startsWith('Resolved') ? '#16a34a' : '#64748b' }}>
+                    <p
+                      style={{
+                        color: federationStatus.startsWith('Resolved') ? '#16a34a' : '#64748b',
+                      }}
+                    >
                       {federationStatus}
                     </p>
                   )}
                   {/* Asset Selector */}
                   <div className="input-wrap">
-                    <label htmlFor="asset-select" style={{ fontSize: '0.875rem', fontWeight: 500, marginBottom: 4, display: 'block' }}>Asset</label>
+                    <label
+                      htmlFor="asset-select"
+                      style={{
+                        fontSize: '0.875rem',
+                        fontWeight: 500,
+                        marginBottom: 4,
+                        display: 'block',
+                      }}
+                    >
+                      Asset
+                    </label>
                     <select
                       id="asset-select"
                       value={assetCode}
@@ -1082,11 +1106,12 @@ function App() {
                       }}
                       aria-label="Select asset to send"
                     >
-                      {balance?.balances && balance.balances.map((b) => (
-                        <option key={b.asset} value={b.asset}>
-                          {b.asset} - {formatBalanceWithAsset(b.balance, b.asset)}
-                        </option>
-                      ))}
+                      {balance?.balances &&
+                        balance.balances.map((b) => (
+                          <option key={b.asset} value={b.asset}>
+                            {b.asset} - {formatBalanceWithAsset(b.balance, b.asset)}
+                          </option>
+                        ))}
                     </select>
                   </div>
                   {trustlineAsset && (
@@ -1151,7 +1176,12 @@ function App() {
                     <motion.button
                       onClick={batchMode ? addBatchRecipient : sendPayment}
                       {...tap}
-                      disabled={!recipientValid || !amountValid || loading === 'send' || (batchMode && batchRecipients.length >= 10)}
+                      disabled={
+                        !recipientValid ||
+                        !amountValid ||
+                        loading === 'send' ||
+                        (batchMode && batchRecipients.length >= 10)
+                      }
                     >
                       {loading === 'send' ? (
                         <Spinner label={batchMode ? 'Adding...' : 'Sending payment...'} />
@@ -1310,7 +1340,14 @@ function App() {
                     variants={v.fadeSlide}
                   >
                     <ErrorBoundary context="send-payment">
-                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          marginBottom: 16,
+                        }}
+                      >
                         <h2 id="send-heading">Send Payment</h2>
                         <button
                           type="button"
@@ -1328,22 +1365,49 @@ function App() {
                           {batchMode ? 'Batch Mode (On)' : 'Batch Mode (Off)'}
                         </button>
                       </div>
-                      
+
                       {batchMode && batchRecipients.length > 0 && (
-                        <div style={{ padding: '12px', background: '#f0f9ff', border: '1px solid #bfdbfe', borderRadius: '4px', marginBottom: 16 }}>
+                        <div
+                          style={{
+                            padding: '12px',
+                            background: '#f0f9ff',
+                            border: '1px solid #bfdbfe',
+                            borderRadius: '4px',
+                            marginBottom: 16,
+                          }}
+                        >
                           <h3 style={{ margin: '0 0 8px 0', fontSize: '0.95rem', fontWeight: 600 }}>
                             Recipients ({batchRecipients.length}/10)
                           </h3>
                           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                             {batchRecipients.map((p, i) => (
-                              <div key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px', background: '#fff', borderRadius: '3px' }}>
+                              <div
+                                key={i}
+                                style={{
+                                  display: 'flex',
+                                  justifyContent: 'space-between',
+                                  alignItems: 'center',
+                                  padding: '8px',
+                                  background: '#fff',
+                                  borderRadius: '3px',
+                                }}
+                              >
                                 <span style={{ fontSize: '0.85rem' }}>
-                                  {formatBalanceWithAsset(p.amount, p.assetCode)} to {p.destination.slice(0, 16)}...
+                                  {formatBalanceWithAsset(p.amount, p.assetCode)} to{' '}
+                                  {p.destination.slice(0, 16)}...
                                 </span>
                                 <button
                                   type="button"
                                   onClick={() => removeBatchRecipient(i)}
-                                  style={{ background: '#ef4444', color: '#fff', border: 'none', padding: '4px 8px', borderRadius: '2px', cursor: 'pointer', fontSize: '0.8rem' }}
+                                  style={{
+                                    background: '#ef4444',
+                                    color: '#fff',
+                                    border: 'none',
+                                    padding: '4px 8px',
+                                    borderRadius: '2px',
+                                    cursor: 'pointer',
+                                    fontSize: '0.8rem',
+                                  }}
                                 >
                                   Remove
                                 </button>
@@ -1352,7 +1416,7 @@ function App() {
                           </div>
                         </div>
                       )}
-                      
+
                       <AddressBook
                         onSelect={(address) =>
                           dispatch({ type: A.SET_RECIPIENT, payload: address })
@@ -1401,9 +1465,11 @@ function App() {
                           <QRScanner
                             onScan={(parsed) => {
                               dispatch({ type: A.SET_RECIPIENT, payload: parsed.destination });
-                              if (parsed.amount) dispatch({ type: A.SET_AMOUNT, payload: parsed.amount });
+                              if (parsed.amount)
+                                dispatch({ type: A.SET_AMOUNT, payload: parsed.amount });
                               if (parsed.memo) dispatch({ type: A.SET_MEMO, payload: parsed.memo });
-                              if (parsed.memoType) dispatch({ type: A.SET_MEMO_TYPE, payload: parsed.memoType });
+                              if (parsed.memoType)
+                                dispatch({ type: A.SET_MEMO_TYPE, payload: parsed.memoType });
                               setShowScanner(false);
                             }}
                             onClose={() => setShowScanner(false)}
@@ -1421,11 +1487,18 @@ function App() {
                             animate="visible"
                             exit="exit"
                           >
-                            Invalid Stellar address format (must start with G and be 56 characters) or federation address
+                            Invalid Stellar address format (must start with G and be 56 characters)
+                            or federation address
                           </motion.p>
                         )}
                         {federationStatus && (
-                          <p style={{ color: federationStatus.startsWith('Resolved') ? '#16a34a' : '#64748b' }}>
+                          <p
+                            style={{
+                              color: federationStatus.startsWith('Resolved')
+                                ? '#16a34a'
+                                : '#64748b',
+                            }}
+                          >
                             {federationStatus}
                           </p>
                         )}
@@ -1517,16 +1590,19 @@ function App() {
                           <label htmlFor="memo-input" className="sr-only">
                             {memoType === 'text' && 'Payment memo (optional, max 28 bytes)'}
                             {memoType === 'id' && 'Numeric memo ID (uint64, exchange deposit)'}
-                            {(memoType === 'hash' || memoType === 'return') && `${memoType} memo (64 hex chars = 32 bytes)`}
+                            {(memoType === 'hash' || memoType === 'return') &&
+                              `${memoType} memo (64 hex chars = 32 bytes)`}
                           </label>
                           <input
                             id="memo-input"
                             type={memoType === 'id' ? 'number' : 'text'}
                             inputMode={memoType === 'id' ? 'numeric' : undefined}
                             placeholder={
-                              memoType === 'text' ? 'Memo (optional, max 28 bytes)' :
-                              memoType === 'id' ? 'Numeric memo ID (exchange deposit)' :
-                              `${memoType} memo (64 hex characters)`
+                              memoType === 'text'
+                                ? 'Memo (optional, max 28 bytes)'
+                                : memoType === 'id'
+                                  ? 'Numeric memo ID (exchange deposit)'
+                                  : `${memoType} memo (64 hex characters)`
                             }
                             value={memo}
                             onChange={(e) => {
@@ -1546,32 +1622,47 @@ function App() {
                             }}
                             onKeyDown={(e) => e.key === 'Enter' && sendPayment()}
                             aria-label={
-                              memoType === 'text' ? 'Payment memo (optional)' :
-                              memoType === 'id' ? 'Numeric memo ID for exchange deposit' :
-                              `${memoType} memo (64 hex characters)`
+                              memoType === 'text'
+                                ? 'Payment memo (optional)'
+                                : memoType === 'id'
+                                  ? 'Numeric memo ID for exchange deposit'
+                                  : `${memoType} memo (64 hex characters)`
                             }
-                            maxLength={memoType === 'id' ? 20 : memoType === 'text' ? undefined : 64}
+                            maxLength={
+                              memoType === 'id' ? 20 : memoType === 'text' ? undefined : 64
+                            }
                             style={{ paddingRight: memo ? '60px' : '10px' }}
                           />
                           {memo && (
                             <span className="input-icon" aria-hidden="true">
-                              {memoType === 'text' && `${new TextEncoder().encode(memo).length}/28 bytes`}
+                              {memoType === 'text' &&
+                                `${new TextEncoder().encode(memo).length}/28 bytes`}
                               {memoType === 'id' && memo.length > 0 && '✓'}
-                              {(memoType === 'hash' || memoType === 'return') && `${memo.length}/64`}
+                              {(memoType === 'hash' || memoType === 'return') &&
+                                `${memo.length}/64`}
                             </span>
                           )}
                         </div>
                       </div>
 
                       {memo && memoType === 'hash' && memo.length > 0 && memo.length !== 64 && (
-                        <p className="field-error" role="alert">Hash memo must be exactly 64 hex characters (32 bytes)</p>
+                        <p className="field-error" role="alert">
+                          Hash memo must be exactly 64 hex characters (32 bytes)
+                        </p>
                       )}
                       {memo && memoType === 'return' && memo.length > 0 && memo.length !== 64 && (
-                        <p className="field-error" role="alert">Return memo must be exactly 64 hex characters (32 bytes)</p>
+                        <p className="field-error" role="alert">
+                          Return memo must be exactly 64 hex characters (32 bytes)
+                        </p>
                       )}
-                      {memo && memoType === 'id' && memo && BigInt(memo) > 18446744073709551615n && (
-                        <p className="field-error" role="alert">Memo ID exceeds max uint64 value</p>
-                      )}
+                      {memo &&
+                        memoType === 'id' &&
+                        memo &&
+                        BigInt(memo) > 18446744073709551615n && (
+                          <p className="field-error" role="alert">
+                            Memo ID exceeds max uint64 value
+                          </p>
+                        )}
 
                       <FeeDisplay amount={amount} visible={amountValid} />
                       {amountValid &&
@@ -1596,7 +1687,9 @@ function App() {
                             !amountValid ||
                             loading === 'send' ||
                             largeTransactionBlocked ||
-                            ((memoType === 'hash' || memoType === 'return') && memo.length > 0 && memo.length !== 64)
+                            ((memoType === 'hash' || memoType === 'return') &&
+                              memo.length > 0 &&
+                              memo.length !== 64)
                           }
                           aria-busy={loading === 'send'}
                           aria-label="Send XLM payment"
@@ -1701,7 +1794,7 @@ function App() {
                               section.action();
                             } else {
                               setActiveSettingsSection(
-                                activeSettingsSection === section.id ? null : section.id
+                                activeSettingsSection === section.id ? null : section.id,
                               );
                             }
                           }}
@@ -1774,85 +1867,140 @@ function App() {
                       <PathPayment account={account} />
                     </ErrorBoundary>
                   </motion.div>
-                {/* Account Recovery */}
-                <motion.div variants={v.fadeSlide}>
-                  <Suspense fallback={<Spinner />}>
-                    <AccountRecovery />
-                  </Suspense>
-                </motion.div>
-                {/* Settings Sections Tabs */}
-                <motion.section className="section" variants={v.fadeSlide}>
-                  <h2 style={{ marginBottom: 16 }}>Advanced Features</h2>
-                  <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
-                    {[
-                      { id: 'multisig', label: '🔐 Multi-Sig', ariaLabel: 'Toggle multi-signature transactions panel' },
-                      { id: 'kyc', label: '📋 KYC', ariaLabel: 'Toggle KYC identity verification panel' },
-                      { id: 'notifications', label: '🔔 Notifications', ariaLabel: 'Toggle notification preferences panel' },
-                      { id: 'backup', label: '💾 Backup', ariaLabel: 'Open backup settings', action: () => setShowBackupSettings(true) },
-                      ...(['COMPLIANCE', 'ADMIN'].includes(userRole) ? [{ id: 'compliance', label: '🛡️ Compliance', ariaLabel: 'Open compliance dashboard', action: () => setShowComplianceDashboard(true) }] : []),
-                    ].map((section) => (
-                      <button
-                        key={section.id}
-                        type="button"
-                        aria-label={section.ariaLabel}
-                        aria-expanded={!section.action ? activeSettingsSection === section.id : undefined}
-                        aria-controls={!section.action ? `advanced-section-${section.id}` : undefined}
-                        onClick={() => {
-                          if (section.action) {
-                            section.action();
-                          } else {
-                            setActiveSettingsSection(activeSettingsSection === section.id ? null : section.id);
+                  {/* Account Recovery */}
+                  <motion.div variants={v.fadeSlide}>
+                    <Suspense fallback={<Spinner />}>
+                      <AccountRecovery />
+                    </Suspense>
+                  </motion.div>
+                  {/* Settings Sections Tabs */}
+                  <motion.section className="section" variants={v.fadeSlide}>
+                    <h2 style={{ marginBottom: 16 }}>Advanced Features</h2>
+                    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
+                      {[
+                        {
+                          id: 'multisig',
+                          label: '🔐 Multi-Sig',
+                          ariaLabel: 'Toggle multi-signature transactions panel',
+                        },
+                        {
+                          id: 'kyc',
+                          label: '📋 KYC',
+                          ariaLabel: 'Toggle KYC identity verification panel',
+                        },
+                        {
+                          id: 'notifications',
+                          label: '🔔 Notifications',
+                          ariaLabel: 'Toggle notification preferences panel',
+                        },
+                        {
+                          id: 'backup',
+                          label: '💾 Backup',
+                          ariaLabel: 'Open backup settings',
+                          action: () => setShowBackupSettings(true),
+                        },
+                        ...(['COMPLIANCE', 'ADMIN'].includes(userRole)
+                          ? [
+                              {
+                                id: 'compliance',
+                                label: '🛡️ Compliance',
+                                ariaLabel: 'Open compliance dashboard',
+                                action: () => setShowComplianceDashboard(true),
+                              },
+                            ]
+                          : []),
+                      ].map((section) => (
+                        <button
+                          key={section.id}
+                          type="button"
+                          aria-label={section.ariaLabel}
+                          aria-expanded={
+                            !section.action ? activeSettingsSection === section.id : undefined
                           }
-                        }}
-                        style={{
-                          padding: '10px 16px',
-                          background: activeSettingsSection === section.id ? '#2563eb' : '#f3f4f6',
-                          color: activeSettingsSection === section.id ? '#fff' : '#333',
-                          border: 'none',
-                          borderRadius: 4,
-                          cursor: 'pointer',
-                          fontWeight: 500,
-                          transition: 'all 0.2s',
-                        }}
-                      >
-                        {section.label}
-                      </button>
-                    ))}
-                  </div>
+                          aria-controls={
+                            !section.action ? `advanced-section-${section.id}` : undefined
+                          }
+                          onClick={() => {
+                            if (section.action) {
+                              section.action();
+                            } else {
+                              setActiveSettingsSection(
+                                activeSettingsSection === section.id ? null : section.id,
+                              );
+                            }
+                          }}
+                          style={{
+                            padding: '10px 16px',
+                            background:
+                              activeSettingsSection === section.id ? '#2563eb' : '#f3f4f6',
+                            color: activeSettingsSection === section.id ? '#fff' : '#333',
+                            border: 'none',
+                            borderRadius: 4,
+                            cursor: 'pointer',
+                            fontWeight: 500,
+                            transition: 'all 0.2s',
+                          }}
+                        >
+                          {section.label}
+                        </button>
+                      ))}
+                    </div>
 
-                  <AnimatePresence mode="wait">
-                    {activeSettingsSection === 'multisig' && (
-                      <motion.div id="advanced-section-multisig" key="multisig" variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit">
-                        <Suspense fallback={<Spinner />}>
-                          <MultiSigTransactions publicKey={account.publicKey} />
-                        </Suspense>
-                        <ErrorBoundary context="Multi-Sig Transactions">
-                          <MultiSigTransactions publicKey={account.publicKey} />
-                        </ErrorBoundary>
-                      </motion.div>
-                    )}
-                    {activeSettingsSection === 'kyc' && (
-                      <motion.div id="advanced-section-kyc" key="kyc" variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit">
-                        <Suspense fallback={<Spinner />}>
-                          <KYCForm />
-                        </Suspense>
-                        <ErrorBoundary context="KYC Form">
-                          <KYCForm />
-                        </ErrorBoundary>
-                      </motion.div>
-                    )}
-                    {activeSettingsSection === 'notifications' && (
-                      <motion.div id="advanced-section-notifications" key="notifications" variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit">
-                        <NotificationPreferences />
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
-                </motion.section>
-                {/* Path Payment */}
-                <motion.div variants={v.fadeSlide}>
-                  <ErrorBoundary context="Path Payment">
-                    <PathPayment account={account} />
-                  </ErrorBoundary>
+                    <AnimatePresence mode="wait">
+                      {activeSettingsSection === 'multisig' && (
+                        <motion.div
+                          id="advanced-section-multisig"
+                          key="multisig"
+                          variants={v.fadeSlide}
+                          initial="hidden"
+                          animate="visible"
+                          exit="exit"
+                        >
+                          <Suspense fallback={<Spinner />}>
+                            <MultiSigTransactions publicKey={account.publicKey} />
+                          </Suspense>
+                          <ErrorBoundary context="Multi-Sig Transactions">
+                            <MultiSigTransactions publicKey={account.publicKey} />
+                          </ErrorBoundary>
+                        </motion.div>
+                      )}
+                      {activeSettingsSection === 'kyc' && (
+                        <motion.div
+                          id="advanced-section-kyc"
+                          key="kyc"
+                          variants={v.fadeSlide}
+                          initial="hidden"
+                          animate="visible"
+                          exit="exit"
+                        >
+                          <Suspense fallback={<Spinner />}>
+                            <KYCForm />
+                          </Suspense>
+                          <ErrorBoundary context="KYC Form">
+                            <KYCForm />
+                          </ErrorBoundary>
+                        </motion.div>
+                      )}
+                      {activeSettingsSection === 'notifications' && (
+                        <motion.div
+                          id="advanced-section-notifications"
+                          key="notifications"
+                          variants={v.fadeSlide}
+                          initial="hidden"
+                          animate="visible"
+                          exit="exit"
+                        >
+                          <NotificationPreferences />
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </motion.section>
+                  {/* Path Payment */}
+                  <motion.div variants={v.fadeSlide}>
+                    <ErrorBoundary context="Path Payment">
+                      <PathPayment account={account} />
+                    </ErrorBoundary>
+                  </motion.div>
                 </motion.div>
               )}
             </AnimatePresence>
@@ -1977,12 +2125,32 @@ function App() {
                   exit={{ scale: 0.9, y: 20 }}
                 >
                   <h3 style={{ marginTop: 0, marginBottom: 16 }}>Confirm Batch Payment</h3>
-                  <div style={{ marginBottom: 16, padding: '12px', background: '#f3f4f6', borderRadius: '4px' }}>
-                    <p style={{ margin: '0 0 12px 0', fontWeight: 600 }}>Recipients ({batchRecipients.length}/10):</p>
+                  <div
+                    style={{
+                      marginBottom: 16,
+                      padding: '12px',
+                      background: '#f3f4f6',
+                      borderRadius: '4px',
+                    }}
+                  >
+                    <p style={{ margin: '0 0 12px 0', fontWeight: 600 }}>
+                      Recipients ({batchRecipients.length}/10):
+                    </p>
                     {batchRecipients.map((p, i) => (
-                      <div key={i} style={{ fontSize: '0.875rem', marginBottom: 8, paddingBottom: 8, borderBottom: i < batchRecipients.length - 1 ? '1px solid #e5e7eb' : 'none' }}>
+                      <div
+                        key={i}
+                        style={{
+                          fontSize: '0.875rem',
+                          marginBottom: 8,
+                          paddingBottom: 8,
+                          borderBottom:
+                            i < batchRecipients.length - 1 ? '1px solid #e5e7eb' : 'none',
+                        }}
+                      >
                         <p style={{ margin: '0 0 4px 0' }}>{p.destination.slice(0, 20)}...</p>
-                        <p style={{ margin: 0, color: '#666' }}>{formatBalanceWithAsset(p.amount, p.assetCode)}</p>
+                        <p style={{ margin: 0, color: '#666' }}>
+                          {formatBalanceWithAsset(p.amount, p.assetCode)}
+                        </p>
                       </div>
                     ))}
                   </div>
@@ -2050,21 +2218,19 @@ function App() {
               />
             )}
             {showSettings && account && (
-              <AccountSettings
-                publicKey={account.publicKey}
-                onClose={() => setShowSettings(false)}
-              />
+              <Suspense fallback={<Spinner />}>
+                <AccountSettings
+                  publicKey={account.publicKey}
+                  onClose={() => setShowSettings(false)}
+                />
+              </Suspense>
             )}
 
-        {showBackupSettings && (
-          <Suspense fallback={<Spinner />}>
-            <BackupSettings onClose={() => setShowBackupSettings(false)} />
-          </Suspense>
-        )}
-      </AnimatePresence>
-    </motion.div>
-    </div>
-  </>
+            {showBackupSettings && (
+              <Suspense fallback={<Spinner />}>
+                <BackupSettings onClose={() => setShowBackupSettings(false)} />
+              </Suspense>
+            )}
             {showComplianceDashboard && (
               <ErrorBoundary context="Compliance Dashboard">
                 <Suspense fallback={<Spinner />}>

--- a/frontend/src/components/TransactionHistory.jsx
+++ b/frontend/src/components/TransactionHistory.jsx
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { useState, useCallback, useRef, useEffect } from 'react';
 import apiClient from '../api/client.js';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
@@ -21,7 +20,6 @@ function fmt(dateStr) {
   return new Date(dateStr).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
 }
 
-
 function csvEscape(val) {
   const s = val == null ? '' : String(val);
   return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s;
@@ -32,7 +30,9 @@ async function fetchAllTransactions(publicKey) {
   let cursor = null;
   do {
     const params = { limit: 50, ...(cursor ? { cursor } : {}) };
-    const { data } = await apiClient.get(`/api/stellar/account/${publicKey}/transactions`, { params });
+    const { data } = await apiClient.get(`/api/stellar/account/${publicKey}/transactions`, {
+      params,
+    });
     all.push(...(data.records ?? []));
     cursor = data.nextCursor ?? null;
   } while (cursor);
@@ -40,20 +40,34 @@ async function fetchAllTransactions(publicKey) {
 }
 
 function downloadCsv(rows, filename) {
-  const COLS = ['date', 'type', 'direction', 'amount', 'asset', 'counterparty', 'hash', 'fee', 'status'];
+  const COLS = [
+    'date',
+    'type',
+    'direction',
+    'amount',
+    'asset',
+    'counterparty',
+    'hash',
+    'fee',
+    'status',
+  ];
   const lines = [
     COLS.join(','),
-    ...rows.map(tx => [
-      tx.date ? new Date(tx.date).toISOString() : '',
-      TYPE_LABELS[tx.type] ?? tx.type ?? '',
-      tx.direction ?? '',
-      tx.amount ?? '',
-      tx.asset ?? 'XLM',
-      tx.counterparty ?? '',
-      tx.hash ?? '',
-      tx.fee ?? '',
-      tx.successful ? 'success' : 'failed',
-    ].map(csvEscape).join(',')),
+    ...rows.map((tx) =>
+      [
+        tx.date ? new Date(tx.date).toISOString() : '',
+        TYPE_LABELS[tx.type] ?? tx.type ?? '',
+        tx.direction ?? '',
+        tx.amount ?? '',
+        tx.asset ?? 'XLM',
+        tx.counterparty ?? '',
+        tx.hash ?? '',
+        tx.fee ?? '',
+        tx.successful ? 'success' : 'failed',
+      ]
+        .map(csvEscape)
+        .join(','),
+    ),
   ];
   const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
@@ -82,13 +96,14 @@ function TxRow({ tx, onClick, onRetry }) {
       tabIndex={0}
       aria-label={label}
     >
-      <span className={`tx-dir ${isReceived ? 'tx-in' : isSent ? 'tx-out' : 'tx-neutral'}`} aria-hidden="true">
+      <span
+        className={`tx-dir ${isReceived ? 'tx-in' : isSent ? 'tx-out' : 'tx-neutral'}`}
+        aria-hidden="true"
+      >
         {isReceived ? '↓' : isSent ? '↑' : '•'}
       </span>
       <span className="tx-type">{TYPE_LABELS[tx.type] ?? tx.type}</span>
-      <span className="tx-amount">
-        {tx.amount ? `${tx.amount} ${tx.asset ?? ''}` : '—'}
-      </span>
+      <span className="tx-amount">{tx.amount ? `${tx.amount} ${tx.asset ?? ''}` : '—'}</span>
       <span className="tx-date">{fmt(tx.date)}</span>
       <span className={`tx-status ${tx.successful ? 'tx-ok' : 'tx-fail'}`} aria-hidden="true">
         {tx.successful ? '✓' : '✗'}
@@ -96,7 +111,10 @@ function TxRow({ tx, onClick, onRetry }) {
       {!tx.successful && onRetry && (
         <button
           className="tx-retry-btn"
-          onClick={(e) => { e.stopPropagation(); onRetry(tx); }}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRetry(tx);
+          }}
           aria-label={`Retry failed transaction ${tx.hash}`}
         >
           Retry
@@ -113,7 +131,9 @@ function TxModal({ tx, onClose }) {
   const v = makeVariants(prefersReduced);
 
   useEffect(() => {
-    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
   }, [onClose]);
@@ -122,12 +142,15 @@ function TxModal({ tx, onClose }) {
     <motion.div
       className="tx-overlay"
       onClick={onClose}
-      variants={v.fadeSlide} initial="hidden" animate="visible" exit="exit"
+      variants={v.fadeSlide}
+      initial="hidden"
+      animate="visible"
+      exit="exit"
     >
       <motion.div
         ref={modalRef}
         className="tx-modal"
-        onClick={e => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
         variants={v.pop}
         role="dialog"
         aria-modal="true"
@@ -135,13 +158,33 @@ function TxModal({ tx, onClose }) {
       >
         <div className="tx-modal-header">
           <h3 id="tx-modal-title">Transaction Details</h3>
-          <button className="qr-close" onClick={onClose} aria-label="Close transaction details dialog">✕</button>
+          <button
+            className="qr-close"
+            onClick={onClose}
+            aria-label="Close transaction details dialog"
+          >
+            ✕
+          </button>
         </div>
         <dl className="tx-detail-list">
-          <dt>Hash</dt><dd className="tx-hash">{tx.hash}</dd>
-          <dt>Type</dt><dd>{TYPE_LABELS[tx.type] ?? tx.type}</dd>
-          {tx.direction && <><dt>Direction</dt><dd>{tx.direction}</dd></>}
-          {tx.amount && <><dt>Amount</dt><dd>{tx.amount} {tx.asset}</dd></>}
+          <dt>Hash</dt>
+          <dd className="tx-hash">{tx.hash}</dd>
+          <dt>Type</dt>
+          <dd>{TYPE_LABELS[tx.type] ?? tx.type}</dd>
+          {tx.direction && (
+            <>
+              <dt>Direction</dt>
+              <dd>{tx.direction}</dd>
+            </>
+          )}
+          {tx.amount && (
+            <>
+              <dt>Amount</dt>
+              <dd>
+                {tx.amount} {tx.asset}
+              </dd>
+            </>
+          )}
           {tx.counterparty && (
             <>
               <dt>Counterparty</dt>
@@ -151,10 +194,18 @@ function TxModal({ tx, onClose }) {
               </dd>
             </>
           )}
-          <dt>Date</dt><dd>{fmt(tx.date)}</dd>
-          <dt>Fee</dt><dd>{tx.fee} stroops</dd>
-          {tx.memo && <><dt>Memo</dt><dd>{tx.memo}</dd></>}
-          <dt>Status</dt><dd>{tx.successful ? '✓ Success' : '✗ Failed'}</dd>
+          <dt>Date</dt>
+          <dd>{fmt(tx.date)}</dd>
+          <dt>Fee</dt>
+          <dd>{tx.fee} stroops</dd>
+          {tx.memo && (
+            <>
+              <dt>Memo</dt>
+              <dd>{tx.memo}</dd>
+            </>
+          )}
+          <dt>Status</dt>
+          <dd>{tx.successful ? '✓ Success' : '✗ Failed'}</dd>
         </dl>
       </motion.div>
     </motion.div>
@@ -163,17 +214,17 @@ function TxModal({ tx, onClose }) {
 
 export function TransactionHistory({ publicKey }) {
   const [txs, setTxs] = useState([]);
-  const [hasMore, setHasMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const [reachedEnd, setReachedEnd] = useState(false);
   const [selected, setSelected] = useState(null);
   const [filters, setFilters] = useState({ type: '', dateFrom: '', dateTo: '', hash: '' });
-  const [page, setPage] = useState(1);
-  const [cursors, setCursors] = useState([]); // cursor per page index for back-navigation
   const [error, setError] = useState(null);
-  const [retrying, setRetrying] = useState({}); // { [txId]: 'pending' | 'success' | 'error' }
+  const [retrying, setRetrying] = useState({});
   const [exporting, setExporting] = useState(false);
-  const [nextCursor, setNextCursor] = useState(null); // eslint-disable-line no-unused-vars
+  const sentinelRef = useRef(null);
   const prefersReduced = useReducedMotion();
   const tap = tapScale(prefersReduced);
 
@@ -190,58 +241,104 @@ export function TransactionHistory({ publicKey }) {
     }
   };
 
-  const fetchPage = useCallback(async (targetPage = 1, cursor = null) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const params = { page: targetPage, pageSize: PAGE_SIZE, ...(cursor ? { cursor } : {}) };
+  const buildParams = useCallback(
+    (cursor = null) => {
+      const params = { limit: PAGE_SIZE };
+      if (cursor) params.cursor = cursor;
       if (filters.type) params.type = filters.type;
       if (filters.dateFrom) params.dateFrom = filters.dateFrom;
       if (filters.dateTo) params.dateTo = filters.dateTo;
       if (filters.hash) params.hash = filters.hash;
-      const { data: resp } = await axios.get(`/api/v1/transactions/${publicKey}`, { params });
-      const records = resp.data ?? resp.records ?? resp;
-      setTxs(Array.isArray(records) ? records : []);
-      setHasMore(!!resp.nextCursor || (Array.isArray(records) && records.length === PAGE_SIZE));
-      setPage(targetPage);
-      const { data } = await apiClient.get(`/api/stellar/account/${publicKey}/transactions`, { params });
-      setTxs(data.records);
-      setNextCursor(data.nextCursor);
-      setLoaded(true);
+      return params;
+    },
+    [filters],
+  );
 
-      if (targetPage > 1 && resp.nextCursor) {
-        setCursors(prev => {
-          const next = [...prev];
-          next[targetPage - 1] = resp.nextCursor;
-          return next;
-        });
-      }
+  const loadFirst = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setTxs([]);
+    setNextCursor(null);
+    setReachedEnd(false);
+    try {
+      const { data } = await apiClient.get(`/api/stellar/account/${publicKey}/transactions`, {
+        params: buildParams(),
+      });
+      const records = data.records ?? [];
+      setTxs(records);
+      const cursor = data.nextCursor ?? null;
+      setNextCursor(cursor);
+      setReachedEnd(cursor === null);
+      setLoaded(true);
     } catch (e) {
       setError(e?.response?.data?.error ?? e?.message ?? 'Failed to load transactions.');
     } finally {
       setLoading(false);
     }
-  }, [publicKey, filters]);
+  }, [publicKey, buildParams]);
 
-  const handleLoad = () => { setCursors([]); setPage(1); fetchPage(1, null); };
-  const handleNext = () => fetchPage(page + 1, cursors[page - 1] ?? null);
-  const handleBack = () => fetchPage(page - 1, cursors[page - 2] ?? null);
-  const applyFilters = (e) => { e.preventDefault(); setCursors([]); setPage(1); fetchPage(1, null); };
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    setError(null);
+    try {
+      const { data } = await apiClient.get(`/api/stellar/account/${publicKey}/transactions`, {
+        params: buildParams(nextCursor),
+      });
+      const records = data.records ?? [];
+      setTxs((prev) => [...prev, ...records]);
+      const cursor = data.nextCursor ?? null;
+      setNextCursor(cursor);
+      if (cursor === null) setReachedEnd(true);
+    } catch (e) {
+      setError(e?.response?.data?.error ?? e?.message ?? 'Failed to load more transactions.');
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [publicKey, nextCursor, loadingMore, buildParams]);
+
+  useEffect(() => {
+    if (!loaded || reachedEnd || loadingMore || !nextCursor) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) loadMore();
+      },
+      { rootMargin: '200px' },
+    );
+    const el = sentinelRef.current;
+    if (el) observer.observe(el);
+    return () => {
+      if (el) observer.unobserve(el);
+    };
+  }, [loaded, reachedEnd, loadingMore, nextCursor, loadMore]);
+
+  const handleLoad = () => loadFirst();
+  const applyFilters = (e) => {
+    e.preventDefault();
+    loadFirst();
+  };
 
   const handleRetry = useCallback(async (tx) => {
-    setRetrying(r => ({ ...r, [tx.id]: 'pending' }));
+    setRetrying((r) => ({ ...r, [tx.id]: 'pending' }));
     try {
       await apiClient.post('/api/retry/transaction', { transactionHash: tx.hash });
-      setRetrying(r => ({ ...r, [tx.id]: 'success' }));
-      setTxs(prev => prev.map(t => t.id === tx.id ? { ...t, successful: true } : t));
+      setRetrying((r) => ({ ...r, [tx.id]: 'success' }));
+      setTxs((prev) => prev.map((t) => (t.id === tx.id ? { ...t, successful: true } : t)));
     } catch {
-      setRetrying(r => ({ ...r, [tx.id]: 'error' }));
+      setRetrying((r) => ({ ...r, [tx.id]: 'error' }));
     }
   }, []);
 
   return (
     <section className="section" aria-labelledby="tx-history-heading">
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 8,
+        }}
+      >
         <h3 id="tx-history-heading">Transaction History</h3>
         <div style={{ display: 'flex', gap: 8 }}>
           <motion.button
@@ -267,41 +364,51 @@ export function TransactionHistory({ publicKey }) {
       </div>
 
       <form className="tx-filters" onSubmit={applyFilters} aria-label="Filter transactions">
-        <label htmlFor="tx-type-filter" className="sr-only">Transaction type</label>
+        <label htmlFor="tx-type-filter" className="sr-only">
+          Transaction type
+        </label>
         <select
           id="tx-type-filter"
           value={filters.type}
-          onChange={e => setFilters(f => ({ ...f, type: e.target.value }))}
+          onChange={(e) => setFilters((f) => ({ ...f, type: e.target.value }))}
           aria-label="Filter by transaction type"
         >
           <option value="">All types</option>
           <option value="payment">Payment</option>
           <option value="create_account">Account Created</option>
         </select>
-        <label htmlFor="tx-date-from" className="sr-only">From date</label>
+        <label htmlFor="tx-date-from" className="sr-only">
+          From date
+        </label>
         <input
           id="tx-date-from"
           type="date"
           value={filters.dateFrom}
-          onChange={e => setFilters(f => ({ ...f, dateFrom: e.target.value }))}
+          onChange={(e) => setFilters((f) => ({ ...f, dateFrom: e.target.value }))}
           aria-label="Filter from date"
         />
-        <label htmlFor="tx-date-to" className="sr-only">To date</label>
+        <label htmlFor="tx-date-to" className="sr-only">
+          To date
+        </label>
         <input
           id="tx-date-to"
           type="date"
           value={filters.dateTo}
-          onChange={e => setFilters(f => ({ ...f, dateTo: e.target.value }))}
+          onChange={(e) => setFilters((f) => ({ ...f, dateTo: e.target.value }))}
           aria-label="Filter to date"
         />
-        <button type="submit" className="tx-filter-btn">Filter</button>
-        <label htmlFor="tx-hash-filter" className="sr-only">Transaction hash</label>
+        <button type="submit" className="tx-filter-btn">
+          Filter
+        </button>
+        <label htmlFor="tx-hash-filter" className="sr-only">
+          Transaction hash
+        </label>
         <input
           id="tx-hash-filter"
           type="text"
           placeholder="Search by hash…"
           value={filters.hash}
-          onChange={e => setFilters(f => ({ ...f, hash: e.target.value }))}
+          onChange={(e) => setFilters((f) => ({ ...f, hash: e.target.value }))}
           aria-label="Filter by transaction hash"
           spellCheck={false}
         />
@@ -309,30 +416,87 @@ export function TransactionHistory({ publicKey }) {
 
       <AnimatePresence mode="wait">
         {error && (
-          <motion.div key="error" className="tx-error" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+          <motion.div
+            key="error"
+            className="tx-error"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
             <p>{error}</p>
-            <button className="tx-page-btn" onClick={() => fetchPage(cursors[cursors.length - 1] ?? null)}>↺ Retry</button>
+            <button className="tx-page-btn" onClick={loadFirst}>
+              ↺ Retry
+            </button>
           </motion.div>
         )}
         {!error && loading && (
-          <motion.div key="skeleton" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} aria-label="Loading transactions" aria-busy="true">
-            {Array.from({ length: 5 }, (_, i) => <SkeletonCard key={i} />)}
+          <motion.div
+            key="skeleton"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            aria-label="Loading transactions"
+            aria-busy="true"
+          >
+            {Array.from({ length: 5 }, (_, i) => (
+              <SkeletonCard key={i} />
+            ))}
           </motion.div>
         )}
         {!error && !loading && loaded && (
-          <motion.div key="list" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+          <motion.div
+            key="list"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
             {txs.length === 0 ? (
-              <div className="tx-empty" role="status" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12, padding: '24px 0' }}>
-                <svg width="80" height="80" viewBox="0 0 80 80" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+              <div
+                className="tx-empty"
+                role="status"
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: 12,
+                  padding: '24px 0',
+                }}
+              >
+                <svg
+                  width="80"
+                  height="80"
+                  viewBox="0 0 80 80"
+                  fill="none"
+                  aria-hidden="true"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
                   <circle cx="40" cy="40" r="38" stroke="#e5e7eb" strokeWidth="2" />
                   <rect x="22" y="28" width="36" height="6" rx="3" fill="#e5e7eb" />
                   <rect x="22" y="38" width="28" height="6" rx="3" fill="#e5e7eb" />
                   <rect x="22" y="48" width="20" height="6" rx="3" fill="#e5e7eb" />
                   <circle cx="58" cy="54" r="10" fill="#f3f4f6" stroke="#e5e7eb" strokeWidth="2" />
-                  <line x1="55" y1="54" x2="61" y2="54" stroke="#9ca3af" strokeWidth="2" strokeLinecap="round" />
-                  <line x1="58" y1="51" x2="58" y2="57" stroke="#9ca3af" strokeWidth="2" strokeLinecap="round" />
+                  <line
+                    x1="55"
+                    y1="54"
+                    x2="61"
+                    y2="54"
+                    stroke="#9ca3af"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                  <line
+                    x1="58"
+                    y1="51"
+                    x2="58"
+                    y2="57"
+                    stroke="#9ca3af"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
                 </svg>
-                <p style={{ margin: 0, fontSize: 14, color: '#6b7280' }}>No transactions yet — send your first payment above.</p>
+                <p style={{ margin: 0, fontSize: 14, color: '#6b7280' }}>
+                  No transactions yet — send your first payment above.
+                </p>
               </div>
             ) : (
               <>
@@ -340,7 +504,11 @@ export function TransactionHistory({ publicKey }) {
                   <VirtualList
                     items={txs}
                     renderItem={(tx) => (
-                      <TxRow tx={tx} onClick={setSelected} onRetry={retrying[tx.id] !== 'pending' ? handleRetry : null} />
+                      <TxRow
+                        tx={tx}
+                        onClick={setSelected}
+                        onRetry={retrying[tx.id] !== 'pending' ? handleRetry : null}
+                      />
                     )}
                     itemHeight={64}
                     height={Math.min(txs.length * 64 + 1, 480)}
@@ -349,16 +517,37 @@ export function TransactionHistory({ publicKey }) {
                   <ul className="tx-list">
                     {txs.map((tx) => (
                       <li key={tx.id || tx.hash}>
-                        <TxRow tx={tx} onClick={setSelected} onRetry={retrying[tx.id] !== 'pending' ? handleRetry : null} />
+                        <TxRow
+                          tx={tx}
+                          onClick={setSelected}
+                          onRetry={retrying[tx.id] !== 'pending' ? handleRetry : null}
+                        />
                       </li>
                     ))}
                   </ul>
                 )}
-                <nav className="tx-pagination" aria-label="Transaction page navigation">
-                  <button onClick={handleBack} disabled={page <= 1 || loading} className="tx-page-btn" aria-label="Previous page">← Prev</button>
-                  <span className="tx-page-info" aria-current="page">Page {page}</span>
-                  <button onClick={handleNext} disabled={!hasMore || loading} className="tx-page-btn" aria-label="Next page">Next →</button>
-                </nav>
+                <div ref={sentinelRef} aria-hidden="true" style={{ height: 1 }} />
+                {loadingMore && (
+                  <div aria-label="Loading more transactions" aria-busy="true">
+                    {Array.from({ length: 3 }, (_, i) => (
+                      <SkeletonCard key={i} />
+                    ))}
+                  </div>
+                )}
+                {reachedEnd && (
+                  <p
+                    className="tx-end-message"
+                    role="status"
+                    style={{
+                      textAlign: 'center',
+                      color: '#6b7280',
+                      fontSize: 14,
+                      padding: '12px 0',
+                    }}
+                  >
+                    You've reached the end
+                  </p>
+                )}
               </>
             )}
           </motion.div>


### PR DESCRIPTION
## Summary


### closes #715 — Server-side cursor pagination for transaction history

**Backend** (`backend/src/routes/stellar.js`): the `/account/:publicKey/transactions` route now enforces a default `limit` of 20 (was 10), a maximum of 100 (was 50), and returns `400` with a descriptive message for any `limit` that is not an integer in [1, 100]. The underlying `getTransactions()` service in `stellar.js` already supported cursor-based pagination — the route just wasn't exposing correct defaults or validation.

**Frontend** (`frontend/src/components/TransactionHistory.jsx`): replaced the old prev/next button pagination with infinite scroll driven by an `IntersectionObserver` on a 1 px sentinel element at the bottom of the list. New pages are appended without resetting state. A skeleton loader appears while the next page loads, and a "You've reached the end" status message appears when `nextCursor` is `null`. Errors show a retry button that re-fetches the current page.

### closes #716 — Redis caching for account balance responses

Added `backend/src/cache/balanceCache.js`, a thin wrapper around the existing `RedisBackend` class. Cache key: `balance:{accountId}`, TTL configurable via `BALANCE_CACHE_TTL_SECONDS` (default 10 s). Integrated into `stellar.js`:
- `getBalance()` now calls `getCachedBalance()` — cache hit returns immediately, miss falls through to Horizon, Redis errors fail open so balance fetches are never blocked.
- `sendPayment()` calls `invalidateBalanceCache()` immediately after a successful transaction submission so the post-send balance is always live.

### closes #717 — Lazy-load non-critical frontend routes

`AccountSettings` (previously a static import) is now loaded via `React.lazy` and wrapped in `<Suspense fallback={<Spinner />}>` at its usage site. `AMMPoolBrowser`, `AccountRecovery`, `MultiSigTransactions`, `KYCForm`, `ComplianceDashboard`, and `BackupSettings` were already lazy — this change completes the set by converting the remaining eagerly-loaded heavy component.

Also fixed a pre-existing structural JSX bug in `App.jsx` (a stagger `<motion.div>` that was never closed, causing the `{account && (...)}` expression to have multiple roots) and removed a duplicate premature fragment close that was left over from a merge conflict. Without these fixes the file failed both ESLint and Prettier.

### closes #718 — Memoize exchange rate calculations in `assetConverter.js`

`AssetConverterService.getConversionRate()` now caches results in an in-process `Map` keyed by `${sourceAsset}:${destAsset}:${intervalKey}`, where `intervalKey = Math.floor(Date.now() / (ttl * 1000))`. All calls for the same pair within the same TTL window share one Horizon fetch. Expired entries are evicted on each cache miss. TTL is configurable via `RATE_CACHE_TTL_SECONDS` (default 30 s); a warning is logged if it is set below 5 s.

## Files changed

| File | Change |
|------|--------|
| `backend/src/cache/balanceCache.js` | New — Redis-backed balance cache with fail-open behaviour |
| `backend/src/services/stellar.js` | Wire `getCachedBalance` / `invalidateBalanceCache` into `getBalance` and `sendPayment` |
| `backend/src/routes/stellar.js` | Fix `limit` default (20), max (100), and add 400 validation |
| `backend/src/services/assetConverter.js` | Add in-process rate memoization with TTL-keyed eviction |
| `frontend/src/App.jsx` | Lazy-load `AccountSettings`; fix stagger div close and premature fragment |
| `frontend/src/components/TransactionHistory.jsx` | Replace prev/next pagination with IntersectionObserver infinite scroll |

## Test plan

- [ ] `GET /api/stellar/account/:key/transactions` without `limit` returns 20 records and a `nextCursor`
- [ ] `GET …?limit=0` and `GET …?limit=101` return 400
- [ ] Scrolling to the bottom of Transaction History loads the next page without duplicates
- [ ] "You've reached the end" appears when `nextCursor` is null
- [ ] Dashboard balance loads from cache on repeated requests (check logs for `cache.balance.hit`)
- [ ] Submitting a payment invalidates the cache; the next balance fetch goes to Horizon
- [ ] Killing Redis does not break balance fetches (fail-open)
- [ ] Navigating to Account Settings / AMM Pool Browser shows the Spinner briefly, then the component
- [ ] Repeated calls to `getConversionRate` for the same pair within 30 s produce one Horizon request