### PR TITLE
feat: structured logging, correlation IDs, microservice health, dev c…

### DIFF
--- a/backend/src/microservices/discovery.js
+++ b/backend/src/microservices/discovery.js
@@ -77,6 +77,33 @@ export class ServiceRegistry {
       })),
     };
   }
+
+  /**
+   * Returns a health snapshot for every registered service.
+   * Used by load balancers and orchestration systems to check service status.
+   * @returns {{ status: 'healthy'|'degraded'|'unhealthy', uptime: number, timestamp: string, services: object[] }}
+   */
+  health() {
+    const uptime = process.uptime();
+    const services = Array.from(this.services.keys()).map((name) => {
+      const instances = this.discoverInstances(name);
+      const total = instances.length;
+      const healthy = instances.filter((i) => i.status === 'healthy').length;
+      const status = total === 0 ? 'unknown' : healthy === total ? 'healthy' : healthy > 0 ? 'degraded' : 'unhealthy';
+      return { name, status, totalInstances: total, healthyInstances: healthy };
+    });
+
+    const unhealthy = services.filter((s) => s.status === 'unhealthy').length;
+    const degraded = services.filter((s) => s.status === 'degraded').length;
+    const overallStatus = unhealthy > 0 ? 'unhealthy' : degraded > 0 ? 'degraded' : 'healthy';
+
+    return {
+      status: overallStatus,
+      uptime,
+      timestamp: new Date().toISOString(),
+      services,
+    };
+  }
 }
 
 export const createServiceRegistry = () => new ServiceRegistry();

--- a/backend/src/microservices/gateway.js
+++ b/backend/src/microservices/gateway.js
@@ -323,6 +323,23 @@ export class APIGateway {
   getRoutes() {
     return Array.from(this.routes.values()).map(config => ({ ...config }));
   }
+
+  /**
+   * Returns a health snapshot for the gateway.
+   * Reports uptime, total registered routes, and a per-service instance summary
+   * sourced from the underlying registry.
+   * @returns {{ status: 'healthy'|'degraded'|'unhealthy', uptime: number, timestamp: string, routes: number, services: object[] }}
+   */
+  health() {
+    const registryHealth = this.registry.health();
+    return {
+      status: registryHealth.status,
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString(),
+      routes: this.routes.size,
+      services: registryHealth.services,
+    };
+  }
 }
 
 export const createAPIGateway = (registry) => new APIGateway(registry);

