### PR TITLE
#924 Add rate limiting to contact creation and other unthrottled account-mutation endpoints

### DIFF
--- a/backend/CONFIGURATION.md
+++ b/backend/CONFIGURATION.md
@@ -92,6 +92,25 @@ Everything else has a safe default for local development.
 | `RATE_LIMIT_MESSAGE` | string | — | `"Too many requests..."` | Error message returned when rate-limited. | `"Slow down!"` |
 | `RATE_LIMIT_WHITELIST` | CSV | — | — | Comma-separated IPs/CIDR ranges exempt from rate limiting. | `127.0.0.1,10.0.0.0/8` |
 
+#### Endpoint-specific limits
+
+In addition to the global IP-based limiter, the following routes have dedicated **per-user** limiters
+(keyed on the authenticated user id, falling back to IP for unauthenticated requests):
+
+| Route | Limiter | Window | Max | Reason |
+|---|---|---|---|---|
+| `POST /api/v1/accounts/contacts` | `contactCreateLimiter` | 1 min | 20 | Write-heavy; prevents rapid contact row creation |
+| `PUT /api/v1/admin/kyc/:userId/approve` | `kycActionLimiter` | 10 min | 30 | Sensitive state mutation; limits blast radius of a compromised admin token |
+| `PUT /api/v1/admin/kyc/:userId/reject` | `kycActionLimiter` | 10 min | 30 | Sensitive state mutation; limits blast radius of a compromised admin token |
+
+#### Per-user contact cap
+
+`POST /api/v1/accounts/contacts` also enforces a hard cap of **500 contacts per user**
+(constant `MAX_CONTACTS_PER_USER` in `backend/src/routes/contacts.js`).
+A `400` response is returned once the cap is reached, regardless of rate-limit headroom.
+This prevents a slow-and-steady script from creating an unbounded number of rows within
+rate-limit rules.
+
 ### Caching
 
 | Variable | Type | Required | Default | Description | Example |

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -2,8 +2,21 @@ import express from 'express';
 import prisma from '../db/client.js';
 import { requireAdmin } from '../middleware/adminAuth.js';
 import { logAdminAction } from '../db/adminAuditLog.js';
+import { createPerUserRateLimiter } from '../middleware/rateLimiter.js';
 
 const router = express.Router();
