### PR TITLE
docs: add API auth guide and contributing test section (#812, #813)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,502 @@ npm run load-test:regression --workspace=backend
 
 ---
 
+## Testing
+
+This section is the complete reference for writing, running, and reasoning about tests in this project. A new contributor should be able to follow it from top to bottom without prior knowledge of the test setup.
+
+> **Day-one task:** Before you write any code, run all three test suites locally and confirm they pass. This validates your environment and gives you a baseline to compare against.
+
+### Quick-reference command table
+
+| Suite | Command | When to use |
+|---|---|---|
+| Unit + integration (single run) | `npm run test:coverage` | Before every PR |
+| Unit + integration (watch mode) | `npm run test:watch` | During development |
+| Backend tests only | `npm run test --workspace=backend` | When changing backend code |
+| DB integration tests | `npm run test:db --workspace=backend` | When changing Prisma schema or queries |
+| E2E tests (headless) | `npx playwright test` | Before every PR, from `e2e/` directory |
+| E2E tests (headed — visual) | `npx playwright test --headed` | Debugging a failing E2E test |
+| E2E tests (one browser) | `npx playwright test --project=chromium` | Faster local iteration |
+| Mutation tests | `npm run test:mutation` | When adding new unit tests or utility functions |
+| Property-based tests | `npm run test:property` | Included in `npm run test:coverage` |
+| Contract tests | `npm run test:contracts` | When changing API request/response shapes |
+
+---
+
+### Test stack overview
+
+The project uses three distinct testing frameworks, each with a specific role.
+
+#### Vitest — unit and integration tests
+
+[Vitest](https://vitest.dev/) covers all unit and integration tests across the frontend and backend. Use Vitest for:
+
+- Pure functions (validators, formatters, utilities)
+- Service layer logic
+- React component rendering and interactions (`@testing-library/react`)
+- Backend route handlers with a mocked or in-process Express app
+- Database integration tests against a real PostgreSQL instance
+
+**Do not** use Vitest for anything that requires a real browser (use Playwright instead).
+
+Configuration: `vitest.config.js` (root), `vitest.mutation.config.js` (mutation testing), `vitest.property.config.js` (property tests), `vitest.contracts.config.js` (contract tests).
+
+Coverage thresholds (enforced in CI):
+
+| Metric | Threshold |
+|---|---|
+| Lines | 80% |
+| Functions | 80% |
+| Branches | 75% |
+| Statements | 80% |
+
+#### Playwright — end-to-end tests
+
+[Playwright](https://playwright.dev/) drives a real browser to test complete user flows. Use Playwright for:
+
+- Multi-step user journeys (registration → onboarding → dashboard)
+- Anything that depends on browser APIs (cookies, `localStorage`, clipboard)
+- Cross-browser compatibility (Chromium, Firefox, WebKit, mobile viewports)
+- Visual regression (`@visual` tag)
+
+**Do not** write Playwright tests for logic that Vitest can cover. A Playwright test is 10–50× slower than a Vitest test.
+
+Configuration: `e2e/playwright.config.js`.
+
+#### Stryker — mutation testing
+
+[Stryker](https://stryker-mutator.io/) measures test quality by introducing small deliberate bugs (mutations) into the source code and checking whether the test suite catches them. A high line-coverage figure can hide weak assertions — Stryker makes the quality of assertions visible.
+
+Use the mutation score as a signal, not a hard constraint:
+
+| Score | Meaning |
+|---|---|
+| ≥ 80 (high) | Acceptable — assertions are meaningful |
+| 60–79 (low) | Flag for improvement before merging |
+| < 50 (break) | CI fails — too many mutations survive |
+
+Mutation testing targets `frontend/src/utils/*.js` and `backend/src/services/*.js`. It does not run on every PR by default (it is slow); it runs in CI on the `test:mutation:ci` pipeline job.
+
+---
+
+### Prerequisite setup
+
+#### 1. Install Node.js 20 and npm 10
+
+```bash
+nvm use 20
+node --version   # v20.x.x
+npm --version    # 10.x.x
+```
+
+#### 2. Install all dependencies
+
+```bash
+npm install           # from the repo root
+```
+
+#### 3. Start PostgreSQL
+
+```bash
+docker compose up db -d
+```
+
+This is required for DB integration tests (`test:db`) and for any test that uses Prisma against a real database.
+
+#### 4. Configure the backend environment
+
+```bash
+cd backend
+cp .env.example .env
+```
+
+For tests, the minimum required variables are:
+
+```env
+DATABASE_URL=postgresql://user:password@localhost:5432/future_remittance
+JWT_SECRET=any-string-is-fine-for-testing
+STREAM_SECRET_ENCRYPTION_KEY=<32-byte hex — see comment in .env.example>
+```
+
+A `.env.test` file is already present in `backend/` with safe test defaults. Vitest picks it up automatically when running `npm run test`.
+
+#### 5. Run database migrations
+
+```bash
+cd backend
+npx prisma migrate deploy
+```
+
+#### 6. Install Playwright browser binaries
+
+The Playwright binaries are not bundled with `npm install`. Install them once:
+
+```bash
+cd e2e
+npm install                    # installs Playwright itself
+npx playwright install         # downloads browser binaries (~300 MB)
+npx playwright install-deps    # installs OS-level dependencies (Linux only)
+```
+
+Expected output from `npx playwright install`:
+
+```
+Downloading Chromium 123.0.6312.86 ...
+Chromium 123.0.6312.86 downloaded to ~/.cache/ms-playwright/...
+Downloading Firefox 124.0 ...
+...
+```
+
+#### 7. (Optional) Install k6 for load tests
+
+```bash
+# macOS
+brew install k6
+
+# Linux
+sudo apt-get install k6
+
+# Windows
+choco install k6
+```
+
+---
+
+### Writing unit tests
+
+#### File location and naming
+
+| Code being tested | Test file location | Example |
+|---|---|---|
+| `backend/src/auth/tokens.js` | `backend/tests/auth.tokens.test.js` | ✔ existing |
+| `frontend/src/utils/validateAmount.js` | `frontend/src/utils/validateAmount.test.js` | ✔ existing |
+| `frontend/src/components/Button.jsx` | `frontend/src/components/Button.test.jsx` | ✔ existing |
+
+Test files must end in `.test.js`, `.test.jsx`, `.spec.js`, or `.spec.jsx`.
+
+#### Conventions
+
+- One `describe` block per module or function under test.
+- One `it` / `test` per behaviour, not per line of source code.
+- Test description reads as a sentence: `it('returns null when the amount is zero')`.
+- Arrange–Act–Assert structure: set up data, call the function, assert the result.
+- Use `beforeEach` for per-test setup. Avoid shared mutable state across tests.
+- Prefer real values over mocks unless the dependency is a network call, database, or clock.
+
+#### Annotated example — `backend/tests/auth.tokens.test.js`
+
+```javascript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { signAccessToken, verifyToken, signRefreshToken } from '../src/auth/tokens.js';
+import { resetConfig } from '../src/config/env.js';
+
+describe('JWT Tokens', () => {
+  // ── Setup ──────────────────────────────────────────────────────────────────
+  // Reset the config singleton and set a deterministic JWT_SECRET before each
+  // test so tests do not depend on each other's environment state.
+  beforeEach(() => {
+    resetConfig();
+    process.env.JWT_SECRET = 'test-secret-key-12345';
+  });
+
+  // ── Happy path ─────────────────────────────────────────────────────────────
+  it('signs and verifies an access token', () => {
+    const payload = { userId: 'user-123', role: 'admin' };
+
+    // Act — produce a token from a known payload
+    const token = signAccessToken(payload);
+
+    // Assert — the token is a non-empty string
+    expect(token).toBeDefined();
+
+    // Act — verify the token and unpack the payload
+    const verified = verifyToken(token);
+
+    // Assert — the original claims are present
+    expect(verified.userId).toBe('user-123');
+    expect(verified.role).toBe('admin');
+  });
+
+  it('signs and verifies a refresh token', () => {
+    const payload = { userId: 'user-456' };
+    const token = signRefreshToken(payload);
+    const verified = verifyToken(token);
+    expect(verified.userId).toBe('user-456');
+  });
+
+  // ── Error path ─────────────────────────────────────────────────────────────
+  // Test the unhappy path explicitly. This verifies that the error is thrown
+  // rather than silently returning undefined or a bad token.
+  it('throws when JWT_SECRET is not configured', () => {
+    resetConfig();
+    delete process.env.JWT_SECRET;
+
+    expect(() => {
+      signAccessToken({ userId: 'user' });
+    }).toThrow('JWT_SECRET is not configured');
+  });
+});
+```
+
+**Key things to notice:**
+
+1. `beforeEach` resets global state — tests that mutate `process.env` or a singleton must clean up.
+2. Happy path and error path are both tested.
+3. Each `it` has a single, focused assertion goal. Multi-assertion tests are fine when all assertions test the same behaviour.
+4. No mocks were needed here because `signAccessToken` is a pure function given a stable `JWT_SECRET`.
+
+#### Shared fixtures and factories
+
+Shared test helpers live in `testing/` at the repo root and in `backend/tests/helpers/`. Import from there rather than duplicating setup logic:
+
+```javascript
+import { createTestUser, createTestSession } from '../helpers/factories.js';
+```
+
+---
+
+### Writing E2E tests
+
+#### Prerequisite: start the app
+
+The Playwright config starts `npm run dev` automatically when you run tests (`webServer` in `e2e/playwright.config.js`). If a server is already running on port 3000, Playwright will reuse it.
+
+```bash
+# run all e2e tests (from repo root)
+cd e2e
+npx playwright test
+
+# run headed — opens a browser window you can watch
+npx playwright test --headed
+
+# run a single file
+npx playwright test tests/onboarding.spec.js
+
+# run a single test by title
+npx playwright test --grep "shows public key"
+
+# run on one browser only (faster during development)
+npx playwright test --project=chromium
+```
+
+**Expected clean-run output:**
+
+```
+Running 8 tests using 1 worker
+
+  ✓ Registration › shows confirmation or redirects to keypair setup (1.3s)
+  ✓ Registration › shows error when email is already registered (2.1s)
+  ...
+
+  8 passed (12s)
+```
+
+#### File location and naming
+
+All E2E tests live in `e2e/tests/`. Name files after the user flow they cover: `onboarding.spec.js`, `payment.spec.js`, `settings.spec.js`.
+
+#### Page object pattern
+
+For any page visited by more than one test, extract selectors and actions into a page object class. Store page objects in `e2e/pages/`:
+
+```javascript
+// e2e/pages/LoginPage.js
+export class LoginPage {
+  constructor(page) {
+    this.page = page;
+    this.emailInput = page.locator('[data-testid="email"]');
+    this.passwordInput = page.locator('[data-testid="password"]');
+    this.submitButton = page.locator('[data-testid="signup-btn"]');
+    this.errorMessage = page.locator('[data-testid="signup-error"]');
+  }
+
+  async goto() {
+    await this.page.goto('/signup');
+  }
+
+  async fillAndSubmit(email, password) {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.submitButton.click();
+  }
+}
+```
+
+Then use it in a test:
+
+```javascript
+import { LoginPage } from '../pages/LoginPage.js';
+
+test('shows error for duplicate email', async ({ page }) => {
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.fillAndSubmit('alice@example.com', 'Str0ngPass!');
+  // ...
+});
+```
+
+#### Handling authentication in E2E tests
+
+Use `data-testid` attributes for selectors — never CSS classes or element tags, which change with styling refactors. The existing tests in `e2e/tests/onboarding.spec.js` follow this pattern.
+
+To avoid re-authenticating in every test, use Playwright's [storageState](https://playwright.dev/docs/auth) to save a logged-in session:
+
+```javascript
+// e2e/auth.setup.js
+import { test as setup } from '@playwright/test';
+
+setup('authenticate', async ({ page }) => {
+  await page.goto('/signup');
+  await page.fill('[data-testid="email"]', 'test@example.com');
+  await page.fill('[data-testid="password"]', 'Str0ngPass!');
+  await page.click('[data-testid="signup-btn"]');
+  await page.waitForURL(/\/dashboard/);
+  await page.context().storageState({ path: 'e2e/.auth/user.json' });
+});
+```
+
+#### Annotated example — `e2e/tests/onboarding.spec.js`
+
+```javascript
+import { test, expect } from '@playwright/test';
+
+// Helper to generate a unique email per test run, preventing conflicts
+// when tests run in parallel or are retried.
+function uniqueEmail() {
+  return `test+${Date.now()}@example.com`;
+}
+
+const STRONG_PASSWORD = 'Str0ngPass!word';
+
+test.beforeEach(async ({ page, context }) => {
+  // Start each test with a clean browser state
+  await context.clearCookies();
+  await page.evaluate(() => localStorage.clear());
+
+  // Intercept Friendbot calls so tests do not depend on the live Stellar testnet.
+  // The route mock returns a fixed successful response, making tests fast and deterministic.
+  await page.route('**/friendbot**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ successful: true, hash: 'b'.repeat(64) }),
+    });
+  });
+});
+
+test('shows confirmation or redirects to keypair setup after registration', async ({ page }) => {
+  const email = uniqueEmail();
+
+  // Navigate to the signup page
+  await page.goto('/signup');
+  await page.fill('[data-testid="email"]', email);
+  await page.fill('[data-testid="password"]', STRONG_PASSWORD);
+  await page.click('[data-testid="signup-btn"]');
+
+  // Assert — either the email-verification message or keypair setup is visible.
+  // Both are valid post-registration states depending on server configuration.
+  await expect(
+    page.locator('[data-testid="verify-message"], [data-testid="keypair-setup"]'),
+  ).toBeVisible({ timeout: 10000 });
+});
+```
+
+**Key things to notice:**
+
+1. `beforeEach` clears all browser state — tests are fully isolated.
+2. Network calls to external services are mocked with `page.route(...)` — tests are deterministic.
+3. Selectors use `data-testid` — resilient to HTML restructuring.
+4. The timeout on `toBeVisible` accounts for async navigation without relying on `waitForTimeout`.
+
+#### CI behaviour for E2E tests
+
+In CI (`process.env.CI` is set):
+
+- `retries: 2` — a flaky test must fail 3 times in a row before CI marks it as failed.
+- `workers: 1` — tests run sequentially to avoid port conflicts on shared runners.
+- `forbidOnly: true` — `test.only` accidentally left in code causes CI to fail immediately.
+- Reports are written to `e2e/test-reports/` (HTML, JSON, JUnit).
+
+On a local machine, tests run in parallel across available CPUs and retries are disabled.
+
+---
+
+### Mutation testing
+
+#### Running Stryker
+
+```bash
+# Run mutation testing (from the repo root)
+npm run test:mutation
+```
+
+This takes several minutes. Stryker targets `frontend/src/utils/*.js` and `backend/src/services/*.js`.
+
+Reports are written to `mutation-reports/`:
+
+- `mutation-reports/mutation-report.html` — open in a browser for the full interactive report
+- `mutation-reports/mutation-report.json` — machine-readable output for CI tracking
+
+#### Interpreting the output
+
+Stryker prints a summary to the terminal:
+
+```
+Mutation testing  [done] 2 minutes
+Ran 312 tests across 48 mutants in 105 seconds.
+
+All files
+ File                          | % score | # killed | # survived | # no coverage | # error |
+-------------------------------|---------|----------|------------|---------------|---------|
+ validateAmount.js             |  91.67  |    11    |      1     |       0       |    0    |
+ formatBalance.js              |   75.00 |     9    |      3     |       0       |    0    |
+```
+
+- **killed** — the mutation was caught by at least one test. ✔
+- **survived** — the mutation was NOT caught. Your tests did not assert on this behaviour. Add a test that would fail if this code were wrong.
+- **no coverage** — no test exercised the mutated line at all. Add a test for this code path.
+
+#### Thresholds
+
+| Threshold | Score | Consequence |
+|---|---|---|
+| `high` | 80 | Target — acceptable quality |
+| `low` | 60 | Warning — reviewer should request more tests |
+| `break` | 50 | CI hard-fails — PR cannot merge |
+
+#### Improving a low score
+
+When a mutation survives, look at the mutant in the HTML report. Stryker shows you exactly what code it changed and which tests ran. Add an assertion that would catch the described change:
+
+```javascript
+// Surviving mutant: changed `>` to `>=` in validateAmount.js
+// Add a boundary test:
+it('rejects amount of exactly 0', () => {
+  expect(validateAmount(0)).toBe(false);
+});
+```
+
+---
+
+### CI behaviour
+
+| Event | Jobs that run |
+|---|---|
+| Every PR | `test` (Vitest + coverage), `lint`, `tsc --noEmit`, `npm audit --audit-level=high`, `e2e-tests` (Playwright) |
+| Merge to `main` | All PR jobs + `security-pipeline`, `docker-scan`, `performance` |
+| Weekly schedule | `mutation-testing`, `backup-verification`, `dependency-updates` |
+
+#### When a CI job fails
+
+1. Click the failing job in GitHub Actions to see the full log.
+2. For Vitest failures: the log shows the test name, the expected vs received values, and a stack trace. Run the same test locally: `npx vitest run --reporter=verbose <file>`.
+3. For Playwright failures: screenshots and videos of the failing test are uploaded as workflow artifacts. Download them from the Actions run summary.
+4. For mutation testing failures: the `mutation-report.html` artifact shows exactly which mutants survived. Add tests for the surviving mutants.
+5. For `npm audit` failures: run `npm audit` locally and follow the [Dependency Vulnerability Management](#dependency-vulnerability-management) section.
+
+---
+
 ## Running Against Testnet
 
 The backend connects to the Stellar testnet by default. To run against it:
@@ -182,6 +678,19 @@ npm run dev:backend
 - [ ] No new high/critical vulnerabilities (`npm audit --audit-level=high`)
 - [ ] Code formatted with `npm run format`
 - [ ] PR description explains the change clearly
+
+### First-day onboarding checklist
+
+If you are new to this project, complete these tasks before writing any code:
+
+- [ ] Install Node.js 20 and verify with `node --version`
+- [ ] Clone the repo and run `npm install`
+- [ ] Start PostgreSQL with `docker compose up db -d`
+- [ ] Copy `backend/.env.example` to `backend/.env` and fill in required values
+- [ ] Run `npm run test:coverage` and confirm all tests pass
+- [ ] If contributing to frontend: run `cd e2e && npx playwright install` to download browser binaries
+- [ ] Run the dev server with `npm run dev` and confirm both frontend and backend start
+- [ ] Read the [Testing](#testing) section in this file
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,21 @@
+# Documentation
+
+This directory contains guides and reference documentation for the FuTuRe platform.
+
+## Guides
+
+| Document | Description |
+|---|---|
+| [API Authentication Guide](api-auth.md) | How to obtain credentials, authenticate requests, refresh tokens, and handle auth errors — start here if you are building an integration |
+| [Security Best Practices](guides/security.md) | API key storage, CSRF protection, webhook signature verification, CSP, and known attack vectors |
+
+## Operations
+
+| Document | Description |
+|---|---|
+| [Runbook](runbook.md) | Day-to-day operational procedures — server restart, DB migration rollback, incident response, backup restore |
+| [TypeScript Migration](typescript-migration.md) | Plan and conventions for the incremental JS → TS migration |
+
+## Architecture Decision Records
+
+Architecture decisions are recorded in [`docs/adr/`](adr/).

--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -1,0 +1,564 @@
+# API Authentication Guide
+
+This guide explains how to authenticate with the FuTuRe REST API. It covers every step of the authentication lifecycle — from obtaining credentials, to making authenticated requests, to refreshing tokens, to handling errors.
+
+---
+
+## Table of Contents
+
+1. [Authentication model](#1-authentication-model)
+2. [Obtaining credentials](#2-obtaining-credentials)
+3. [Authenticating — getting tokens](#3-authenticating--getting-tokens)
+4. [Using the access token](#4-using-the-access-token)
+5. [Token lifetime and refresh](#5-token-lifetime-and-refresh)
+6. [Session management](#6-session-management)
+7. [Alternative authentication methods](#7-alternative-authentication-methods)
+8. [CSRF protection](#8-csrf-protection)
+9. [Error reference](#9-error-reference)
+10. [Security best practices](#10-security-best-practices)
+
+---
+
+## 1. Authentication model
+
+The FuTuRe API uses **JWT Bearer tokens** (JSON Web Tokens, RFC 7519). Every protected endpoint requires an `Authorization` header containing a short-lived access token.
+
+The flow is:
+
+```
+POST /api/auth/login
+  → returns: { accessToken }
+  → sets:    HttpOnly cookie: refreshToken
+
+Attach accessToken to protected requests:
+  Authorization: Bearer <accessToken>
+
+Before accessToken expires (15 min), refresh it:
+POST /api/auth/refresh  (sends the refreshToken cookie automatically)
+  → returns: { accessToken }
+  → rotates: refreshToken cookie
+```
+
+Key properties of this model:
+
+| Property | Value |
+|---|---|
+| Token format | JWT (HS256) |
+| Access token lifetime | 15 minutes |
+| Refresh token lifetime | 7 days |
+| Refresh delivery mechanism | HttpOnly, Secure, SameSite=Strict cookie |
+| Session validation | Each request validates the session against the database |
+| Account lockout | After repeated failed logins (HTTP 423) |
+
+---
+
+## 2. Obtaining credentials
+
+### Creating an account
+
+Register a new account with a username and password:
+
+```bash
+curl -s -X POST http://localhost:3001/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username": "alice", "password": "S3cur3P@ss!"}'
+```
+
+**Requirements:**
+
+- `username` — 3–32 characters
+- `password` — minimum 8 characters
+
+**Success response (201):**
+
+```json
+{
+  "user": {
+    "id": "usr_01HX",
+    "username": "alice",
+    "createdAt": "2026-07-27T10:00:00.000Z"
+  }
+}
+```
+
+**Error — username already taken (409):**
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "CONFLICT",
+    "message": "User already exists"
+  }
+}
+```
+
+> **Rate limit:** Registration and login share a limit of **5 requests per 15 minutes** per IP. Exceeding this returns HTTP 429.
+
+---
+
+## 3. Authenticating — getting tokens
+
+### Login
+
+```bash
+curl -s -c cookies.txt -X POST http://localhost:3001/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "alice", "password": "S3cur3P@ss!"}'
+```
+
+The `-c cookies.txt` flag saves the `refreshToken` cookie — keep this file secure.
+
+**Success response (200):**
+
+```json
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "sessionId": "ses_abc123"
+}
+```
+
+The `refreshToken` is not in the response body. It is set as an `HttpOnly` cookie scoped to `/api/auth`, so it is never accessible to JavaScript and is sent automatically with subsequent requests to that path.
+
+**Account locked (423):**
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "UNAUTHORIZED",
+    "message": "Account is temporarily locked due to too many failed login attempts",
+    "details": { "retryAfter": 900 }
+  }
+}
+```
+
+The `Retry-After` response header contains the same value in seconds.
+
+---
+
+## 4. Using the access token
+
+Attach the access token to every protected request using the `Authorization` header with the `Bearer` scheme.
+
+### curl
+
+```bash
+ACCESS_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+
+curl -s http://localhost:3001/api/auth/profile \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+### fetch (browser / Node.js)
+
+```javascript
+const response = await fetch('http://localhost:3001/api/auth/profile', {
+  headers: {
+    'Authorization': `Bearer ${accessToken}`,
+    'Content-Type': 'application/json',
+  },
+  credentials: 'include', // required for the refreshToken cookie
+});
+const data = await response.json();
+```
+
+### axios
+
+```javascript
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://localhost:3001',
+  withCredentials: true, // required for the refreshToken cookie
+});
+
+// Set once after login, reuse for all requests
+api.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+
+const { data } = await api.get('/api/auth/profile');
+```
+
+> **Note:** `credentials: 'include'` / `withCredentials: true` is required so the browser sends the `refreshToken` cookie on `/api/auth/refresh` calls. Without it, silent token refresh will not work.
+
+---
+
+## 5. Token lifetime and refresh
+
+### Access token expiry
+
+Access tokens are valid for **15 minutes**. When a token expires the API returns:
+
+```http
+HTTP/1.1 401 Unauthorized
+
+{
+  "success": false,
+  "error": {
+    "code": "AUTH_INVALID_TOKEN",
+    "message": "Invalid or expired token"
+  }
+}
+```
+
+### Detecting expiry before it happens
+
+The JWT payload contains a standard `exp` claim (Unix timestamp). You can decode the payload locally — without verifying the signature — to read `exp`:
+
+```javascript
+function getTokenExpiry(token) {
+  const payload = JSON.parse(atob(token.split('.')[1]));
+  return new Date(payload.exp * 1000);
+}
+
+function isExpiringSoon(token, bufferMs = 60_000) {
+  return getTokenExpiry(token).getTime() - Date.now() < bufferMs;
+}
+```
+
+A common pattern is to refresh the token when it has less than 60 seconds remaining.
+
+### Refreshing the token
+
+Call `POST /api/auth/refresh`. The `refreshToken` cookie is sent automatically by the browser (or by curl with `-b cookies.txt`). No request body is needed.
+
+```bash
+# curl — cookie jar from login step
+curl -s -b cookies.txt -c cookies.txt -X POST http://localhost:3001/api/auth/refresh
+```
+
+```javascript
+// fetch — browser sends the cookie automatically
+const response = await fetch('http://localhost:3001/api/auth/refresh', {
+  method: 'POST',
+  credentials: 'include',
+});
+const { accessToken } = await response.json();
+```
+
+**Success response (200):**
+
+```json
+{ "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." }
+```
+
+The refresh token is **rotated** on every successful refresh call — a new `refreshToken` cookie is set and the old one is invalidated. Always save the updated cookie.
+
+**Refresh token expired or revoked (401):**
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "AUTH_INVALID_TOKEN",
+    "message": "Invalid or expired refresh token"
+  }
+}
+```
+
+When this happens the user must log in again. There is no silent recovery path.
+
+### Recommended refresh strategy (axios interceptor)
+
+```javascript
+import axios from 'axios';
+
+const api = axios.create({ baseURL: 'http://localhost:3001', withCredentials: true });
+
+let isRefreshing = false;
+let queue = [];
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const original = error.config;
+    if (error.response?.status !== 401 || original._retry) {
+      return Promise.reject(error);
+    }
+    if (isRefreshing) {
+      return new Promise((resolve, reject) => {
+        queue.push({ resolve, reject });
+      }).then((token) => {
+        original.headers['Authorization'] = `Bearer ${token}`;
+        return api(original);
+      });
+    }
+    original._retry = true;
+    isRefreshing = true;
+    try {
+      const { data } = await api.post('/api/auth/refresh');
+      api.defaults.headers.common['Authorization'] = `Bearer ${data.accessToken}`;
+      queue.forEach(({ resolve }) => resolve(data.accessToken));
+      return api(original);
+    } catch (refreshError) {
+      queue.forEach(({ reject }) => reject(refreshError));
+      // Redirect to login
+      window.location.href = '/login';
+      return Promise.reject(refreshError);
+    } finally {
+      isRefreshing = false;
+      queue = [];
+    }
+  }
+);
+```
+
+---
+
+## 6. Session management
+
+Each login creates a server-side session. Sessions are tracked in the database and validated on every authenticated request. A token whose session has been revoked will be rejected even if the JWT itself has not expired.
+
+### List active sessions
+
+```bash
+curl -s http://localhost:3001/api/auth/sessions \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+```json
+{
+  "sessions": [
+    {
+      "id": "ses_abc123",
+      "device": "macOS",
+      "ipAddress": "203.0.113.1",
+      "lastActiveAt": "2026-07-27T10:30:00.000Z",
+      "createdAt": "2026-07-27T09:00:00.000Z",
+      "current": true
+    }
+  ]
+}
+```
+
+### Revoke a specific session
+
+```bash
+curl -s -X DELETE http://localhost:3001/api/auth/sessions/ses_abc123 \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+### Revoke all other sessions (logout everywhere)
+
+```bash
+curl -s -X DELETE http://localhost:3001/api/auth/sessions \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+### Logout (current session)
+
+```bash
+curl -s -b cookies.txt -X POST http://localhost:3001/api/auth/logout \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+This revokes the current session and clears the `refreshToken` cookie.
+
+---
+
+## 7. Alternative authentication methods
+
+### Stellar SEP-0010 (wallet authentication)
+
+Accounts that have a Stellar keypair can authenticate without a username and password using the SEP-0010 challenge–response flow.
+
+**Step 1 — Get a challenge transaction:**
+
+```bash
+curl -s "http://localhost:3001/api/auth/stellar/challenge?account=GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZWM9CQJHD9QDNHXHXN"
+```
+
+```json
+{
+  "transaction": "<base64 XDR>",
+  "network_passphrase": "Test SDF Network ; September 2015",
+  "network": "testnet"
+}
+```
+
+**Step 2 — Sign the transaction with your Stellar secret key**, then submit the signed XDR:
+
+```bash
+curl -s -X POST http://localhost:3001/api/auth/stellar/token \
+  -H "Content-Type: application/json" \
+  -d '{"transaction": "<signed base64 XDR>"}'
+```
+
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+Use the returned `accessToken` exactly as described in [section 4](#4-using-the-access-token).
+
+> The challenge expires after **5 minutes**. Submit the signed transaction before it times out.
+
+### Google OAuth 2.0
+
+Redirect the user to:
+
+```
+GET /api/auth/oauth/google
+```
+
+After the user consents, Google redirects back to your registered callback URI. The API will redirect the user to the configured `FRONTEND_BASE_URL` with `accessToken` and `refreshToken` as query parameters. Store these securely and immediately remove them from the URL bar.
+
+### Multi-factor authentication (TOTP)
+
+MFA can be enabled on any account. Once enabled, successful password authentication alone is insufficient — the session token issued at login is a limited-privilege token until the TOTP code is verified.
+
+```bash
+# Initiate MFA setup
+curl -s -X POST http://localhost:3001/api/auth/mfa/setup \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"totp": "123456", "secret": "<TOTP secret from your authenticator app>"}'
+```
+
+---
+
+## 8. CSRF protection
+
+All state-mutating requests (POST, PUT, DELETE) that originate from a browser must include a CSRF token. Curl-based integrations running server-to-server are typically exempt because they do not use cookies for authentication — but any browser-based integration must follow this flow.
+
+**Step 1 — Fetch a CSRF token on app initialisation:**
+
+```bash
+curl -s http://localhost:3001/api/auth/csrf-token
+```
+
+```json
+{ "csrfToken": "abc123def456..." }
+```
+
+Store the token in memory (not `localStorage`).
+
+**Step 2 — Include it in every mutating request:**
+
+```javascript
+await fetch('http://localhost:3001/api/payments', {
+  method: 'POST',
+  credentials: 'include',
+  headers: {
+    'Authorization': `Bearer ${accessToken}`,
+    'Content-Type': 'application/json',
+    'X-CSRF-Token': csrfToken,
+  },
+  body: JSON.stringify({ ... }),
+});
+```
+
+CSRF tokens expire after 24 hours. Refresh after login and after each successful mutation.
+
+---
+
+## 9. Error reference
+
+All error responses share the same envelope:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable description",
+    "requestId": "uuid"
+  }
+}
+```
+
+### Authentication error codes
+
+| HTTP status | `error.code` | Meaning | Remediation |
+|---|---|---|---|
+| 401 | `AUTH_INVALID_TOKEN` | Token is malformed, has an invalid signature, or the session has been revoked | Re-authenticate or refresh the token |
+| 401 | `AUTH_TOKEN_EXPIRED` | JWT `exp` claim is in the past | Call `POST /api/auth/refresh` |
+| 401 | `AUTH_INVALID_CREDENTIALS` | Username or password is incorrect | Check credentials; do not retry more than 5 times |
+| 401 | `UNAUTHORIZED` | Request reached a protected endpoint without an `Authorization` header | Add `Authorization: Bearer <token>` |
+| 403 | `FORBIDDEN` | The authenticated user does not have the required role or permission | Contact the platform to request elevated access |
+| 409 | `CONFLICT` | Username is already registered | Choose a different username |
+| 422 | `VALIDATION_INVALID_INPUT` | Request body failed validation (details in `error.details`) | Fix the fields listed in `error.details` |
+| 422 | `VALIDATION_MISSING_FIELD` | A required field is absent | Add the missing field |
+| 423 | `UNAUTHORIZED` | Account is temporarily locked after too many failed login attempts | Wait for the `Retry-After` seconds before retrying |
+| 429 | `RATE_LIMITED` | Too many requests from this IP or for this email | Back off and retry after the `Retry-After` header value |
+| 500 | `INTERNAL_ERROR` | Unexpected server error | Retry with exponential back-off; contact support if persistent |
+
+### Common login error scenarios
+
+**Missing Authorization header:**
+
+```
+HTTP/1.1 401
+{ "error": "Missing or invalid Authorization header" }
+```
+
+Add `Authorization: Bearer <token>` to the request.
+
+**Expired access token:**
+
+```
+HTTP/1.1 401
+{ "success": false, "error": { "code": "AUTH_INVALID_TOKEN", "message": "Invalid or expired token" } }
+```
+
+Call `POST /api/auth/refresh` to get a new access token without prompting the user to re-authenticate.
+
+**Refresh token missing or expired:**
+
+```
+HTTP/1.1 401
+{ "success": false, "error": { "code": "AUTH_INVALID_TOKEN", "message": "Refresh token missing or expired" } }
+```
+
+The user must log in again.
+
+---
+
+## 10. Security best practices
+
+### Store credentials safely
+
+- Keep your `JWT_SECRET` and all credentials in environment variables or a secrets manager (AWS Secrets Manager, HashiCorp Vault). Never commit them to source control.
+- Do not store access tokens in `localStorage` — XSS can read it. Prefer memory (a module-level variable or React state). The `refreshToken` is already stored in an HttpOnly cookie by the API, so it is never reachable from JavaScript.
+- Treat a published secret as compromised immediately, even if the commit is reverted. Git history and CI logs may retain it.
+
+### Use separate credentials per environment
+
+Never share API credentials between development, staging, and production. Register a separate account for each environment. If a development credential is compromised, production is not affected.
+
+### Rotate credentials after a suspected compromise
+
+1. Call `DELETE /api/auth/sessions` to revoke all active sessions.
+2. Call `POST /api/auth/logout` to invalidate the current refresh token cookie.
+3. Change the account password via `POST /api/auth/password-reset`.
+4. Rotate the server-side `JWT_SECRET` in the backend environment and restart the service — this invalidates **all** existing tokens platform-wide. Coordinate with the team before doing this in production.
+
+### Implement token refresh proactively
+
+Do not wait for a 401 to refresh. Check the `exp` claim and refresh when the token has less than 60 seconds remaining. This avoids failed requests during peak traffic.
+
+### Apply least-privilege
+
+Request only the access your integration needs. Do not authenticate as an admin account for routine operations.
+
+### Never log tokens
+
+Ensure your logging infrastructure does not capture `Authorization` header values or response bodies that contain tokens. Treat tokens the same as passwords.
+
+### Enable MFA on integration accounts
+
+For accounts used by automated integrations, enabling TOTP-based MFA adds a second factor that protects against credential theft.
+
+### Use HTTPS in production
+
+All requests in production must go over HTTPS. The `refreshToken` cookie is marked `Secure` in production — it will not be sent over plain HTTP.
+
+---
+
+## Related documentation
+
+- [Security best practices for integrators](guides/security.md)
+- [Operational runbook](runbook.md) — JWT secret rotation and incident response
+- [Backend configuration reference](../backend/CONFIGURATION.md)


### PR DESCRIPTION
This PR resolves two documentation gaps that created friction for integration partners and new contributors.

---

## Issue #812 — API Authentication Guide

### Problem

FuTuRe exposes a REST API used by third-party integrators, but there was no documentation explaining how to authenticate. Partners had to contact the core team for basic credential and token management information, and developers onboarding to the API had to read through middleware source to understand the auth model.

### What was added

**New file: \`docs/api-auth.md\`**

A complete API authentication reference guide covering the full token lifecycle, sourced directly from the implementation in \`backend/src/routes/auth.js\`, \`backend/src/auth/tokens.js\`, \`backend/src/middleware/auth.js\`, and \`backend/src/middleware/errorHandler.js\`.

Sections:

- **Authentication model** — JWT HS256, access token TTL (15 min), refresh token TTL (7 days), HttpOnly cookie delivery, session-backed validation
- **Obtaining credentials** — \`POST /api/auth/register\` with validation rules, success/error response examples
- **Getting tokens** — \`POST /api/auth/login\` with full curl example, account lockout behaviour (HTTP 423), rate limits (5 req / 15 min)
- **Using the access token** — curl, \`fetch\`, and axios examples; notes on \`credentials: include\` / \`withCredentials\` requirement
- **Token lifetime and refresh** — how to decode the \`exp\` claim, \`POST /api/auth/refresh\` curl + fetch examples, a production-grade axios interceptor with request queuing for concurrent 401s
- **Session management** — list sessions, revoke one, revoke all, logout
- **Alternative auth methods** — SEP-0010 Stellar wallet challenge–response flow, Google OAuth 2.0, TOTP MFA setup
- **CSRF protection** — fetch the token, attach \`X-CSRF-Token\` header on mutating requests
- **Error reference** — table mapping every auth-related \`ErrorCodes\` value to its HTTP status, meaning, and remediation steps
- **Security best practices** — token storage, per-environment credentials, rotation procedure, proactive refresh, HTTPS requirement

**New file: \`docs/README.md\`**

A documentation index linking \`api-auth.md\`, \`guides/security.md\`, \`runbook.md\`, and \`typescript-migration.md\` so the docs directory is navigable without prior knowledge of the structure.

---

## Issue #813 — Contributing Guide: Testing Section

### Problem

\`CONTRIBUTING.md\` had a minimal list of test commands but no guidance on which framework to use for which kind of test, how to set up the test environment (especially Playwright browser binaries), how to interpret Stryker mutation scores, or what structure a well-written test should follow. This led to misplaced tests, local environment failures, low mutation scores going unnoticed, and boilerplate inconsistency.

### What was changed

**Modified: \`CONTRIBUTING.md\`**

The existing \`## Running Tests\` block was replaced with a comprehensive \`## Testing\` section. The load-test commands are preserved within the new section.

#### Quick-reference command table

A full command table at the top of the section covers every suite — unit, E2E, mutation, property, contract — so experienced contributors can find what they need without reading further.

#### Test stack overview

Explains the role of each framework and when to use it vs. the alternatives:

- **Vitest** — unit and integration tests; do not use for anything requiring a real browser
- **Playwright** — end-to-end browser tests; do not use for logic Vitest can cover
- **Stryker** — mutation testing to measure assertion quality, not just line coverage

#### Prerequisite setup

Step-by-step instructions to get all three suites running locally from scratch:

1. Node 20 + npm 10
2. \`npm install\`
3. \`docker compose up db -d\`
4. \`backend/.env\` minimum config (DATABASE_URL, JWT_SECRET, STREAM_SECRET_ENCRYPTION_KEY)
5. Playwright browser binaries: \`cd e2e && npx playwright install\`
6. k6 for load tests

#### Writing unit tests

- File location and naming conventions matching the existing codebase layout
- Arrange–Act–Assert pattern, \`beforeEach\` state isolation, when to mock
- Annotated example using the real \`backend/tests/auth.tokens.test.js\` file, with inline comments explaining each structural decision

#### Writing E2E tests

- How to run headed vs. headless
- Page object pattern with a concrete example
- \`data-testid\` selector convention
- Network mocking with \`page.route()\` to avoid live testnet dependencies
- Playwright storage state for auth setup across tests
- Annotated example using the real \`e2e/tests/onboarding.spec.js\` file
- CI-specific behaviour (retries, workers, \`forbidOnly\`)

#### Mutation testing

- How to run Stryker and where reports are written
- How to read the killed / survived / no-coverage table
- The three score thresholds (break=50, low=60, high=80) and what each means for a PR
- Concrete workflow for improving a surviving mutant

#### CI behaviour

Maps every test suite to the event that triggers it (PR, merge to main, scheduled) and gives actionable steps for each type of CI failure.

#### First-day onboarding checklist

Added to the PR Review Process section. Includes 'run the test suite locally' as an explicit day-one task with all prerequisite steps listed.

---

## Files changed

| File | Change |
|---|---|
| \`docs/api-auth.md\` | New — full API authentication reference |
| \`docs/README.md\` | New — documentation index |
| \`CONTRIBUTING.md\` | Updated — replaced minimal test commands with comprehensive Testing section and first-day onboarding checklist |

## Testing

These are documentation-only changes. No source code was modified.

All curl examples in \`docs/api-auth.md\` were verified against the route definitions in \`backend/src/routes/auth.js\` and the middleware in \`backend/src/middleware/auth.js\`. All command examples in \`CONTRIBUTING.md\` were verified against \`package.json\` scripts in the root and \`backend/\` workspace.

Closes #812 
Closes #813 