### PR TITLE
Add encrypted backup (download + verify + reminder) and RTL layout support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,7 @@ Key conventions:
 - Async/await preferred over `.then()` chains.
 - No unused variables; `_` prefix for intentionally unused parameters.
 - Keep functions small and single-purpose; avoid deeply nested callbacks.
+- All new CSS must use logical properties instead of physical directional ones, so layouts mirror correctly for RTL locales (Arabic, Hebrew). Use `margin-inline-start`/`margin-inline-end` instead of `margin-left`/`margin-right`, `padding-inline-start`/`padding-inline-end` instead of `padding-left`/`padding-right`, `text-align: start`/`end` instead of `left`/`right`, `border-inline-start`/`border-inline-end` instead of `border-left`/`border-right`, and `inset-inline-start`/`inset-inline-end` instead of positioning with `left`/`right`.
 
 ---
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -45,6 +45,9 @@ export default [
         alert: 'readonly',
         prompt: 'readonly',
         axios: 'readonly',
+        crypto: 'readonly',
+        TextEncoder: 'readonly',
+        TextDecoder: 'readonly',
       },
     },
     settings: {

--- a/frontend/src/components/AdvancedSearch.css
+++ b/frontend/src/components/AdvancedSearch.css
@@ -32,8 +32,8 @@
 .suggestions-dropdown {
   position: absolute;
   top: 100%;
-  left: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   background: white;
   border: 1px solid #ddd;
   border-top: none;

--- a/frontend/src/components/BackupReminderBanner.jsx
+++ b/frontend/src/components/BackupReminderBanner.jsx
@@ -1,0 +1,53 @@
+/**
+ * BackupReminderBanner — dismissible nudge shown after N transactions have
+ * occurred since the account's last backup/verification.
+ * Props: transactionsSinceBackup, threshold, onBackupNow, onDismiss
+ */
+export function BackupReminderBanner({ transactionsSinceBackup, threshold, onBackupNow, onDismiss }) {
+  return (
+    <div
+      role="alert"
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        gap: 12,
+        padding: 12,
+        marginBottom: 20,
+        background: '#fef3c7',
+        color: '#92400e',
+        borderRadius: 8,
+        fontSize: '0.9rem',
+      }}
+    >
+      <span>
+        ⚠️ You&apos;ve made {transactionsSinceBackup} transactions since your last backup (reminder threshold: {threshold}).
+        Consider creating an updated backup.
+      </span>
+      <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+        <button
+          type="button"
+          onClick={onBackupNow}
+          style={{ width: 'auto', padding: '6px 12px', fontSize: '0.85rem' }}
+        >
+          💾 Back Up Now
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss backup reminder"
+          style={{
+            width: 'auto',
+            padding: '6px 10px',
+            fontSize: '0.85rem',
+            background: 'transparent',
+            color: 'inherit',
+            border: '1px solid currentColor',
+          }}
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/BackupSettings.jsx
+++ b/frontend/src/components/BackupSettings.jsx
@@ -1,15 +1,31 @@
 import { useState, useEffect } from 'react';
 import apiClient from '../api/client.js';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useAppState } from '../store/index.js';
+import {
+  encryptBackup,
+  serializeBackupFile,
+  buildBackupFilename,
+  downloadBackupFile,
+  scorePasswordStrength,
+} from '../utils/backup.js';
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const MIN_BACKUP_PASSWORD_LENGTH = 8;
 
 export function BackupSettings({ onClose }) {
+  const { account, accountLabel } = useAppState();
   const [status, setStatus] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [creating, setCreating] = useState(false);
   const [backups, setBackups] = useState([]);
+
+  const [backupPassword, setBackupPassword] = useState('');
+  const [backupPasswordConfirm, setBackupPasswordConfirm] = useState('');
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState(null);
+  const [downloadSuccess, setDownloadSuccess] = useState(null);
 
   useEffect(() => {
     loadStatus();
@@ -57,6 +73,48 @@ export function BackupSettings({ onClose }) {
     // For now, we'll just show an alert
     alert(`Download functionality would retrieve: ${filename}`);
   };
+
+  const downloadEncryptedBackup = async (e) => {
+    e.preventDefault();
+    setDownloadError(null);
+    setDownloadSuccess(null);
+
+    if (!account?.publicKey || !account?.secretKey) {
+      setDownloadError('No account is loaded to back up.');
+      return;
+    }
+    if (backupPassword.length < MIN_BACKUP_PASSWORD_LENGTH) {
+      setDownloadError(`Backup password must be at least ${MIN_BACKUP_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+    if (backupPassword !== backupPasswordConfirm) {
+      setDownloadError('Backup passwords do not match.');
+      return;
+    }
+
+    setDownloading(true);
+    try {
+      const payload = {
+        publicKey: account.publicKey,
+        secretKey: account.secretKey,
+        accountLabel: accountLabel || '',
+        createdAt: new Date().toISOString(),
+      };
+      const envelope = await encryptBackup(payload, backupPassword);
+      const filename = buildBackupFilename();
+      downloadBackupFile(filename, serializeBackupFile(envelope));
+
+      setDownloadSuccess(`Backup downloaded as ${filename}. Store the file and your password separately.`);
+      setBackupPassword('');
+      setBackupPasswordConfirm('');
+    } catch {
+      setDownloadError('Failed to create encrypted backup. Please try again.');
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const passwordStrength = scorePasswordStrength(backupPassword);
 
   const isStale = status?.lastBackup
     ? Date.now() - new Date(status.lastBackup.timestamp).getTime() > SEVEN_DAYS_MS
@@ -138,6 +196,72 @@ export function BackupSettings({ onClose }) {
               >
                 {creating ? 'Creating Backup...' : '💾 Create Manual Backup'}
               </button>
+            </div>
+
+            {/* Encrypted Backup Download */}
+            <div style={{ marginBottom: 24, padding: 16, background: 'var(--bg-secondary, #f9fafb)', borderRadius: 8 }}>
+              <h3 style={{ margin: '0 0 12px 0', fontSize: '1rem' }}>Download Encrypted Backup</h3>
+              <p style={{ margin: '0 0 12px 0', fontSize: '0.85rem', color: 'var(--text-muted, #64748b)' }}>
+                Export your keypair and settings as an encrypted file you can store offline (USB drive, password
+                manager, etc). Choose a backup password below — you will need it to restore or verify this backup.
+              </p>
+
+              <div
+                role="alert"
+                style={{ marginBottom: 12, padding: 12, background: '#fef3c7', color: '#92400e', borderRadius: 4, fontSize: '0.85rem' }}
+              >
+                ⚠️ Store the backup password separately from the downloaded file. Anyone with both can access your
+                account. We cannot recover this password if you lose it.
+              </div>
+
+              {downloadError && (
+                <div role="alert" style={{ padding: 12, background: '#fee', color: '#c00', borderRadius: 4, marginBottom: 12 }}>
+                  {downloadError}
+                </div>
+              )}
+              {downloadSuccess && (
+                <div role="status" style={{ padding: 12, background: '#ecfdf5', color: '#166534', borderRadius: 4, marginBottom: 12 }}>
+                  ✅ {downloadSuccess}
+                </div>
+              )}
+
+              <form onSubmit={downloadEncryptedBackup}>
+                <div style={{ marginBottom: 12 }}>
+                  <label htmlFor="backup-password" style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, marginBottom: 4 }}>
+                    Backup Password
+                  </label>
+                  <input
+                    id="backup-password"
+                    type="password"
+                    value={backupPassword}
+                    onChange={(e) => setBackupPassword(e.target.value)}
+                    placeholder={`At least ${MIN_BACKUP_PASSWORD_LENGTH} characters`}
+                    autoComplete="new-password"
+                  />
+                  {backupPassword && (
+                    <div style={{ fontSize: '0.75rem', color: 'var(--text-muted, #64748b)' }}>
+                      Strength: {passwordStrength.label}
+                    </div>
+                  )}
+                </div>
+
+                <div style={{ marginBottom: 12 }}>
+                  <label htmlFor="backup-password-confirm" style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, marginBottom: 4 }}>
+                    Confirm Backup Password
+                  </label>
+                  <input
+                    id="backup-password-confirm"
+                    type="password"
+                    value={backupPasswordConfirm}
+                    onChange={(e) => setBackupPasswordConfirm(e.target.value)}
+                    autoComplete="new-password"
+                  />
+                </div>
+
+                <button type="submit" disabled={downloading} style={{ width: '100%', padding: '12px 16px', fontSize: '1rem' }}>
+                  {downloading ? 'Encrypting…' : '🔒 Download Encrypted Backup'}
+                </button>
+              </form>
             </div>
 
             {/* Backup Metrics */}

--- a/frontend/src/components/BackupSettings.jsx
+++ b/frontend/src/components/BackupSettings.jsx
@@ -125,6 +125,7 @@ export function BackupSettings({ onClose }) {
       setDownloadSuccess(`Backup downloaded as ${filename}. Store the file and your password separately.`);
       setBackupPassword('');
       setBackupPasswordConfirm('');
+      await creditBackupEvent(account.publicKey);
     } catch {
       setDownloadError('Failed to create encrypted backup. Please try again.');
     } finally {

--- a/frontend/src/components/BackupSettings.jsx
+++ b/frontend/src/components/BackupSettings.jsx
@@ -8,10 +8,23 @@ import {
   buildBackupFilename,
   downloadBackupFile,
   scorePasswordStrength,
+  parseBackupFile,
+  verifyBackupAgainstAccount,
+  BACKUP_ERROR_CODES,
 } from '../utils/backup.js';
+import { recordBackupEvent } from '../utils/backupReminder.js';
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 const MIN_BACKUP_PASSWORD_LENGTH = 8;
+
+async function creditBackupEvent(publicKey) {
+  try {
+    const { data } = await apiClient.get(`/api/stellar/account/${publicKey}/transactions`, { params: { limit: 100 } });
+    recordBackupEvent(data?.records?.length || 0);
+  } catch {
+    recordBackupEvent(0);
+  }
+}
 
 export function BackupSettings({ onClose }) {
   const { account, accountLabel } = useAppState();
@@ -26,6 +39,11 @@ export function BackupSettings({ onClose }) {
   const [downloading, setDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState(null);
   const [downloadSuccess, setDownloadSuccess] = useState(null);
+
+  const [verifyFile, setVerifyFile] = useState(null);
+  const [verifyPassword, setVerifyPassword] = useState('');
+  const [verifying, setVerifying] = useState(false);
+  const [verifyResult, setVerifyResult] = useState(null);
 
   useEffect(() => {
     loadStatus();
@@ -111,6 +129,60 @@ export function BackupSettings({ onClose }) {
       setDownloadError('Failed to create encrypted backup. Please try again.');
     } finally {
       setDownloading(false);
+    }
+  };
+
+  const verifyBackupFile = async (e) => {
+    e.preventDefault();
+    setVerifyResult(null);
+
+    if (!verifyFile) {
+      setVerifyResult({ type: 'error', message: 'Select a backup file to verify.' });
+      return;
+    }
+
+    setVerifying(true);
+    try {
+      const fileText = await verifyFile.text();
+
+      let envelope;
+      try {
+        envelope = parseBackupFile(fileText);
+      } catch {
+        setVerifyResult({ type: 'error', message: 'This backup file is corrupted or not a valid backup — it could not be read.' });
+        return;
+      }
+
+      let result;
+      try {
+        result = await verifyBackupAgainstAccount(envelope, verifyPassword, account?.publicKey);
+      } catch (err) {
+        if (err.code === BACKUP_ERROR_CODES.WRONG_PASSWORD) {
+          setVerifyResult({ type: 'error', message: 'Incorrect backup password. Please try again.' });
+        } else {
+          setVerifyResult({ type: 'error', message: 'This backup file is corrupted and could not be decrypted.' });
+        }
+        return;
+      }
+
+      if (result.outcome === 'mismatch') {
+        setVerifyResult({
+          type: 'error',
+          message: `This backup does not match the currently loaded account (backup public key: ${result.backupPublicKey}).`,
+          createdAt: result.createdAt,
+        });
+        return;
+      }
+
+      setVerifyResult({
+        type: 'success',
+        message: 'Backup verified — it decrypts successfully and matches this account.',
+        createdAt: result.createdAt,
+      });
+      await creditBackupEvent(account.publicKey);
+    } finally {
+      setVerifying(false);
+      setVerifyPassword('');
     }
   };
 
@@ -260,6 +332,66 @@ export function BackupSettings({ onClose }) {
 
                 <button type="submit" disabled={downloading} style={{ width: '100%', padding: '12px 16px', fontSize: '1rem' }}>
                   {downloading ? 'Encrypting…' : '🔒 Download Encrypted Backup'}
+                </button>
+              </form>
+            </div>
+
+            {/* Verify Backup */}
+            <div style={{ marginBottom: 24, padding: 16, background: 'var(--bg-secondary, #f9fafb)', borderRadius: 8 }}>
+              <h3 style={{ margin: '0 0 12px 0', fontSize: '1rem' }}>Verify Backup</h3>
+              <p style={{ margin: '0 0 12px 0', fontSize: '0.85rem', color: 'var(--text-muted, #64748b)' }}>
+                Upload a downloaded backup file and its password to confirm it decrypts correctly and matches this
+                account — without exposing your secret key.
+              </p>
+
+              {verifyResult && (
+                <div
+                  role={verifyResult.type === 'success' ? 'status' : 'alert'}
+                  style={{
+                    padding: 12,
+                    borderRadius: 4,
+                    marginBottom: 12,
+                    background: verifyResult.type === 'success' ? '#ecfdf5' : '#fee',
+                    color: verifyResult.type === 'success' ? '#166534' : '#c00',
+                  }}
+                >
+                  {verifyResult.type === 'success' ? '✅' : '⚠️'} {verifyResult.message}
+                  {verifyResult.createdAt && (
+                    <div style={{ marginTop: 4, fontSize: '0.8rem' }}>
+                      Backup created: {new Date(verifyResult.createdAt).toLocaleString()}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <form onSubmit={verifyBackupFile}>
+                <div style={{ marginBottom: 12 }}>
+                  <label htmlFor="verify-backup-file" style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, marginBottom: 4 }}>
+                    Backup File
+                  </label>
+                  <input
+                    id="verify-backup-file"
+                    type="file"
+                    accept=".enc,.json,application/json"
+                    onChange={(e) => setVerifyFile(e.target.files?.[0] || null)}
+                  />
+                </div>
+
+                <div style={{ marginBottom: 12 }}>
+                  <label htmlFor="verify-backup-password" style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, marginBottom: 4 }}>
+                    Backup Password
+                  </label>
+                  <input
+                    id="verify-backup-password"
+                    type="password"
+                    value={verifyPassword}
+                    onChange={(e) => setVerifyPassword(e.target.value)}
+                    autoComplete="off"
+                  />
+                </div>
+
+                <button type="submit" disabled={verifying} style={{ width: '100%', padding: '12px 16px', fontSize: '1rem' }}>
+                  {verifying ? 'Verifying…' : '🔍 Verify Backup'}
                 </button>
               </form>
             </div>

--- a/frontend/src/components/NotificationPreferences.jsx
+++ b/frontend/src/components/NotificationPreferences.jsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { FormField } from './FormField';
 import { Spinner } from './Spinner';
 import { StatusMessage } from './StatusMessage';
+import { getBackupReminderThreshold, setBackupReminderThreshold } from '../utils/backupReminder';
 
 function Toggle({ checked, onChange, disabled }) {
   return (
@@ -59,6 +60,15 @@ export function NotificationPreferences() {
     lowBalanceThreshold: 10.0,
     lowBalanceAsset: 'XLM',
   });
+
+  const [backupReminderThreshold, setBackupReminderThresholdValue] = useState(() => getBackupReminderThreshold());
+
+  const handleBackupReminderThresholdChange = (value) => {
+    const n = parseInt(value, 10);
+    const normalized = Number.isFinite(n) && n > 0 ? n : 1;
+    setBackupReminderThresholdValue(normalized);
+    setBackupReminderThreshold(normalized);
+  };
 
   const fetchPreferences = useCallback(async () => {
     setLoading(true);
@@ -324,6 +334,25 @@ export function NotificationPreferences() {
               </FormField>
             </div>
           )}
+        </div>
+
+        {/* Backup Reminder */}
+        <div style={{ paddingBottom: 16, borderBottom: '1px solid #e5e7eb' }}>
+          <h3 style={{ fontSize: '1rem', fontWeight: 600, marginBottom: 12 }}>Backup Reminder</h3>
+          <p style={{ fontSize: '0.875rem', color: '#666', marginBottom: 12 }}>
+            Show a dismissible reminder to create a fresh backup after this many new transactions since your last
+            backup or verification.
+          </p>
+          <FormField label="Transactions Before Reminder" required>
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={backupReminderThreshold}
+              onChange={(e) => handleBackupReminderThresholdChange(e.target.value)}
+              style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4, boxSizing: 'border-box' }}
+            />
+          </FormField>
         </div>
 
         {/* Info Box */}

--- a/frontend/src/hooks/useBackupReminder.js
+++ b/frontend/src/hooks/useBackupReminder.js
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import {
+  getBackupReminderThreshold,
+  getLastBackupInfo,
+  isBackupReminderSnoozed,
+  snoozeBackupReminder,
+} from '../utils/backupReminder';
+
+/**
+ * Computes whether the "create a fresh backup" reminder should show, based on
+ * how many transactions have occurred since the last backup/verification.
+ * @param {number|null} transactionCount - current transaction count for the account, or null if not yet loaded
+ */
+export function useBackupReminder(transactionCount) {
+  const threshold = getBackupReminderThreshold();
+  const { lastBackupTransactionCount, lastBackupTimestamp } = getLastBackupInfo();
+
+  const hasCount = typeof transactionCount === 'number';
+  const transactionsSinceBackup = hasCount ? Math.max(0, transactionCount - lastBackupTransactionCount) : 0;
+  const showReminder = hasCount && transactionsSinceBackup >= threshold && !isBackupReminderSnoozed();
+
+  const dismiss = useCallback(() => {
+    snoozeBackupReminder();
+  }, []);
+
+  return { showReminder, threshold, transactionsSinceBackup, lastBackupTimestamp, dismiss };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,7 +33,7 @@
   .skip-link {
     position: absolute;
     top: -100%;
-    left: 0;
+    inset-inline-start: 0;
     background: var(--primary);
     color: var(--on-primary);
     padding: 8px 16px;
@@ -248,7 +248,7 @@ button:disabled {
 .settings-toggle__thumb {
   position: absolute;
   top: 2px;
-  left: 2px;
+  inset-inline-start: 2px;
   width: 18px;
   height: 18px;
   border-radius: 50%;
@@ -258,7 +258,7 @@ button:disabled {
 .settings-toggle.on .settings-toggle__thumb { transform: translateX(18px); }
 .btn-send-max {
   position: absolute;
-  right: 10px;
+  inset-inline-end: 10px;
   top: 50%;
   transform: translateY(-50%);
   width: auto;
@@ -348,9 +348,9 @@ select {
   flex-direction: column;
 }
 
-.input-wrap input { 
-  margin-bottom: 0; 
-  padding-right: 60px;
+.input-wrap input {
+  margin-bottom: 0;
+  padding-inline-end: 60px;
   width: 100%;
   box-sizing: border-box;
 }
@@ -386,11 +386,11 @@ select {
 }
 .input-wrap input {
   margin-bottom: 0;
-  padding-right: 60px;
+  padding-inline-end: 60px;
 }
 .input-icon {
   position: absolute;
-  right: 10px;
+  inset-inline-end: 10px;
   top: 50%;
   transform: translateY(-50%);
   pointer-events: none;
@@ -406,9 +406,9 @@ select {
   .input-wrap.memo-wrap select {
     width: 100%;
   }
-  
+
   .input-wrap.memo-wrap input {
-    padding-right: 40px;
+    padding-inline-end: 40px;
   }
 }
 
@@ -547,7 +547,7 @@ select {
 
 .qr-scan-btn {
   position: absolute;
-  right: 50px;
+  inset-inline-end: 50px;
   top: 50%;
   transform: translateY(-50%);
   background: none;
@@ -569,7 +569,7 @@ select {
 /* Responsive QR scan button */
 @media (max-width: 360px) {
   .qr-scan-btn {
-    right: 40px;
+    inset-inline-end: 40px;
     font-size: 1rem;
     padding: 2px 4px;
   }
@@ -671,7 +671,7 @@ select {
 .net-panel {
   position: absolute;
   top: calc(100% + 6px);
-  right: 0;
+  inset-inline-end: 0;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -817,8 +817,8 @@ select {
 .payment-confirmation-overlay {
   position: fixed;
   top: 0;
-  left: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   bottom: 0;
   background: rgba(0, 0, 0, 0.6);
   display: flex;
@@ -1058,10 +1058,10 @@ select {
     flex-direction: column;
   }
 }
-.sm-time { margin-left: auto; color: #999; white-space: nowrap; font-size: 11px; }
+.sm-time { margin-inline-start: auto; color: #999; white-space: nowrap; font-size: 11px; }
 
 .sm-time {
-  margin-left: auto;
+  margin-inline-start: auto;
   color: #999;
   white-space: nowrap;
   font-size: 11px;
@@ -1425,7 +1425,7 @@ kbd {
 .slideover-panel {
   position: fixed;
   top: 0;
-  right: 0;
+  inset-inline-end: 0;
   bottom: 0;
   width: 100%;
   max-width: 420px;
@@ -1582,7 +1582,7 @@ kbd {
 .fee-usd {
   color: #64748b;
   font-weight: 400;
-  margin-left: 4px;
+  margin-inline-start: 4px;
 }
 .fee-total {
   border-top: 1px solid #bae6fd;
@@ -1941,7 +1941,7 @@ kbd {
 .confirm-dialog__row dd {
   margin: 0;
   font-weight: 500;
-  text-align: right;
+  text-align: end;
   word-break: break-all;
 }
 .confirm-dialog__row--total dt,
@@ -1951,7 +1951,7 @@ kbd {
 .confirm-dialog__usd {
   font-size: 0.8rem;
   color: var(--text-secondary, #6b7280);
-  margin-left: 4px;
+  margin-inline-start: 4px;
 }
 
 .confirm-dialog__actions {
@@ -1966,7 +1966,7 @@ kbd {
   position: relative;
   display: inline-flex;
   align-items: center;
-  margin-left: 4px;
+  margin-inline-start: 4px;
   vertical-align: middle;
 }
 
@@ -2017,7 +2017,7 @@ kbd {
   box-shadow: var(--shadow);
   z-index: 1000;
   pointer-events: auto;
-  text-align: left;
+  text-align: start;
 }
 
 .xlm-tooltip::after {
@@ -2055,15 +2055,15 @@ kbd {
 /* Ensure tooltip doesn't overflow viewport */
 @media (max-width: 320px) {
   .xlm-tooltip {
-    left: auto;
-    right: 0;
+    inset-inline-start: auto;
+    inset-inline-end: 0;
     transform: none;
     max-width: 180px;
   }
-  
+
   .xlm-tooltip::after {
-    left: auto;
-    right: 12px;
+    inset-inline-start: auto;
+    inset-inline-end: 12px;
     transform: none;
   }
 .confirm-dialog__btn-confirm {
@@ -2169,7 +2169,7 @@ kbd {
   padding: 12px;
   margin-bottom: 12px;
   list-style: none;
-  padding-left: 0;
+  padding-inline-start: 0;
   margin-top: 0;
   font-size: 13px;
   color: #7f1d1d;

--- a/frontend/src/pages/AccountDashboardPage.jsx
+++ b/frontend/src/pages/AccountDashboardPage.jsx
@@ -14,6 +14,9 @@ import { FeeDisplay } from '../components/FeeDisplay';
 import { NotificationPermissionManager } from '../components/NotificationPermissionManager';
 import { ClaimableBalances } from '../components/ClaimableBalances';
 import { CreateClaimableBalance } from '../components/CreateClaimableBalance';
+import { BackupReminderBanner } from '../components/BackupReminderBanner';
+import { BackupSettings } from '../components/BackupSettings';
+import { useBackupReminder } from '../hooks/useBackupReminder';
 import { logError } from '../utils/errorLogger';
 
 function AnimatedBalance({ balance, asset }) {
@@ -29,13 +32,39 @@ export function AccountDashboardPage() {
   const [showQR, setShowQR] = useState(false);
   const [editingLabel, setEditingLabel] = useState(false);
   const [labelDraft, setLabelDraft] = useState(accountLabel || '');
+  const [transactionCount, setTransactionCount] = useState(null);
+  const [showBackupSettings, setShowBackupSettings] = useState(false);
+  // Bumping this forces a re-render so useBackupReminder re-reads localStorage
+  // after a dismiss/backup/verification, none of which otherwise touch React state.
+  const [, setReminderTick] = useState(0);
 
   const prefersReduced = useReducedMotion();
   const v = makeVariants(prefersReduced);
 
+  const { showReminder, threshold, transactionsSinceBackup, dismiss } = useBackupReminder(transactionCount);
+
   useEffect(() => {
     setLabelDraft(accountLabel || '');
   }, [accountLabel]);
+
+  useEffect(() => {
+    if (!account?.publicKey) {
+      setTransactionCount(null);
+      return;
+    }
+    let cancelled = false;
+    apiClient
+      .get(`/api/stellar/account/${account.publicKey}/transactions`, { params: { limit: 100 } })
+      .then(({ data }) => {
+        if (!cancelled) setTransactionCount(data?.records?.length ?? 0);
+      })
+      .catch(() => {
+        if (!cancelled) setTransactionCount(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [account?.publicKey]);
 
   const checkBalance = useCallback(async () => {
     if (!account) return;
@@ -73,6 +102,18 @@ export function AccountDashboardPage() {
   return (
     <motion.section className="section" variants={v.fadeSlide}>
       <h2>Account Dashboard</h2>
+
+      {showReminder && (
+        <BackupReminderBanner
+          transactionsSinceBackup={transactionsSinceBackup}
+          threshold={threshold}
+          onBackupNow={() => setShowBackupSettings(true)}
+          onDismiss={() => {
+            dismiss();
+            setReminderTick((t) => t + 1);
+          }}
+        />
+      )}
 
       <div style={{ marginBottom: 20, padding: 16, background: '#f9fafb', borderRadius: 8 }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
@@ -193,6 +234,15 @@ export function AccountDashboardPage() {
 
       {showQR && account && (
         <QRCodeModal publicKey={account.publicKey} onClose={() => setShowQR(false)} />
+      )}
+
+      {showBackupSettings && (
+        <BackupSettings
+          onClose={() => {
+            setShowBackupSettings(false);
+            setReminderTick((t) => t + 1);
+          }}
+        />
       )}
     </motion.section>
   );

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom';
+
+// jsdom's crypto polyfill does not implement SubtleCrypto — swap in Node's
+// WebCrypto so code under test using crypto.subtle (e.g. backup encryption) works.
+if (!globalThis.crypto?.subtle) {
+  const { webcrypto } = await import('node:crypto');
+  globalThis.crypto = webcrypto;
+}

--- a/frontend/src/utils/backup.js
+++ b/frontend/src/utils/backup.js
@@ -1,0 +1,176 @@
+/**
+ * Client-side encrypted account backup.
+ *
+ * Encrypts the user's Stellar keypair + local settings with a
+ * user-supplied password (PBKDF2 → AES-256-GCM) so the resulting file can be
+ * stored offline. The server never sees the plaintext or the password.
+ */
+
+const FORMAT_VERSION = 1;
+const PBKDF2_ITERATIONS = 250000;
+const SALT_BYTES = 16;
+const IV_BYTES = 12;
+
+export const BACKUP_ERROR_CODES = {
+  CORRUPTED_FILE: 'CORRUPTED_FILE',
+  WRONG_PASSWORD: 'WRONG_PASSWORD',
+};
+
+function backupError(code, message) {
+  const err = new Error(message);
+  err.code = code;
+  return err;
+}
+
+function arrayBufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(base64) {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+async function deriveAesKey(password, saltBytes, usage) {
+  const baseKey = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(password),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt: saltBytes, iterations: PBKDF2_ITERATIONS, hash: 'SHA-256' },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    [usage],
+  );
+}
+
+/**
+ * Encrypt a backup payload (keypair + settings) with a user-supplied password.
+ * @param {object} payload - e.g. { publicKey, secretKey, accountLabel }
+ * @param {string} password
+ * @returns {Promise<object>} envelope — safe to JSON.stringify and download
+ */
+export async function encryptBackup(payload, password) {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const key = await deriveAesKey(password, salt, 'encrypt');
+
+  const plaintext = new TextEncoder().encode(JSON.stringify(payload));
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext);
+
+  return {
+    version: FORMAT_VERSION,
+    createdAt: new Date().toISOString(),
+    salt: arrayBufferToBase64(salt),
+    iv: arrayBufferToBase64(iv),
+    ciphertext: arrayBufferToBase64(ciphertext),
+  };
+}
+
+/** Serialise an envelope (from encryptBackup) to a JSON string for download. */
+export function serializeBackupFile(envelope) {
+  return JSON.stringify(envelope, null, 2);
+}
+
+/**
+ * Parse and structurally validate a backup file's contents.
+ * Throws a CORRUPTED_FILE error if the envelope is malformed.
+ */
+export function parseBackupFile(fileText) {
+  let envelope;
+  try {
+    envelope = JSON.parse(fileText);
+  } catch {
+    throw backupError(BACKUP_ERROR_CODES.CORRUPTED_FILE, 'The backup file is not valid and could not be read.');
+  }
+
+  const hasRequiredFields =
+    envelope &&
+    typeof envelope === 'object' &&
+    typeof envelope.version === 'number' &&
+    typeof envelope.salt === 'string' &&
+    typeof envelope.iv === 'string' &&
+    typeof envelope.ciphertext === 'string';
+
+  if (!hasRequiredFields) {
+    throw backupError(BACKUP_ERROR_CODES.CORRUPTED_FILE, 'The backup file is missing required data and appears corrupted.');
+  }
+
+  return envelope;
+}
+
+/**
+ * Decrypt a parsed backup envelope with the user-supplied password.
+ * @returns {Promise<object>} the original payload — { publicKey, secretKey, accountLabel, ... }
+ */
+export async function decryptBackup(envelope, password) {
+  const salt = new Uint8Array(base64ToArrayBuffer(envelope.salt));
+  const iv = new Uint8Array(base64ToArrayBuffer(envelope.iv));
+  const ciphertext = base64ToArrayBuffer(envelope.ciphertext);
+  const key = await deriveAesKey(password, salt, 'decrypt');
+
+  let plaintext;
+  try {
+    plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+  } catch {
+    throw backupError(BACKUP_ERROR_CODES.WRONG_PASSWORD, 'Incorrect backup password.');
+  }
+
+  return JSON.parse(new TextDecoder().decode(plaintext));
+}
+
+/** Build the download filename, e.g. future-backup-2026-07-26.enc */
+export function buildBackupFilename(date = new Date()) {
+  const iso = date.toISOString().slice(0, 10);
+  return `future-backup-${iso}.enc`;
+}
+
+/** Trigger a browser download of the given text content. */
+export function downloadBackupFile(filename, contents) {
+  const blob = new Blob([contents], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  try {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+const STRENGTH_LABELS = ['Very Weak', 'Weak', 'Fair', 'Good', 'Strong'];
+
+/**
+ * Simple heuristic password strength scorer (0-4) for the backup password field.
+ * Not a substitute for a full zxcvbn-style estimator, but enough to nudge users
+ * away from trivially weak backup passwords.
+ */
+export function scorePasswordStrength(password) {
+  if (!password) return { score: 0, label: STRENGTH_LABELS[0] };
+
+  let score = 0;
+  if (password.length >= 8) score += 1;
+  if (password.length >= 14) score += 1;
+  if (/[a-z]/.test(password) && /[A-Z]/.test(password)) score += 1;
+  if (/\d/.test(password)) score += 1;
+  if (/[^A-Za-z0-9]/.test(password)) score += 1;
+
+  const clamped = Math.min(score, STRENGTH_LABELS.length - 1);
+  return { score: clamped, label: STRENGTH_LABELS[clamped] };
+}

--- a/frontend/src/utils/backup.js
+++ b/frontend/src/utils/backup.js
@@ -132,6 +132,22 @@ export async function decryptBackup(envelope, password) {
   return JSON.parse(new TextDecoder().decode(plaintext));
 }
 
+/**
+ * Verify a parsed backup envelope against the currently loaded account,
+ * without ever exposing the decrypted secret key to the caller.
+ * @returns {Promise<{outcome: 'success'|'mismatch', createdAt: string, backupPublicKey: string}>}
+ * @throws {Error} with .code === BACKUP_ERROR_CODES.WRONG_PASSWORD on decryption failure
+ */
+export async function verifyBackupAgainstAccount(envelope, password, currentPublicKey) {
+  const decrypted = await decryptBackup(envelope, password);
+
+  if (!currentPublicKey || decrypted.publicKey !== currentPublicKey) {
+    return { outcome: 'mismatch', createdAt: envelope.createdAt, backupPublicKey: decrypted.publicKey };
+  }
+
+  return { outcome: 'success', createdAt: envelope.createdAt, backupPublicKey: decrypted.publicKey };
+}
+
 /** Build the download filename, e.g. future-backup-2026-07-26.enc */
 export function buildBackupFilename(date = new Date()) {
   const iso = date.toISOString().slice(0, 10);

--- a/frontend/src/utils/backupReminder.js
+++ b/frontend/src/utils/backupReminder.js
@@ -1,0 +1,59 @@
+/**
+ * Local (device-scoped) tracking for the "create a fresh backup" reminder.
+ * Persisted to localStorage rather than the backend, since it only concerns
+ * this browser's nudge state, not account data.
+ */
+
+const STORAGE_KEY = 'future_backup_reminder_v1';
+const DEFAULT_THRESHOLD = 10;
+const SNOOZE_MS = 24 * 60 * 60 * 1000;
+
+function readState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeState(patch) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...readState(), ...patch }));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+export function getBackupReminderThreshold() {
+  const { threshold } = readState();
+  return Number.isFinite(threshold) && threshold > 0 ? threshold : DEFAULT_THRESHOLD;
+}
+
+export function setBackupReminderThreshold(threshold) {
+  const n = Number(threshold);
+  writeState({ threshold: Number.isFinite(n) && n > 0 ? n : DEFAULT_THRESHOLD });
+}
+
+export function getLastBackupInfo() {
+  const { lastBackupTimestamp = null, lastBackupTransactionCount = 0 } = readState();
+  return { lastBackupTimestamp, lastBackupTransactionCount };
+}
+
+/** Call whenever a backup is created or successfully verified. */
+export function recordBackupEvent(transactionCount = 0) {
+  writeState({
+    lastBackupTimestamp: new Date().toISOString(),
+    lastBackupTransactionCount: transactionCount,
+    snoozedUntil: null,
+  });
+}
+
+export function snoozeBackupReminder() {
+  writeState({ snoozedUntil: Date.now() + SNOOZE_MS });
+}
+
+export function isBackupReminderSnoozed() {
+  const { snoozedUntil } = readState();
+  return typeof snoozedUntil === 'number' && Date.now() < snoozedUntil;
+}

--- a/frontend/tests/backup.test.js
+++ b/frontend/tests/backup.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  encryptBackup,
+  decryptBackup,
+  serializeBackupFile,
+  parseBackupFile,
+  BACKUP_ERROR_CODES,
+} from '../src/utils/backup.js';
+
+const PAYLOAD = {
+  publicKey: 'GABC123',
+  secretKey: 'SABC123',
+  accountLabel: 'My Account',
+  createdAt: '2026-07-26T00:00:00.000Z',
+};
+
+describe('backup encryption round trip', () => {
+  it('encrypts and decrypts a payload with the correct password', async () => {
+    const envelope = await encryptBackup(PAYLOAD, 'correct horse battery staple');
+    const decrypted = await decryptBackup(envelope, 'correct horse battery staple');
+    expect(decrypted).toEqual(PAYLOAD);
+  });
+
+  it('serialises and parses the envelope without losing data', async () => {
+    const envelope = await encryptBackup(PAYLOAD, 'my-backup-password');
+    const json = serializeBackupFile(envelope);
+    const parsed = parseBackupFile(json);
+    const decrypted = await decryptBackup(parsed, 'my-backup-password');
+    expect(decrypted).toEqual(PAYLOAD);
+  });
+
+  it('throws a WRONG_PASSWORD error when decrypting with an incorrect password', async () => {
+    const envelope = await encryptBackup(PAYLOAD, 'my-backup-password');
+    await expect(decryptBackup(envelope, 'wrong-password')).rejects.toMatchObject({
+      code: BACKUP_ERROR_CODES.WRONG_PASSWORD,
+    });
+  });
+
+  it('throws a CORRUPTED_FILE error for malformed JSON', () => {
+    expect(() => parseBackupFile('not json')).toThrow(
+      expect.objectContaining({ code: BACKUP_ERROR_CODES.CORRUPTED_FILE }),
+    );
+  });
+
+  it('throws a CORRUPTED_FILE error when required envelope fields are missing', () => {
+    expect(() => parseBackupFile(JSON.stringify({ version: 1 }))).toThrow(
+      expect.objectContaining({ code: BACKUP_ERROR_CODES.CORRUPTED_FILE }),
+    );
+  });
+});

--- a/frontend/tests/backupVerification.test.js
+++ b/frontend/tests/backupVerification.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  encryptBackup,
+  parseBackupFile,
+  verifyBackupAgainstAccount,
+  BACKUP_ERROR_CODES,
+} from '../src/utils/backup.js';
+
+const PAYLOAD = {
+  publicKey: 'GABC123ACCOUNT',
+  secretKey: 'SABC123SECRET',
+  accountLabel: 'My Account',
+  createdAt: '2026-07-26T00:00:00.000Z',
+};
+const PASSWORD = 'my-backup-password';
+
+describe('backup verification outcomes', () => {
+  it('success: decrypts and matches the currently loaded account', async () => {
+    const envelope = await encryptBackup(PAYLOAD, PASSWORD);
+    const result = await verifyBackupAgainstAccount(envelope, PASSWORD, PAYLOAD.publicKey);
+    expect(result).toEqual({ outcome: 'success', createdAt: envelope.createdAt, backupPublicKey: PAYLOAD.publicKey });
+  });
+
+  it('wrong password: rejects with a WRONG_PASSWORD error', async () => {
+    const envelope = await encryptBackup(PAYLOAD, PASSWORD);
+    await expect(verifyBackupAgainstAccount(envelope, 'not-the-password', PAYLOAD.publicKey)).rejects.toMatchObject({
+      code: BACKUP_ERROR_CODES.WRONG_PASSWORD,
+    });
+  });
+
+  it('corrupted file: parseBackupFile rejects malformed input before verification even begins', () => {
+    expect(() => parseBackupFile('{ this is not valid json')).toThrow(
+      expect.objectContaining({ code: BACKUP_ERROR_CODES.CORRUPTED_FILE }),
+    );
+  });
+
+  it('mismatched account: decrypts fine but the public key does not match the current account', async () => {
+    const envelope = await encryptBackup(PAYLOAD, PASSWORD);
+    const result = await verifyBackupAgainstAccount(envelope, PASSWORD, 'GDIFFERENTACCOUNT');
+    expect(result).toEqual({ outcome: 'mismatch', createdAt: envelope.createdAt, backupPublicKey: PAYLOAD.publicKey });
+  });
+
+  it('never returns the secret key as part of any outcome', async () => {
+    const envelope = await encryptBackup(PAYLOAD, PASSWORD);
+    const success = await verifyBackupAgainstAccount(envelope, PASSWORD, PAYLOAD.publicKey);
+    const mismatch = await verifyBackupAgainstAccount(envelope, PASSWORD, 'GDIFFERENTACCOUNT');
+    expect(success).not.toHaveProperty('secretKey');
+    expect(mismatch).not.toHaveProperty('secretKey');
+  });
+});

--- a/scripts/pii-scan.mjs
+++ b/scripts/pii-scan.mjs
@@ -33,6 +33,7 @@ const SKIP_EXACT = new Set([
   // Test files that use deliberately fake/generated Stellar keys and JWTs
   'backend/tests/keypairRotation.test.js',
   'backend/tests/stellar.unit.test.js',
+  'backend/tests/assets.routes.test.js',
   'security/tests/secret-scanner-detection.test.js',
   'security/tests/security-vulnerabilities.test.js',
 ]);


### PR DESCRIPTION
## Summary

Bundles four related tickets into one PR:

- **#799 — Add encrypted backup download to BackupSettings**
  Adds `frontend/src/utils/backup.js`: PBKDF2 (250k iterations, SHA-256, random salt) derives an AES-256-GCM key from a user-supplied password, which encrypts the account keypair + settings into a versioned JSON envelope (salt/iv/ciphertext/createdAt). The server never sees the plaintext or password. `BackupSettings.jsx` gets a new "Download Encrypted Backup" section: password + confirm fields with a strength indicator, a warning to store the password separately from the file, and a button that encrypts and downloads `future-backup-YYYY-MM-DD.enc`.

- **#800 — Add backup integrity verification flow**
  Adds a "Verify Backup" section to `BackupSettings.jsx`: upload a previously downloaded backup file, supply its password, and confirm it decrypts correctly and matches the currently loaded account — without ever exposing the secret key. Covers four outcomes: success (shows the backup's creation timestamp), wrong password, corrupted/invalid file, and mismatched account. `verifyBackupAgainstAccount()` in `backup.js` keeps this decision logic pure and testable. A successful verification credits the backup reminder system the same way a fresh backup does.

- **#801 — Add automatic backup reminder after N transactions**
  Adds `frontend/src/utils/backupReminder.js` (localStorage-backed tracking of last-backup timestamp/transaction-count and snooze state), a `useBackupReminder` hook, and a `BackupReminderBanner` component. Integrated into `AccountDashboardPage.jsx`: fetches the account's transaction count, shows a dismissible banner once N new transactions have occurred since the last backup/verification (default N=10, dismiss snoozes for 24h), with a CTA that opens `BackupSettings`. The threshold N is configurable in `NotificationPreferences.jsx`. Both the download flow (#799) and verify flow (#800) reset the counter.

- **#802 — Add RTL layout support for Arabic and Hebrew**
  Migrates physical directional CSS properties (`margin-left/right`, `padding-left/right`, `text-align: left/right`, `left`/`right` positioning) to their logical equivalents (`margin-inline-start/end`, `padding-inline-start/end`, `text-align: start/end`, `inset-inline-start/end`) across `frontend/src/index.css` and `components/AdvancedSearch.css`, so layouts mirror correctly under `dir="rtl"` (the existing i18n `dir` detection and `useRTL` hook already set this per-language; this makes the layout actually respond to it). Adds a CONTRIBUTING.md note requiring logical properties for new CSS.

Also includes a small standalone fix: `backend/tests/assets.routes.test.js`'s deliberately-fake placeholder Stellar secret key wasn't on the PII pre-commit scanner's allowlist (unlike two near-identical fake-key test files), which was blocking commits repo-wide; added it to the existing allowlist.

## Test plan

- [x] `frontend/tests/backup.test.js` — encrypt/decrypt round trip, envelope serialise/parse round trip, wrong password, corrupted file (5/5 passing)
- [x] `frontend/tests/backupVerification.test.js` — success, wrong password, corrupted file, mismatched account, no secret-key leakage (5/5 passing)
- [x] `npx eslint` clean on all new/modified files (only pre-existing warnings remain, none introduced by this change)
- [x] Full `vitest run frontend` suite: same 21 pre-existing failing files / 67 pre-existing failing tests before and after this branch (confirmed via baseline comparison) — no regressions introduced

Closes #799
Closes #800
Closes #801
Closes #802