--- a/backend/src/routes/microservicesHealth.js
+++ b/backend/src/routes/microservicesHealth.js
@@ -1,0 +1,26 @@
+/**
+ * Microservices health route
+ * Exposes GET /microservices/health for load-balancer and orchestration probes.
+ * Delegates to ServiceRegistry.health() which aggregates per-service instance status.
+ */
+import express from 'express';
+import { ServiceRegistry } from '../microservices/discovery.js';
+
+const router = express.Router();
+
+// Shared singleton registry — callers register services/instances against this.
+export const serviceRegistry = new ServiceRegistry();
+
+/**
+ * GET /microservices/health
+ * Returns the aggregate health of all registered microservices.
+ * Response shape:
+ *   { status, uptime, timestamp, services: [{ name, status, totalInstances, healthyInstances }] }
+ */
+router.get('/microservices/health', (req, res) => {
+  const health = serviceRegistry.health();
+  const statusCode = health.status === 'healthy' ? 200 : health.status === 'degraded' ? 200 : 503;
+  res.status(statusCode).json(health);
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -21,6 +21,7 @@ import securityRoutes from './routes/security.js';
 import loadTestingRoutes from './routes/loadTesting.js';
 import chaosRoutes from './routes/chaos.js';
 import healthRoutes from './routes/health.js';
+import microservicesHealthRoutes from './routes/microservicesHealth.js';
 import mobileRoutes from './routes/mobile.js';
 import webhookRoutes from './routes/webhooks.js';
 import metricsRoutes from './routes/metrics.js';
@@ -190,6 +191,7 @@ app.get('/.well-known/stellar.toml', (_req, res) => {
 
 // Health routes (not versioned - used by load balancers)
 app.use('/', healthRoutes);
+app.use('/', microservicesHealthRoutes);
 
 // Deprecation middleware for unversioned /api/* paths
 app.use('/api/*', (req, res, next) => {

--- a/backend/src/services/assetConverter.js
+++ b/backend/src/services/assetConverter.js
@@ -1,4 +1,5 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
+import logger from '../config/logger.js';
 
 /**
  * Asset Conversion Utility Service
@@ -10,9 +11,10 @@ class AssetConverterService {
     this._rateCache = new Map();
     this._rateTtl = parseInt(process.env.RATE_CACHE_TTL_SECONDS ?? '30', 10);
     if (this._rateTtl < 5) {
-      console.warn(
-        `[assetConverter] RATE_CACHE_TTL_SECONDS=${this._rateTtl}s is very low — possible misconfiguration`,
-      );
+      logger.warn('assetConverter.config.lowCacheTtl', {
+        rateTtlSeconds: this._rateTtl,
+        message: 'RATE_CACHE_TTL_SECONDS is very low — possible misconfiguration',
+      });
     }
   }
 
@@ -35,7 +37,7 @@ class AssetConverterService {
         })),
       }));
     } catch (error) {
-      console.error('Find conversion path error:', error);
+      logger.error('assetConverter.findConversionPath.failed', { sourceAsset, destAsset, amount, error: error.message });
       throw error;
     }
   }
@@ -79,7 +81,7 @@ class AssetConverterService {
         destAmount: destMin,
       };
     } catch (error) {
-      console.error('Asset conversion error:', error);
+      logger.error('assetConverter.convertAsset.failed', { sourceAsset, destAsset, amount, error: error.message });
       throw error;
     }
   }
@@ -112,7 +114,7 @@ class AssetConverterService {
       this._rateCache.set(cacheKey, rate);
       return rate;
     } catch (error) {
-      console.error('Get conversion rate error:', error);
+      logger.error('assetConverter.getConversionRate.failed', { sourceAsset, destAsset, error: error.message });
       return null;
     }
   }

--- a/backend/src/services/assetPortfolio.js
+++ b/backend/src/services/assetPortfolio.js
@@ -1,6 +1,8 @@
 /**
  * Asset Portfolio Management Service
  */
+import logger from '../config/logger.js';
+
 class AssetPortfolioService {
   constructor(assetRegistry, trustlineManager) {
     this.assetRegistry = assetRegistry;
@@ -47,7 +49,7 @@ class AssetPortfolioService {
       this.portfolios.set(publicKey, portfolio);
       return portfolio;
     } catch (error) {
-      console.error('Get portfolio error:', error);
+      logger.error('assetPortfolio.getPortfolio.failed', { publicKey, error: error.message });
       throw error;
     }
   }

--- a/backend/src/services/assetRegistry.js
+++ b/backend/src/services/assetRegistry.js
@@ -1,4 +1,5 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
+import logger from '../config/logger.js';
 
 /**
  * Asset Registry Service for managing Stellar assets
@@ -53,7 +54,7 @@ class AssetRegistryService {
 
       return assets.records.length > 0;
     } catch (error) {
-      console.error('Asset validation error:', error);
+      logger.error('assetRegistry.validateAsset.failed', { code, issuer, error: error.message });
       return false;
     }
   }
@@ -84,7 +85,7 @@ class AssetRegistryService {
         flags: record.flags
       }));
     } catch (error) {
-      console.error('Asset discovery error:', error);
+      logger.error('assetRegistry.discoverAssets.failed', { filters, error: error.message });
       throw error;
     }
   }
@@ -181,7 +182,7 @@ class AssetRegistryService {
       this.priceCache.set(key, priceData);
       return avgPrice;
     } catch (error) {
-      console.error('Price tracking error:', error);
+      logger.error('assetRegistry.trackAssetPrice.failed', { code, issuer, baseAsset, error: error.message });
       return null;
     }
   }

--- a/backend/src/services/paymentAlerting.js
+++ b/backend/src/services/paymentAlerting.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { getConfig } from '../config/env.js';
+import logger from '../config/logger.js';
 
 class PaymentAlertingService {
   constructor() {
@@ -131,16 +132,16 @@ class PaymentAlertingService {
       if (!config.alerts?.email) return;
 
       // Stub implementation — integrate with your email service
-      console.log('[Alert Email]', {
+      logger.info('paymentAlerting.emailAlert.sent', {
         to: config.alerts.email,
         subject: `FuTuRe Alert: ${alert.type}`,
-        body: JSON.stringify(alert, null, 2),
+        body: JSON.stringify(alert),
       });
 
       // Example using axios to send via email service:
       // await axios.post('https://api.mailgun.net/v3/...', {...})
     } catch (error) {
-      console.error('[Alert Email Failed]', error.message);
+      logger.error('paymentAlerting.emailAlert.failed', { error: error.message });
     }
   }
 
@@ -171,7 +172,7 @@ class PaymentAlertingService {
 
       await axios.post(config.alerts.slackWebhookUrl, message, { timeout: 5000 });
     } catch (error) {
-      console.error('[Alert Slack Failed]', error.message);
+      logger.error('paymentAlerting.slackAlert.failed', { error: error.message });
     }
   }
 

--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -1,4 +1,5 @@
 import * as StellarSDK from '@stellar/stellar-sdk';
+import { randomUUID } from 'crypto';
 import { eventMonitor } from '../eventSourcing/index.js';
 import { getConfig } from '../config/env.js';
 import { getIssuer } from '../config/assets.js';
@@ -283,6 +284,11 @@ export async function sendPayment(
   memoType = 'text',
   correlationId = null,
 ) {
+  // Auto-generate a UUID correlation ID if the caller didn't supply one.
+  // This ID is stamped on every log line for this transaction attempt so
+  // engineers can filter the full lifecycle with a single query.
+  const txCorrelationId = correlationId ?? randomUUID();
+
   const { assetIssuer } = getConfig().stellar;
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
   const sourcePublicKey = sourceKeypair.publicKey();
@@ -293,7 +299,7 @@ export async function sendPayment(
     assetCode,
     memo,
     memoType,
-    correlationId,
+    correlationId: txCorrelationId,
   });
 
   // Sequence Numbers
@@ -367,7 +373,7 @@ export async function sendPayment(
         source: sourcePublicKey,
         xlmBalance: xlmAmount,
         threshold: feeBumpThreshold,
-        correlationId,
+        correlationId: txCorrelationId,
       });
       // Track stats for cost monitoring
       await incrementFeeBumpStats(
@@ -387,7 +393,7 @@ export async function sendPayment(
       amount,
       assetCode,
       error: err.message,
-      correlationId,
+      correlationId: txCorrelationId,
     });
     throw err;
   }
@@ -402,7 +408,7 @@ export async function sendPayment(
     feeBump: usedFeeBump,
     memo,
     memoType,
-    correlationId,
+    correlationId: txCorrelationId,
   });
 
   await invalidateBalanceCache(sourcePublicKey);
@@ -416,7 +422,7 @@ export async function sendPayment(
       feeBump: usedFeeBump,
       memo,
       memoType,
-      correlationId,
+      correlationId: txCorrelationId,
     },
     version: 1,
   });
@@ -451,7 +457,7 @@ export async function sendPayment(
       });
     })
     .catch((err) =>
-      logger.warn('db.transaction.save.failed', { error: err.message, correlationId }),
+      logger.warn('db.transaction.save.failed', { error: err.message, correlationId: txCorrelationId }),
     );
 
   return {
@@ -483,7 +489,8 @@ export async function createTrustline(sourceSecret, assetCode) {
 
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
   const sourcePublicKey = sourceKeypair.publicKey();
-  logger.info('stellar.createTrustline', { publicKey: sourcePublicKey, assetCode });
+  const correlationId = randomUUID();
+  logger.info('stellar.createTrustline', { publicKey: sourcePublicKey, assetCode, correlationId });
 
   const sourceAccount = await withHorizonRetry(() =>
     getHorizonServer().loadAccount(sourcePublicKey),
@@ -493,7 +500,7 @@ export async function createTrustline(sourceSecret, assetCode) {
     (b) => b.asset_code === assetCode && b.asset_issuer === issuer,
   );
   if (alreadyTrusted) {
-    logger.info('stellar.createTrustline.exists', { publicKey: sourcePublicKey, assetCode });
+    logger.info('stellar.createTrustline.exists', { publicKey: sourcePublicKey, assetCode, correlationId });
     return { alreadyExists: true, assetCode, issuer };
   }
 
@@ -516,6 +523,7 @@ export async function createTrustline(sourceSecret, assetCode) {
     logger.error('stellar.createTrustline.failed', {
       publicKey: sourcePublicKey,
       assetCode,
+      correlationId,
       error: err.message,
     });
     throw err;
@@ -524,6 +532,7 @@ export async function createTrustline(sourceSecret, assetCode) {
   logger.info('stellar.createTrustline.success', {
     publicKey: sourcePublicKey,
     assetCode,
+    correlationId,
     hash: result.hash,
   });
 
@@ -549,7 +558,8 @@ export async function removeTrustline(sourceSecret, assetCode) {
 
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
   const sourcePublicKey = sourceKeypair.publicKey();
-  logger.info('stellar.removeTrustline', { publicKey: sourcePublicKey, assetCode });
+  const correlationId = randomUUID();
+  logger.info('stellar.removeTrustline', { publicKey: sourcePublicKey, assetCode, correlationId });
 
   const sourceAccount = await withHorizonRetry(() =>
     getHorizonServer().loadAccount(sourcePublicKey),
@@ -586,6 +596,7 @@ export async function removeTrustline(sourceSecret, assetCode) {
     logger.error('stellar.removeTrustline.failed', {
       publicKey: sourcePublicKey,
       assetCode,
+      correlationId,
       error: err.message,
     });
     throw err;
@@ -594,6 +605,7 @@ export async function removeTrustline(sourceSecret, assetCode) {
   logger.info('stellar.removeTrustline.success', {
     publicKey: sourcePublicKey,
     assetCode,
+    correlationId,
     hash: result.hash,
   });
 
@@ -800,7 +812,8 @@ export async function getTrustlines(publicKey) {
 export async function mergeAccount(sourceSecret, destination) {
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
   const sourcePublicKey = sourceKeypair.publicKey();
-  logger.info('stellar.mergeAccount.start', { source: sourcePublicKey, destination });
+  const correlationId = randomUUID();
+  logger.info('stellar.mergeAccount.start', { source: sourcePublicKey, destination, correlationId });
 
   const sourceAccount = await withHorizonRetry(() =>
     getHorizonServer().loadAccount(sourcePublicKey),
@@ -823,6 +836,7 @@ export async function mergeAccount(sourceSecret, destination) {
     logger.error('stellar.mergeAccount.failed', {
       source: sourcePublicKey,
       destination,
+      correlationId,
       error: err.message,
     });
     throw err;
@@ -831,6 +845,7 @@ export async function mergeAccount(sourceSecret, destination) {
   logger.info('stellar.mergeAccount.success', {
     source: sourcePublicKey,
     destination,
+    correlationId,
     hash: result.hash,
     ledger: result.ledger,
   });

--- a/backend/src/services/trustlineManager.js
+++ b/backend/src/services/trustlineManager.js
@@ -1,4 +1,5 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
+import logger from '../config/logger.js';
 
 /**
  * Trustline Manager Service
@@ -42,7 +43,7 @@ class TrustlineManagerService {
         limit: limit
       };
     } catch (error) {
-      console.error('Trustline creation error:', error);
+      logger.error('trustlineManager.createTrustline.failed', { assetCode, assetIssuer, error: error.message });
       throw error;
     }
   }
@@ -85,7 +86,7 @@ class TrustlineManagerService {
         asset: { code: assetCode, issuer: assetIssuer }
       };
     } catch (error) {
-      console.error('Trustline removal error:', error);
+      logger.error('trustlineManager.removeTrustline.failed', { assetCode, assetIssuer, error: error.message });
       throw error;
     }
   }
@@ -108,7 +109,7 @@ class TrustlineManagerService {
           sellingLiabilities: balance.selling_liabilities
         }));
     } catch (error) {
-      console.error('Get trustlines error:', error);
+      logger.error('trustlineManager.getTrustlines.failed', { publicKey, error: error.message });
       throw error;
     }
   }
@@ -123,7 +124,7 @@ class TrustlineManagerService {
         tl => tl.assetCode === assetCode && tl.assetIssuer === assetIssuer
       );
     } catch (error) {
-      console.error('Check trustline error:', error);
+      logger.error('trustlineManager.hasTrustline.failed', { publicKey, assetCode, assetIssuer, error: error.message });
       return false;
     }
   }
@@ -139,7 +140,7 @@ class TrustlineManagerService {
       );
       return balance ? balance.balance : null;
     } catch (error) {
-      console.error('Get balance error:', error);
+      logger.error('trustlineManager.getAssetBalance.failed', { publicKey, assetCode, assetIssuer, error: error.message });
       return null;
     }
   }
@@ -177,7 +178,7 @@ class TrustlineManagerService {
         newLimit: newLimit
       };
     } catch (error) {
-      console.error('Update trustline limit error:', error);
+      logger.error('trustlineManager.updateTrustlineLimit.failed', { assetCode, assetIssuer, newLimit, error: error.message });
       throw error;
     }
   }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,98 @@
+# docker-compose.dev.yml
+# Development override — hot-reload for backend (node --watch) and frontend (Vite HMR).
+# Usage:
+#   docker compose -f docker-compose.dev.yml up
+#
+# Source directories are mounted as volumes so any file change is reflected
+# immediately without rebuilding the image. Prisma migrations run on startup.
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: future_remittance
+      POSTGRES_USER: future_admin
+      POSTGRES_PASSWORD: dev_password
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data_dev:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U future_admin -d future_remittance"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "3001:3001"
+    volumes:
+      # Mount source and prisma for instant hot-reload — no image rebuild needed
+      - ./backend/src:/app/src
+      - ./backend/prisma:/app/prisma
+    environment:
+      APP_ENV: development
+      NODE_ENV: development
+      PORT: 3001
+      DATABASE_URL: postgresql://future_admin:dev_password@postgres:5432/future_remittance
+      REDIS_URL: redis://redis:6379
+      STELLAR_NETWORK: testnet
+      HORIZON_URL: https://horizon-testnet.stellar.org
+      ALLOWED_ORIGINS: http://localhost:3000
+      JWT_SECRET: dev-jwt-secret-change-me
+      STREAM_SECRET_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+      FEE_BUMP_THRESHOLD_XLM: "2"
+      LOG_LEVEL: debug
+      CACHE_TTL_BALANCE_S: "30"
+      RATE_CACHE_TTL_S: "60"
+      CACHE_TTL_FEE_S: "120"
+      RATE_LIMIT_WINDOW_MS: "60000"
+      RATE_LIMIT_MAX: "100"
+      DB_POOL_MAX: "10"
+      DB_SHARD_COUNT: "1"
+      CDN_ENABLED: "false"
+    # node --watch provides hot-reload without nodemon; migrate on each start
+    command: sh -c "npx prisma migrate deploy && node --watch src/server.js"
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+    volumes:
+      # Mount source files for Vite HMR
+      - ./frontend/src:/app/src
+      - ./frontend/public:/app/public
+      - ./frontend/index.html:/app/index.html
+    environment:
+      VITE_API_URL: http://localhost:3001
+      # Vite listens on all interfaces inside the container
+      HOST: "0.0.0.0"
+
+volumes:
+  db_data_dev:


### PR DESCRIPTION
---

**feat: structured logging, correlation IDs, microservice health endpoint, and dev compose with hot-reload**

This PR bundles four observability and developer-experience improvements that work together as a cohesive set.

---

### #755 — Structured JSON logging across all backend services

All `console.log`, `console.error`, and `console.warn` calls across `backend/src/services/` have been replaced with the project's existing Winston-based structured logger imported from `src/config/logger.js`. Every log line now emits a consistent JSON object with `level`, `timestamp`, `message`, and structured context fields rather than freeform strings. This makes logs directly indexable by aggregation tools like Datadog, Loki, and CloudWatch without custom parsing rules.

Files updated:
- `services/assetConverter.js` — config warning, path error, conversion error, rate fetch error
- `services/assetPortfolio.js` — portfolio fetch error
- `services/assetRegistry.js` — asset validation error, discovery error, price tracking error
- `services/paymentAlerting.js` — email alert stub, Slack alert failure
- `services/trustlineManager.js` — create, remove, get, check, balance, and limit update errors

Closes #755

---

### #762 — Correlation IDs on all Stellar transaction submissions

Every Stellar transaction submission now carries a UUID v4 correlation ID that is stamped on every related log line, allowing engineers to reconstruct the full lifecycle of any transaction attempt with a single log query.

- `sendPayment` auto-generates a `txCorrelationId` via `crypto.randomUUID()` when the caller does not supply one. The ID is included in the start, fee-bump applied, submission success, submission failure, and DB save log lines, as well as the `PaymentSent` event payload.
- `createTrustline`, `removeTrustline`, and `mergeAccount` each generate their own correlation ID at entry and propagate it through every log call for that operation (start, exists check, success, failure).
- No breaking change — the existing optional `correlationId` parameter on `sendPayment` is still respected; a UUID is only generated when it is `null`.

Closes #762

---

### #760 — Health endpoint for each microservice

Added a `health()` method to `ServiceRegistry` in `src/microservices/discovery.js`. It aggregates per-service instance status into a single response shape:

```json
{
  "status": "healthy | degraded | unhealthy",
  "uptime": 123.45,
  "timestamp": "2026-07-25T00:00:00.000Z",
  "services": [
    { "name": "payments", "status": "healthy", "totalInstances": 3, "healthyInstances": 3 }
  ]
}
```

`APIGateway` in `src/microservices/gateway.js` gets a matching `health()` method that delegates to the registry and adds the total route count.

A new Express route file `src/routes/microservicesHealth.js` exposes `GET /microservices/health` and is registered in `server.js` alongside the existing health routes. HTTP status is 200 for healthy/degraded and 503 for unhealthy — directly compatible with Kubernetes liveness/readiness probes, ECS health checks, and AWS ALB target group checks.

Closes #760

---

### #764 — docker-compose.dev.yml with hot-reload for all services

Added `docker-compose.dev.yml` as a standalone development compose file (not an override of the production compose). Key differences from `docker-compose.yml`:

- Backend mounts `./backend/src` and `./backend/prisma` as volumes and starts with `node --watch src/server.js` (Node 20 built-in file watcher) — any source file change restarts the server in under a second without rebuilding the image.
- Frontend mounts `./frontend/src`, `./frontend/public`, and `./frontend/index.html` as volumes and starts Vite with `--host 0.0.0.0`, enabling full HMR inside the container with changes reflected in the browser immediately.
- `LOG_LEVEL` is set to `debug` so all structured log output is visible during development.
- Uses a separate `db_data_dev` named volume so dev database state never collides with a production-like compose run.
- Postgres and Redis are identical to the production compose with the same healthcheck gates.

Usage:
```
docker compose -f docker-compose.dev.yml up
```

Closes #764

---

### Testing

- All modified service files pass ESLint with no new warnings.
- Structured log output verified to be valid JSON on all error and warn paths.
- `sendPayment` log lines confirmed to carry the same `correlationId` value across start → fee-bump → success/failure → DB save.
- `GET /microservices/health` returns expected shape with correct HTTP status codes for healthy, degraded, and unhealthy states.
- Dev compose starts cleanly; backend reloads on file save and frontend HMR updates the browser without a full page refresh.