+
+/**
+ * Dedicated per-admin rate limiter for KYC state-mutation routes.
+ * 30 requests per 10 minutes, keyed on the authenticated admin's user id.
+ * Stricter than the global limiter: a compromised admin token cannot hammer
+ * approve/reject at the same rate as a public read endpoint.
+ */
+const kycActionLimiter = createPerUserRateLimiter({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 30,
+  message: 'Too many KYC actions. Please slow down.',
+});
 
 router.get('/stats', requireAdmin, async (req, res) => {
   try {
@@ -71,7 +84,28 @@ router.get('/users', requireAdmin, async (req, res) => {
   }
 });
 
-router.put('/kyc/:userId/approve', requireAdmin, async (req, res) => {
+/**
+ * @swagger
+ * /api/v1/admin/kyc/{userId}/approve:
+ *   put:
+ *     summary: Approve a KYC record (admin only)
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: KYC approved
+ *       429:
+ *         description: Per-admin rate limit exceeded (30 req/10 min)
+ *       500:
+ *         description: Internal server error
+ */
+router.put('/kyc/:userId/approve', requireAdmin, kycActionLimiter, async (req, res) => {
   try {
     const { userId } = req.params;
     const kyc = await prisma.kYCRecord.update({
@@ -85,7 +119,28 @@ router.put('/kyc/:userId/approve', requireAdmin, async (req, res) => {
   }
 });
 
-router.put('/kyc/:userId/reject', requireAdmin, async (req, res) => {
+/**
+ * @swagger
+ * /api/v1/admin/kyc/{userId}/reject:
+ *   put:
+ *     summary: Reject a KYC record (admin only)
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: KYC rejected
+ *       429:
+ *         description: Per-admin rate limit exceeded (30 req/10 min)
+ *       500:
+ *         description: Internal server error
+ */
+router.put('/kyc/:userId/reject', requireAdmin, kycActionLimiter, async (req, res) => {
   try {
     const { userId } = req.params;
     const kyc = await prisma.kYCRecord.update({

--- a/backend/src/routes/contacts.js
+++ b/backend/src/routes/contacts.js
@@ -2,10 +2,29 @@ import express from 'express';
 import { body, param } from 'express-validator';
 import { validate } from '../middleware/validate.js';
 import { requireAuth } from '../middleware/auth.js';
+import { createPerUserRateLimiter } from '../middleware/rateLimiter.js';
 import prisma from '../db/client.js';
 import logger from '../config/logger.js';
 
 const router = express.Router();
+
+/**
+ * Maximum number of contacts a single user is allowed to store.
+ * Prevents slow-and-steady unbounded row growth that rate limiting alone
+ * cannot stop.
+ */
+export const MAX_CONTACTS_PER_USER = 500;
+
+/**
+ * Per-user rate limiter for contact creation.
+ * 20 requests per minute, keyed on the authenticated user id.
+ * Independent of the global IP-based limiter applied in server.js.
+ */
+const contactCreateLimiter = createPerUserRateLimiter({
+  windowMs: 60 * 1000, // 1 minute
+  max: 20,
+  message: 'Too many contact creation requests, please slow down.',
+});
 
 const STELLAR_PUBLIC_KEY = /^G[A-Z2-7]{55}$/;
 
@@ -29,8 +48,45 @@ router.get('/', async (req, res) => {
 });
 
 // POST /api/accounts/contacts
+/**
+ * @swagger
+ * /api/v1/accounts/contacts:
+ *   post:
+ *     summary: Create a new contact for the authenticated user
+ *     tags: [Contacts]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name, address]
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 maxLength: 64
+ *               address:
+ *                 type: string
+ *                 description: Stellar public key (G...)
+ *     responses:
+ *       201:
+ *         description: Contact created
+ *       400:
+ *         description: Contact limit reached (max 500 per user)
+ *       409:
+ *         description: Contact with this address already exists
+ *       422:
+ *         description: Validation error
+ *       429:
+ *         description: Per-user rate limit exceeded (20 req/min)
+ *       500:
+ *         description: Internal server error
+ */
 router.post(
   '/',
+  contactCreateLimiter,
   [
     body('name').trim().notEmpty().withMessage('name is required').isLength({ max: 64 }).withMessage('name too long'),
     body('address').trim().matches(STELLAR_PUBLIC_KEY).withMessage('Invalid Stellar address'),
@@ -40,6 +96,15 @@ router.post(
     try {
       const user = await prisma.user.findUnique({ where: { publicKey: req.user.publicKey } });
       if (!user) return res.status(404).json({ error: 'User not found' });
+
+      // Enforce per-user total-contacts cap before attempting the insert.
+      const contactCount = await prisma.contact.count({ where: { userId: user.id } });
+      if (contactCount >= MAX_CONTACTS_PER_USER) {
+        return res.status(400).json({
+          error: `Contact limit reached. A user may not exceed ${MAX_CONTACTS_PER_USER} contacts.`,
+        });
+      }
+
       const contact = await prisma.contact.create({
         data: { userId: user.id, name: req.body.name, address: req.body.address },
         select: { id: true, name: true, address: true, createdAt: true },

--- a/backend/tests/contacts-admin.ratelimit.test.js
+++ b/backend/tests/contacts-admin.ratelimit.test.js
@@ -1,0 +1,273 @@
+/**
+ * Rate-limiting and contact-cap tests for:
+ *   - POST /api/v1/accounts/contacts  (contacts.js)
+ *   - PUT  /api/v1/admin/kyc/:id/approve  (admin.js)
+ *   - PUT  /api/v1/admin/kyc/:id/reject   (admin.js)
+ *
+ * Each test builds a minimal Express app that wires only the middleware
+ * under test so there are no database, auth, or CSRF side effects.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createPerUserRateLimiter } from '../src/middleware/rateLimiter.js';
+import { MAX_CONTACTS_PER_USER } from '../src/routes/contacts.js';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal app that injects req.user from the X-Test-User-Id header.
+ * This mirrors the pattern used in the existing rateLimiting.test.js.
+ */
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    const userId = req.headers['x-test-user-id'];
+    if (userId) req.user = { id: userId };
+    next();
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// 1. POST /contacts — per-user rate limit
+// ---------------------------------------------------------------------------
+
+describe('POST /contacts – per-user rate limiter', () => {
+  let app;
+
+  beforeEach(() => {
+    app = makeApp();
+
+    // Reproduce the limiter from contacts.js (20 req/min, per-user)
+    const limiter = createPerUserRateLimiter({ windowMs: 60_000, max: 20 });
+    app.post('/contacts', limiter, (_req, res) => res.status(201).json({ ok: true }));
+  });
+
+  it('allows requests up to the limit', async () => {
+    for (let i = 0; i < 20; i++) {
+      const res = await request(app)
+        .post('/contacts')
+        .set('X-Test-User-Id', 'user-a');
+      expect(res.status).toBe(201);
+    }
+  });
+
+  it('returns 429 once the per-user limit is exceeded', async () => {
+    for (let i = 0; i < 20; i++) {
+      await request(app).post('/contacts').set('X-Test-User-Id', 'user-b');
+    }
+    const exceeded = await request(app)
+      .post('/contacts')
+      .set('X-Test-User-Id', 'user-b');
+    expect(exceeded.status).toBe(429);
+    expect(exceeded.body.retryAfter).toBeDefined();
+  });
+
+  it('isolates buckets: one user hitting the limit does not affect another', async () => {
+    // Exhaust limit for user-c
+    for (let i = 0; i < 20; i++) {
+      await request(app).post('/contacts').set('X-Test-User-Id', 'user-c');
+    }
+    const exceeded = await request(app)
+      .post('/contacts')
+      .set('X-Test-User-Id', 'user-c');
+    expect(exceeded.status).toBe(429);
+
+    // user-d should still be allowed
+    const other = await request(app)
+      .post('/contacts')
+      .set('X-Test-User-Id', 'user-d');
+    expect(other.status).toBe(201);
+  });
+
+  it('includes Retry-After header in the 429 response', async () => {
+    for (let i = 0; i < 20; i++) {
+      await request(app).post('/contacts').set('X-Test-User-Id', 'user-e');
+    }
+    const res = await request(app)
+      .post('/contacts')
+      .set('X-Test-User-Id', 'user-e');
+    expect(res.status).toBe(429);
+    expect(res.headers['retry-after']).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. POST /contacts — per-user contact cap (MAX_CONTACTS_PER_USER)
+// ---------------------------------------------------------------------------
+
+describe('POST /contacts – per-user contact cap', () => {
+  it('MAX_CONTACTS_PER_USER is exported and equals 500', () => {
+    expect(MAX_CONTACTS_PER_USER).toBe(500);
+  });
+
+  it('returns 400 when the user already has MAX_CONTACTS_PER_USER contacts', async () => {
+    vi.resetModules();
+
+    // Mock prisma so count returns the cap value.
+    vi.doMock('../src/db/client.js', () => ({
+      default: {
+        user: {
+          findUnique: vi.fn().mockResolvedValue({ id: 'user-cap', publicKey: 'GTEST' }),
+        },
+        contact: {
+          count: vi.fn().mockResolvedValue(MAX_CONTACTS_PER_USER),
+          create: vi.fn(),
+        },
+      },
+    }));
+
+    // Re-import the router with the mocked prisma.
+    const { default: contactsRouter } = await import('../src/routes/contacts.js');
+
+    const app = express();
+    app.use(express.json());
+    // Simulate auth middleware — contacts.js calls requireAuth via router.use
+    // so we must inject req.user before the router handles the request.
+    app.use((req, _res, next) => {
+      req.user = { publicKey: 'GTEST', id: 'user-cap' };
+      next();
+    });
+    app.use('/', contactsRouter);
+
+    const res = await request(app)
+      .post('/')
+      .send({ name: 'Alice', address: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZWM9CQJHD9QDNHXHXN' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/contact limit/i);
+
+    // prisma.contact.create should never have been called.
+    const { default: prisma } = await import('../src/db/client.js');
+    expect(prisma.contact.create).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it('proceeds with creation when the user is below the cap', async () => {
+    vi.resetModules();
+
+    const fakeSid = 'contact-id-1';
+    vi.doMock('../src/db/client.js', () => ({
+      default: {
+        user: {
+          findUnique: vi.fn().mockResolvedValue({ id: 'user-below', publicKey: 'GTEST2' }),
+        },
+        contact: {
+          count: vi.fn().mockResolvedValue(MAX_CONTACTS_PER_USER - 1),
+          create: vi.fn().mockResolvedValue({
+            id: fakeSid,
+            name: 'Bob',
+            address: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZWM9CQJHD9QDNHXHXN',
+            createdAt: new Date().toISOString(),
+          }),
+        },
+      },
+    }));
+
+    const { default: contactsRouter } = await import('../src/routes/contacts.js');
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.user = { publicKey: 'GTEST2', id: 'user-below' };
+      next();
+    });
+    app.use('/', contactsRouter);
+
+    const res = await request(app)
+      .post('/')
+      .send({ name: 'Bob', address: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZWM9CQJHD9QDNHXHXN' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.contact.id).toBe(fakeSid);
+
+    vi.restoreAllMocks();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Admin KYC routes — per-admin rate limiter
+// ---------------------------------------------------------------------------
+
+describe('Admin KYC routes – per-admin rate limiter', () => {
+  let app;
+
+  beforeEach(() => {
+    app = makeApp();
+
+    // Reproduce the admin KYC limiter (30 req/10 min, per-user)
+    const limiter = createPerUserRateLimiter({ windowMs: 10 * 60_000, max: 30 });
+
+    app.put('/kyc/:userId/approve', limiter, (_req, res) =>
+      res.json({ success: true, action: 'approve' }),
+    );
+    app.put('/kyc/:userId/reject', limiter, (_req, res) =>
+      res.json({ success: true, action: 'reject' }),
+    );
+  });
+
+  it('allows admin KYC actions up to the limit', async () => {
+    for (let i = 0; i < 30; i++) {
+      const res = await request(app)
+        .put(`/kyc/user-${i}/approve`)
+        .set('X-Test-User-Id', 'admin-1');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it('returns 429 once the per-admin KYC limit is exceeded', async () => {
+    for (let i = 0; i < 30; i++) {
+      await request(app).put(`/kyc/user-${i}/approve`).set('X-Test-User-Id', 'admin-2');
+    }
+    const exceeded = await request(app)
+      .put('/kyc/user-overflow/approve')
+      .set('X-Test-User-Id', 'admin-2');
+    expect(exceeded.status).toBe(429);
+    expect(exceeded.body.retryAfter).toBeDefined();
+  });
+
+  it('applies the same bucket across approve and reject actions', async () => {
+    // Mix of approve and reject — both draw from the same admin bucket.
+    for (let i = 0; i < 15; i++) {
+      await request(app).put(`/kyc/u${i}/approve`).set('X-Test-User-Id', 'admin-3');
+    }
+    for (let i = 0; i < 15; i++) {
+      await request(app).put(`/kyc/u${i}/reject`).set('X-Test-User-Id', 'admin-3');
+    }
+    const exceeded = await request(app)
+      .put('/kyc/u-extra/reject')
+      .set('X-Test-User-Id', 'admin-3');
+    expect(exceeded.status).toBe(429);
+  });
+
+  it('isolates admin buckets from each other', async () => {
+    // Exhaust admin-4
+    for (let i = 0; i < 30; i++) {
+      await request(app).put(`/kyc/u${i}/approve`).set('X-Test-User-Id', 'admin-4');
+    }
+    const exceeded = await request(app)
+      .put('/kyc/u-extra/approve')
+      .set('X-Test-User-Id', 'admin-4');
+    expect(exceeded.status).toBe(429);
+
+    // admin-5 should be unaffected
+    const other = await request(app)
+      .put('/kyc/u-other/approve')
+      .set('X-Test-User-Id', 'admin-5');
+    expect(other.status).toBe(200);
+  });
+
+  it('the admin KYC limit is distinct from the contacts limit', () => {
+    // Sanity-check: the two limiters use different max values.
+    // contacts: 20/min, KYC: 30/10min — different numbers, different windows.
+    const contactsMax = 20;
+    const kycMax = 30;
+    expect(kycMax).not.toBe(contactsMax);
+  });
+});


### PR DESCRIPTION
Closes #924  Add rate limiting to contact creation and other unthrottled account-mutation endpoints
- Apply createPerUserRateLimiter to POST /api/v1/accounts/contacts (20 req/min, per authenticated user id) via contactCreateLimiter
- Enforce MAX_CONTACTS_PER_USER=500 hard cap in the POST /contacts handler with a count check before the insert; returns 400 when exceeded so a slow-and-steady script cannot grow rows unboundedly
- Apply createPerUserRateLimiter to PUT /admin/kyc/:userId/approve and PUT /admin/kyc/:userId/reject (30 req/10 min) via kycActionLimiter; both routes share the same bucket so mixed approve/reject calls are counted together against one admin
- Add Swagger JSDoc annotations documenting the 429 and 400 responses on the affected routes
- Document the new limits in CONFIGURATION.md under a new Endpoint-specific limits subsection
- Add backend/tests/contacts-admin.ratelimit.test.js covering: contacts per-user rate limit triggers 429 and isolates users, contact cap returns 400 at 500 and allows creation below cap, admin KYC limit triggers 429 across approve+reject mixed calls, and admin buckets are isolated from each other