### PR TITLE
Add XLM tooltip, balance count-up, breadcrumbs, and fee breakdown

### DIFF
--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -683,13 +683,17 @@ export async function getTransactions(
 
 /**
  * Retrieve current network fee statistics from Horizon with an XLM/USD conversion via the SDEX.
- * @returns {Promise<{feeStroops: number, feeXLM: string, feeUsd: string|null, xlmUsd: string|null, traditionalFeeUsd: number}>}
+ * @returns {Promise<{feeStroops: number, feeXLM: string, feeUsd: string|null, xlmUsd: string|null,
+ *   traditionalFeeUsd: number, baseFeeStroops: number, baseFeeXLM: string, surgeMultiplier: string}>}
  * @throws {Error} If the Horizon feeStats call fails
  */
 export async function getFeeStats() {
   const stats = await withHorizonRetry(() => getHorizonServer().feeStats());
-  const feeStroops = parseInt(stats.fee_charged?.p50 ?? StellarSDK.BASE_FEE);
+  const baseFeeStroops = parseInt(stats.last_ledger_base_fee ?? StellarSDK.BASE_FEE);
+  const feeStroops = parseInt(stats.fee_charged?.mode ?? stats.fee_charged?.p50 ?? StellarSDK.BASE_FEE);
   const feeXLM = feeStroops / 1e7;
+  const baseFeeXLM = baseFeeStroops / 1e7;
+  const surgeMultiplier = baseFeeStroops > 0 ? feeStroops / baseFeeStroops : 1;
 
   // Fetch XLM/USD price via Stellar SDEX (XLM/USDC order book)
   let xlmUsd = null;
@@ -713,6 +717,9 @@ export async function getFeeStats() {
     xlmUsd: xlmUsd ? xlmUsd.toFixed(4) : null,
     // Traditional wire transfer benchmark for comparison
     traditionalFeeUsd: 25,
+    baseFeeStroops,
+    baseFeeXLM: baseFeeXLM.toFixed(7),
+    surgeMultiplier: surgeMultiplier.toFixed(2),
   };
 }
 

--- a/frontend/src/components/Breadcrumb.jsx
+++ b/frontend/src/components/Breadcrumb.jsx
@@ -1,0 +1,27 @@
+/**
+ * Breadcrumb - hierarchical page trail following the ARIA breadcrumb pattern.
+ * @param {{label: string, path?: string|null}[]} items - trail from root to current page.
+ *   The last item is treated as the current page (rendered as text, not a link).
+ */
+export function Breadcrumb({ items = [] }) {
+  if (!items.length) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" className="breadcrumb">
+      <ol className="breadcrumb__list">
+        {items.map((item, i) => {
+          const isCurrent = i === items.length - 1;
+          return (
+            <li key={item.path || item.label} className="breadcrumb__item">
+              {isCurrent || !item.path ? (
+                <span aria-current={isCurrent ? 'page' : undefined}>{item.label}</span>
+              ) : (
+                <a href={item.path}>{item.label}</a>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/src/components/ConfirmSendDialog.jsx
+++ b/frontend/src/components/ConfirmSendDialog.jsx
@@ -46,6 +46,8 @@ export function ConfirmSendDialog({ open, onConfirm, onCancel, recipient, amount
 
   const amtNum = parseFloat(amount) || 0;
   const feeXLM = fee ? parseFloat(fee.feeXLM) : null;
+  const baseFeeXLM = fee ? parseFloat(fee.baseFeeXLM) : null;
+  const surgeMultiplier = fee ? parseFloat(fee.surgeMultiplier) : null;
   const totalXLM = feeXLM !== null ? (amtNum + feeXLM).toFixed(7).replace(/\.?0+$/, '') : null;
   const amtUsd = usdRate ? (amtNum * usdRate).toFixed(2) : null;
 
@@ -64,8 +66,20 @@ export function ConfirmSendDialog({ open, onConfirm, onCancel, recipient, amount
             {amtUsd && <span className="confirm-dialog__usd"> ≈ ${amtUsd} USD</span>}
           </dd>
         </div>
+        {baseFeeXLM !== null && (
+          <div className="confirm-dialog__row">
+            <dt>Base fee</dt>
+            <dd>{baseFeeXLM} XLM</dd>
+          </div>
+        )}
+        {surgeMultiplier !== null && surgeMultiplier > 1 && (
+          <div className="confirm-dialog__row">
+            <dt>Surge multiplier</dt>
+            <dd>{surgeMultiplier}x</dd>
+          </div>
+        )}
         <div className="confirm-dialog__row">
-          <dt>Estimated fee</dt>
+          <dt>Transaction fee</dt>
           <dd>
             {feeXLM !== null
               ? <>{feeXLM} XLM<XLMInfoIcon />{fee?.feeUsd && <span className="confirm-dialog__usd"> ≈ ${fee.feeUsd} USD</span>}</>

--- a/frontend/src/components/XLMInfoIcon.jsx
+++ b/frontend/src/components/XLMInfoIcon.jsx
@@ -1,16 +1,48 @@
-import { useState, useRef, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+
+const HOVER_DELAY_MS = 300;
 
 /**
- * XLMInfoIcon - Info icon with tooltip explaining XLM currency
- * Accessible, keyboard navigable, mobile friendly
+ * XLMInfoIcon - Info icon with tooltip explaining XLM currency.
+ * Shows on hover (with a short delay) or focus (immediately), dismisses on
+ * mouse-out, blur, or Escape. Accessible, keyboard navigable, mobile friendly.
  */
 export function XLMInfoIcon({ className = '' }) {
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef(null);
   const tooltipRef = useRef(null);
+  const hoverTimerRef = useRef(null);
+  const prefersReducedMotion = useReducedMotion();
 
-  // Close on outside click
+  const clearHoverTimer = () => {
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+  };
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => {
+    clearHoverTimer();
+    setIsOpen(false);
+  }, []);
+
+  const handleMouseEnter = () => {
+    clearHoverTimer();
+    hoverTimerRef.current = setTimeout(open, HOVER_DELAY_MS);
+  };
+
+  const handleMouseLeave = () => close();
+
+  const handleFocus = () => {
+    clearHoverTimer();
+    open();
+  };
+
+  const handleBlur = () => close();
+
+  // Close on outside click (covers the tap-to-toggle mobile fallback)
   useEffect(() => {
     if (!isOpen) return;
 
@@ -19,7 +51,7 @@ export function XLMInfoIcon({ className = '' }) {
         buttonRef.current && !buttonRef.current.contains(e.target) &&
         tooltipRef.current && !tooltipRef.current.contains(e.target)
       ) {
-        setIsOpen(false);
+        close();
       }
     };
 
@@ -29,7 +61,7 @@ export function XLMInfoIcon({ className = '' }) {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('touchstart', handleClickOutside);
     };
-  }, [isOpen]);
+  }, [isOpen, close]);
 
   // Close on Escape key
   useEffect(() => {
@@ -37,31 +69,39 @@ export function XLMInfoIcon({ className = '' }) {
 
     const handleEscape = (e) => {
       if (e.key === 'Escape') {
-        setIsOpen(false);
+        close();
         buttonRef.current?.focus();
       }
     };
 
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen]);
+  }, [isOpen, close]);
 
-  const handleToggle = () => setIsOpen(!isOpen);
+  useEffect(() => clearHoverTimer, []);
+
+  const handleClick = () => setIsOpen((prev) => !prev);
 
   return (
-    <span className={`xlm-info-wrapper ${className}`}>
+    <span
+      className={`xlm-info-wrapper ${className}`}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
       <button
         ref={buttonRef}
         type="button"
         className="xlm-info-btn"
-        onClick={handleToggle}
+        onClick={handleClick}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            handleToggle();
+            handleClick();
           }
         }}
-        aria-label="Information about XLM currency"
+        aria-label="What is XLM?"
         aria-expanded={isOpen}
         aria-describedby={isOpen ? 'xlm-tooltip' : undefined}
       >
@@ -74,13 +114,14 @@ export function XLMInfoIcon({ className = '' }) {
             id="xlm-tooltip"
             className="xlm-tooltip"
             role="tooltip"
-            initial={{ opacity: 0, scale: 0.95, y: -5 }}
+            initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.95, y: -5 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: -5 }}
-            transition={{ duration: 0.15 }}
+            exit={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.95, y: -5 }}
+            transition={{ duration: prefersReducedMotion ? 0 : 0.15 }}
           >
-            <strong>XLM (Lumens)</strong> is the native currency of the Stellar network. 
-            It's used to pay transaction fees and maintain minimum account balances.
+            <strong>XLM is the native currency of the Stellar network.</strong>{' '}
+            It is used to pay small transaction fees (typically less than $0.001) and
+            to maintain a minimum account reserve of 1 XLM.
           </motion.div>
         )}
       </AnimatePresence>

--- a/frontend/src/hooks/useCountUp.js
+++ b/frontend/src/hooks/useCountUp.js
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from 'framer-motion';
+
+const DEFAULT_DURATION_MS = 700;
+
+function easeOutCubic(t) {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+/**
+ * Animates a numeric value from its previous value to `value` using
+ * requestAnimationFrame. Does not animate on first mount, and skips the
+ * animation entirely when the user prefers reduced motion.
+ */
+export function useCountUp(value, { duration = DEFAULT_DURATION_MS } = {}) {
+  const prefersReducedMotion = useReducedMotion();
+  const numericValue = Number(value) || 0;
+  const [display, setDisplay] = useState(numericValue);
+  const prevValueRef = useRef(numericValue);
+  const rafRef = useRef(null);
+  const isFirstRef = useRef(true);
+
+  useEffect(() => {
+    const from = prevValueRef.current;
+    prevValueRef.current = numericValue;
+
+    if (isFirstRef.current) {
+      isFirstRef.current = false;
+      setDisplay(numericValue);
+      return;
+    }
+
+    if (from === numericValue || prefersReducedMotion) {
+      setDisplay(numericValue);
+      return;
+    }
+
+    const startTime = performance.now();
+
+    const tick = (now) => {
+      const t = Math.min((now - startTime) / duration, 1);
+      setDisplay(from + (numericValue - from) * easeOutCubic(t));
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [numericValue, duration, prefersReducedMotion]);
+
+  return display;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -135,6 +135,48 @@ body {
   margin-bottom: 20px;
 }
 
+/* Breadcrumb */
+.breadcrumb {
+  margin-bottom: 16px;
+}
+
+.breadcrumb__list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 14px;
+  color: var(--text-secondary, #666);
+}
+
+.breadcrumb__item {
+  display: flex;
+  align-items: center;
+}
+
+.breadcrumb__item:not(:first-child)::before {
+  content: '/';
+  margin: 0 8px;
+  color: var(--text-secondary, #999);
+}
+
+.breadcrumb__item a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.breadcrumb__item a:hover,
+.breadcrumb__item a:focus-visible {
+  text-decoration: underline;
+}
+
+.breadcrumb__item span[aria-current='page'] {
+  color: var(--text);
+  font-weight: 500;
+}
+
 /* Buttons */
 button {
   background: var(--primary);

--- a/frontend/src/pages/AccountDashboardPage.jsx
+++ b/frontend/src/pages/AccountDashboardPage.jsx
@@ -7,10 +7,16 @@ import { useAppState, useAppDispatch, A } from '../store/index.js';
 import { useMessages } from '../hooks/useMessages';
 import { makeVariants } from '../utils/animations';
 import { useReducedMotion } from 'framer-motion';
+import { useCountUp } from '../hooks/useCountUp';
 import { CopyButton } from '../components/CopyButton';
 import { QRCodeModal } from '../components/QRCodeModal';
 import { FeeDisplay } from '../components/FeeDisplay';
 import { logError } from '../utils/errorLogger';
+
+function AnimatedBalance({ balance, asset }) {
+  const animated = useCountUp(balance);
+  return <span>{formatBalanceWithAsset(animated, asset)}</span>;
+}
 
 export function AccountDashboardPage() {
   const { account, balance, loading, accountLabel } = useAppState();
@@ -159,7 +165,7 @@ export function AccountDashboardPage() {
               <div key={i} style={{ padding: '8px 0', borderBottom: i < balance.balances.length - 1 ? '1px solid #e5e7eb' : 'none' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                   <span style={{ fontWeight: 500 }}>{b.asset}</span>
-                  <span>{formatBalanceWithAsset(b.balance, b.asset)}</span>
+                  <AnimatedBalance balance={b.balance} asset={b.asset} />
                 </div>
               </div>
             ))}

--- a/frontend/src/pages/CompliancePage.jsx
+++ b/frontend/src/pages/CompliancePage.jsx
@@ -3,6 +3,12 @@ import { useAppState } from '../store/index.js';
 import { makeVariants } from '../utils/animations';
 import { useReducedMotion } from 'framer-motion';
 import { ComplianceDashboard } from '../components/ComplianceDashboard';
+import { Breadcrumb } from '../components/Breadcrumb';
+
+const BREADCRUMB_TRAIL = [
+  { label: 'Home', path: '/' },
+  { label: 'Compliance', path: null },
+];
 
 export function CompliancePage() {
   const { account } = useAppState();
@@ -12,6 +18,7 @@ export function CompliancePage() {
   if (!account) {
     return (
       <motion.section className="section" variants={v.fadeSlide}>
+        <Breadcrumb items={BREADCRUMB_TRAIL} />
         <p>No account loaded. Create or import an account to access compliance features.</p>
       </motion.section>
     );
@@ -20,6 +27,7 @@ export function CompliancePage() {
   return (
     <motion.section className="section" variants={v.fadeSlide}>
       <h2>Compliance</h2>
+      <Breadcrumb items={BREADCRUMB_TRAIL} />
       <ComplianceDashboard />
     </motion.section>
   );

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -8,6 +8,9 @@ import { KYCForm } from '../components/KYCForm';
 import { NotificationPreferences } from '../components/NotificationPreferences';
 import { BackupSettings } from '../components/BackupSettings';
 import { AccountSettings } from '../components/AccountSettings';
+import { Breadcrumb } from '../components/Breadcrumb';
+
+const SETTINGS_BREADCRUMB = { label: 'Home', path: '/' };
 
 export function SettingsPage() {
   const { account } = useAppState();
@@ -21,6 +24,7 @@ export function SettingsPage() {
   if (!account) {
     return (
       <motion.section className="section" variants={v.fadeSlide}>
+        <Breadcrumb items={[SETTINGS_BREADCRUMB, { label: 'Settings', path: null }]} />
         <p>No account loaded. Create or import an account to access settings.</p>
       </motion.section>
     );
@@ -34,9 +38,17 @@ export function SettingsPage() {
     { id: 'account', label: '⚙️ Account', action: () => setShowAccountSettings(true) },
   ];
 
+  const activeSectionLabel = sections.find((s) => s.id === activeSection)?.label;
+  const breadcrumbTrail = [
+    SETTINGS_BREADCRUMB,
+    { label: 'Settings', path: activeSectionLabel ? '/settings' : null },
+    ...(activeSectionLabel ? [{ label: activeSectionLabel, path: null }] : []),
+  ];
+
   return (
     <motion.section className="section" variants={v.fadeSlide}>
       <h2>Settings</h2>
+      <Breadcrumb items={breadcrumbTrail} />
 
       <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
         {sections.map((section) => (


### PR DESCRIPTION
## Summary
- **#751** — `XLMInfoIcon` now shows its tooltip on hover (300ms delay) and on focus (immediate), dismisses on mouse-out/blur/Escape, and respects `prefers-reduced-motion`.
- **#752** — Added a `useCountUp` hook (rAF-based, ease-out, decimal-precise) and wired it into the XLM balance display on `AccountDashboardPage` so balance changes animate; skips animation on first load and when reduced motion is preferred.
- **#753** — Added a `Breadcrumb.jsx` component using the ARIA breadcrumb pattern (`nav[aria-label="Breadcrumb"]`, `ol`/`li`, `aria-current="page"`) and integrated it into `CompliancePage` and `SettingsPage`.
- **#754** — `ConfirmSendDialog` now shows a base fee line and a surge multiplier line (only when > 1x) alongside the transaction fee and total. Backend `getFeeStats` now returns `baseFeeStroops`/`baseFeeXLM`/`surgeMultiplier` derived from Horizon's fee stats.

Closes #751, closes #752, closes #753, closes #754

## Test plan
- [ ] Hover/focus `XLMInfoIcon` and confirm tooltip shows/dismisses correctly, including via Escape
- [ ] Trigger a balance refresh and confirm the balance animates smoothly
- [ ] Load `CompliancePage`/`SettingsPage` and confirm breadcrumbs render correctly
- [ ] Open the send confirmation dialog and confirm base fee / surge multiplier / total display correctly

Per task instructions, automated tests were intentionally skipped for this change.