### PR TITLE
Idempotency for mutating endpoints, fix digest N+1, batch scheduled jobs, validate audit-log dates

### DIFF
--- a/backend/src/config/swagger.js
+++ b/backend/src/config/swagger.js
@@ -685,6 +685,15 @@ const options = {
           bearerFormat: 'JWT',
         },
       },
+      parameters: {
+        IdempotencyKey: {
+          name: 'Idempotency-Key',
+          in: 'header',
+          required: false,
+          description: 'Unique client-generated key (1-255 alphanumeric/hyphen characters). When provided, a repeated request with the same key returns the original cached response instead of creating a duplicate resource. Optional — requests without it are processed normally.',
+          schema: { type: 'string', example: 'a1b2c3d4-e5f6-4a1b-8c3d-4e5f6a1b2c3d' },
+        },
+      },
     },
     security: [{ bearerAuth: [] }],
   },

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,9 +1,30 @@
 import express from 'express';
+import { query, validationResult } from 'express-validator';
 import prisma from '../db/client.js';
 import { requireAdmin } from '../middleware/adminAuth.js';
 import { logAdminAction } from '../db/adminAuditLog.js';
 
 const router = express.Router();
+
+// Returns 400 (not the shared 422 `validate` middleware) to match this
+// endpoint's documented contract for malformed/reversed date filters.
+const validateAuditLogDateRange = [
+  query('from').optional().isISO8601().withMessage('from must be a valid ISO 8601 date'),
+  query('to').optional().isISO8601().withMessage('to must be a valid ISO 8601 date'),
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array().map((e) => ({ field: e.path, message: e.msg })) });
+    }
+
+    const { from, to } = req.query;
+    if (from && to && new Date(from) > new Date(to)) {
+      return res.status(400).json({ error: '`from` must not be later than `to`' });
+    }
+
+    next();
+  },
+];
 
 router.get('/stats', requireAdmin, async (req, res) => {
   try {
@@ -99,7 +120,34 @@ router.put('/kyc/:userId/reject', requireAdmin, async (req, res) => {
   }
 });
 
-router.get('/audit-log', requireAdmin, async (req, res) => {
+/**
+ * @swagger
+ * /api/admin/audit-log:
+ *   get:
+ *     summary: List admin audit log entries
+ *     tags: [Admin]
+ *     parameters:
+ *       - in: query
+ *         name: from
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: ISO 8601 timestamp — only include entries created at or after this time.
+ *       - in: query
+ *         name: to
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: ISO 8601 timestamp — only include entries created at or before this time. Must not be earlier than `from`.
+ *     responses:
+ *       200:
+ *         description: Paginated audit log entries
+ *       400:
+ *         description: Malformed `from`/`to` (not ISO 8601) or `from` later than `to`
+ *       500:
+ *         description: Server error
+ */
+router.get('/audit-log', requireAdmin, validateAuditLogDateRange, async (req, res) => {
   try {
     const { page = 1, limit = 50, adminUserId, actionType, from, to } = req.query;
     const take = Math.min(parseInt(limit), 200);

--- a/backend/src/routes/multiSig.js
+++ b/backend/src/routes/multiSig.js
@@ -3,6 +3,7 @@ import { validate, rules } from '../middleware/validate.js';
 import * as MultiSigService from '../services/multiSig.js';
 import { broadcastToAccount } from '../services/websocket.js';
 import { AppError, ErrorCodes } from '../middleware/errorHandler.js';
+import { idempotencyMiddleware } from '../middleware/idempotency.js';
 import logger from '../config/logger.js';
 
 const router = express.Router();
@@ -160,6 +161,8 @@ router.post('/account/update', rules.updateMultiSig, validate, async (req, res) 
  *     summary: Build a multi-sig transaction
  *     description: Creates an unsigned transaction XDR for signers to collect signatures on.
  *     tags: [MultiSig]
+ *     parameters:
+ *       - $ref: '#/components/parameters/IdempotencyKey'
  *     requestBody:
  *       required: true
  *       content:
@@ -182,7 +185,7 @@ router.post('/account/update', rules.updateMultiSig, validate, async (req, res) 
  *       500:
  *         description: Server error
  */
-router.post('/transaction/build', rules.buildMultiSigTx, validate, async (req, res) => {
+router.post('/transaction/build', idempotencyMiddleware, rules.buildMultiSigTx, validate, async (req, res) => {
   try {
     const { sourcePublicKey, destination, amount, assetCode } = req.body;
     const result = await MultiSigService.buildMultiSigTransaction(

--- a/backend/src/routes/pathPayment.js
+++ b/backend/src/routes/pathPayment.js
@@ -9,6 +9,7 @@ import {
   recordPathPaymentAnalytic,
 } from '../services/pathPayment.js';
 import { validate, rules } from '../middleware/validate.js';
+import { idempotencyMiddleware } from '../middleware/idempotency.js';
 import { SUPPORTED_ASSETS } from '../config/assets.js';
 
 const router = Router();
@@ -104,9 +105,27 @@ router.post(
   },
 );
 
+/**
+ * @swagger
+ * /api/path-payment/send:
+ *   post:
+ *     summary: Execute a path payment
+ *     description: Sends a cross-asset payment along a conversion path.
+ *     tags: [PathPayment]
+ *     parameters:
+ *       - $ref: '#/components/parameters/IdempotencyKey'
+ *     responses:
+ *       200:
+ *         description: Path payment result
+ *       422:
+ *         description: Validation error
+ *       500:
+ *         description: Server error
+ */
 // Execute path payment
 router.post(
   '/send',
+  idempotencyMiddleware,
   body('sourceSecret').trim().matches(STELLAR_SECRET_KEY).withMessage('Invalid Stellar secret key'),
   body('destination')
     .trim()

--- a/backend/src/routes/streaming.js
+++ b/backend/src/routes/streaming.js
@@ -3,6 +3,7 @@ import express from 'express';
 import { body, param, validationResult } from 'express-validator';
 import * as StreamingService from '../services/streaming.js';
 import logger from '../config/logger.js';
+import { idempotencyMiddleware } from '../middleware/idempotency.js';
 
 const router = express.Router();
 
@@ -45,6 +46,8 @@ const streamRules = {
  *   post:
  *     summary: Create a streaming payment
  *     tags: [Streaming]
+ *     parameters:
+ *       - $ref: '#/components/parameters/IdempotencyKey'
  *     requestBody:
  *       required: true
  *       content:
@@ -82,7 +85,7 @@ const streamRules = {
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */
-router.post('/', streamRules.create, validate, async (req, res) => {
+router.post('/', idempotencyMiddleware, streamRules.create, validate, async (req, res) => {
   try {
     const stream = await StreamingService.createStream(req.body);
     res.status(201).json(withNextPaymentAt(stream));

--- a/backend/src/services/digestGenerator.js
+++ b/backend/src/services/digestGenerator.js
@@ -3,15 +3,25 @@
  */
 import * as StellarSDK from '@stellar/stellar-sdk';
 import * as StellarService from './stellar.js';
+import { callWithCircuitBreaker } from './circuitBreaker.js';
 import prisma from '../db/client.js';
 import { sendNotification } from '../notifications/index.js';
 import logger from '../config/logger.js';
+import { runWithConcurrency } from '../utils/concurrency.js';
+import { recordCustomMetric } from '../monitoring/metrics.js';
 
 const DIGEST_LOOKBACK_DAYS = 7;
 const TOP_TRANSACTIONS_COUNT = 5;
+const MAX_PAYMENT_PAGES = 5; // Fetch up to 500 payment ops (5 pages of 100)
+const DIGEST_PAGE_SIZE = 200;
+const DIGEST_CONCURRENCY = 15;
+
+let digestRunRunning = false;
 
 /**
  * Get transaction summary for the past N days.
+ * Uses the account-scoped payments endpoint (one paginated call chain)
+ * instead of one operations() lookup per transaction.
  * @param {string} publicKey - Stellar public key
  * @param {number} days - Number of days to look back
  * @returns {Promise<object>} Transaction summary
@@ -22,12 +32,12 @@ async function getTransactionSummary(publicKey, days = DIGEST_LOOKBACK_DAYS) {
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - days);
 
-    // Fetch transactions
-    let allTransactions = [];
+    // Fetch payments directly — bounded by pagination, not transaction volume
+    let allPayments = [];
     let cursor = null;
 
-    for (let i = 0; i < 5; i++) { // Fetch up to 500 transactions (5 pages of 100)
-      const builder = server.transactions()
+    for (let i = 0; i < MAX_PAYMENT_PAGES; i++) {
+      const builder = server.payments()
         .forAccount(publicKey)
         .order('desc')
         .limit(100);
@@ -36,58 +46,52 @@ async function getTransactionSummary(publicKey, days = DIGEST_LOOKBACK_DAYS) {
         builder.cursor(cursor);
       }
 
-      const response = await builder.call();
-      allTransactions = [...allTransactions, ...response.records];
+      const response = await callWithCircuitBreaker(() => builder.call());
+      if (!response.records.length) break;
 
-      if (!response.records.length || allTransactions.length > 500) break;
+      allPayments = [...allPayments, ...response.records];
+      const oldest = response.records[response.records.length - 1];
+      cursor = oldest.paging_token;
 
-      // Get cursor for next page
-      if (response.records.length > 0) {
-        cursor = response.records[response.records.length - 1].paging_token;
-      }
+      // Stop once we've paged past the lookback window
+      if (new Date(oldest.created_at) < startDate) break;
     }
 
-    // Filter transactions within date range
-    const filteredTransactions = allTransactions.filter((tx) => {
-      const txDate = new Date(tx.created_at);
-      return txDate >= startDate;
-    });
-
-    // Analyze transactions
+    // Analyze payment operations within date range
     let totalReceived = 0;
     let totalSent = 0;
     const transactionDetails = [];
+    const seenHashes = new Set();
 
-    for (const tx of filteredTransactions) {
-      if (!tx.successful) continue;
+    for (const payment of allPayments) {
+      if (payment.type !== 'payment') continue;
+      if (payment.transaction_successful === false) continue;
 
-      // Get operations for this transaction
-      const opsResponse = await server.operations().forTransaction(tx.hash).call();
+      const paymentDate = new Date(payment.created_at);
+      if (paymentDate < startDate) continue;
 
-      for (const op of opsResponse.records) {
-        if (op.type === 'payment') {
-          const amount = parseFloat(op.amount);
+      seenHashes.add(payment.transaction_hash);
 
-          if (op.from === publicKey && op.to !== publicKey) {
-            totalSent += amount;
-          } else if (op.to === publicKey && op.from !== publicKey) {
-            totalReceived += amount;
-          }
+      const amount = parseFloat(payment.amount);
 
-          transactionDetails.push({
-            hash: tx.hash,
-            date: new Date(tx.created_at),
-            type: op.from === publicKey ? 'sent' : 'received',
-            amount,
-            counterparty: op.from === publicKey ? op.to : op.from,
-            asset: op.asset_code || 'XLM',
-          });
-        }
+      if (payment.from === publicKey && payment.to !== publicKey) {
+        totalSent += amount;
+      } else if (payment.to === publicKey && payment.from !== publicKey) {
+        totalReceived += amount;
       }
+
+      transactionDetails.push({
+        hash: payment.transaction_hash,
+        date: paymentDate,
+        type: payment.from === publicKey ? 'sent' : 'received',
+        amount,
+        counterparty: payment.from === publicKey ? payment.to : payment.from,
+        asset: payment.asset_code || 'XLM',
+      });
     }
 
     // Get current balance
-    const account = await server.loadAccount(publicKey);
+    const account = await callWithCircuitBreaker(() => server.loadAccount(publicKey));
     let balance = 0;
     for (const bal of account.balances) {
       if (!bal.asset_code || bal.asset_code === 'XLM') {
@@ -102,7 +106,7 @@ async function getTransactionSummary(publicKey, days = DIGEST_LOOKBACK_DAYS) {
       .slice(0, TOP_TRANSACTIONS_COUNT);
 
     return {
-      transactionCount: filteredTransactions.length,
+      transactionCount: seenHashes.size,
       totalSent: totalSent.toFixed(7),
       totalReceived: totalReceived.toFixed(7),
       balance: balance.toFixed(7),
@@ -177,46 +181,74 @@ export async function sendWeeklyDigest(userId) {
 
 /**
  * Send digests to all users with digest enabled at their scheduled time.
- * Called by scheduled job.
+ * Called by scheduled job. Users are paged through in bounded batches and
+ * sent with bounded concurrency, rather than loading everyone into memory
+ * and processing sequentially.
  * @returns {Promise<object>} Summary of digests sent
  */
 export async function sendScheduledDigests() {
+  if (digestRunRunning) {
+    logger.warn('digestGenerator.scheduledRunSkipped', { reason: 'already_running' });
+    return { sent: 0, failed: 0, skipped: true };
+  }
+
+  digestRunRunning = true;
+  const startedAt = Date.now();
+
   try {
     // Get current day of week (0 = Sunday)
     const currentDay = new Date().getUTCDay();
     const currentHour = new Date().getUTCHours();
 
-    // Find all users with digest enabled for this day and time (within a 1-hour window)
-    const users = await prisma.notificationPreference.findMany({
-      where: {
-        weeklyDigestEnabled: true,
-        weeklyDigestDay: currentDay,
-      },
-      select: {
-        userId: true,
-        weeklyDigestTime: true,
-      },
-    });
-
     let sent = 0;
     let failed = 0;
+    let cursor = null;
 
-    for (const userPref of users) {
-      // Check if current hour matches scheduled time (with 1-hour tolerance)
-      if (Math.abs(currentHour - userPref.weeklyDigestTime) <= 1) {
-        const success = await sendWeeklyDigest(userPref.userId);
-        if (success) {
-          sent++;
-        } else {
-          failed++;
-        }
-      }
+    for (;;) {
+      // Find users with digest enabled for this day (within a 1-hour window of their time)
+      const page = await prisma.notificationPreference.findMany({
+        where: {
+          weeklyDigestEnabled: true,
+          weeklyDigestDay: currentDay,
+        },
+        select: { id: true, userId: true, weeklyDigestTime: true },
+        orderBy: { id: 'asc' },
+        take: DIGEST_PAGE_SIZE,
+        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+      });
+
+      if (page.length === 0) break;
+
+      const dueUsers = page.filter((userPref) => Math.abs(currentHour - userPref.weeklyDigestTime) <= 1);
+
+      await runWithConcurrency(
+        dueUsers,
+        async (userPref) => {
+          const success = await sendWeeklyDigest(userPref.userId);
+          if (success) {
+            sent++;
+          } else {
+            failed++;
+          }
+        },
+        DIGEST_CONCURRENCY,
+      );
+
+      cursor = page[page.length - 1].id;
+      if (page.length < DIGEST_PAGE_SIZE) break;
     }
 
-    logger.info('digestGenerator.scheduledRun', { sent, failed, currentDay, currentHour });
+    const durationMs = Date.now() - startedAt;
+    recordCustomMetric('digestGenerator.job_duration_ms', durationMs, 'ms');
+    recordCustomMetric('digestGenerator.sent', sent, 'count');
+    recordCustomMetric('digestGenerator.failed', failed, 'count');
+
+    logger.info('digestGenerator.scheduledRun', { sent, failed, currentDay, currentHour, durationMs });
     return { sent, failed };
   } catch (error) {
     logger.error('digestGenerator.scheduledRunFailed', { error: error.message });
     return { sent: 0, failed: 0 };
+  } finally {
+    digestRunRunning = false;
   }
 }

--- a/backend/src/services/lowBalanceMonitor.js
+++ b/backend/src/services/lowBalanceMonitor.js
@@ -5,8 +5,14 @@ import * as StellarService from './stellar.js';
 import prisma from '../db/client.js';
 import { sendNotification } from '../notifications/index.js';
 import logger from '../config/logger.js';
+import { runWithConcurrency } from '../utils/concurrency.js';
+import { recordCustomMetric } from '../monitoring/metrics.js';
 
 const ALERT_RECHECK_INTERVAL_HOURS = 24; // Re-alert every 24 hours if still below threshold
+const BALANCE_CHECK_PAGE_SIZE = 200;
+const BALANCE_CHECK_CONCURRENCY = 15;
+
+let balanceCheckRunning = false;
 
 /**
  * Check if a balance alert should be sent based on suppression rules.
@@ -128,35 +134,69 @@ export async function checkAndAlertBalance(userId) {
 
 /**
  * Check balances for all users with low balance alerts enabled.
- * Called by scheduled job.
+ * Called by scheduled job. Users are paged through in bounded batches and
+ * checked with bounded concurrency, rather than loading everyone into
+ * memory and processing sequentially.
  * @returns {Promise<object>} Summary of alerts sent
  */
 export async function checkAllUserBalances() {
-  try {
-    // Get all users with low balance alerts enabled
-    const usersWithAlerts = await prisma.notificationPreference.findMany({
-      where: { lowBalanceAlertEnabled: true },
-      select: { userId: true },
-    });
+  if (balanceCheckRunning) {
+    logger.warn('lowBalanceMonitor.batchCheckSkipped', { reason: 'already_running' });
+    return { alertsSent: 0, checksFailed: 0, usersChecked: 0, skipped: true };
+  }
 
+  balanceCheckRunning = true;
+  const startedAt = Date.now();
+
+  try {
     let alertsSent = 0;
     let checksFailed = 0;
+    let usersChecked = 0;
+    let cursor = null;
 
-    for (const userPref of usersWithAlerts) {
-      try {
-        const sent = await checkAndAlertBalance(userPref.userId);
-        if (sent) alertsSent++;
-      } catch (error) {
-        checksFailed++;
-        logger.error('lowBalanceMonitor.checkFailed', { userId: userPref.userId, error: error.message });
-      }
+    for (;;) {
+      const page = await prisma.notificationPreference.findMany({
+        where: { lowBalanceAlertEnabled: true },
+        select: { id: true, userId: true },
+        orderBy: { id: 'asc' },
+        take: BALANCE_CHECK_PAGE_SIZE,
+        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+      });
+
+      if (page.length === 0) break;
+
+      await runWithConcurrency(
+        page,
+        async (userPref) => {
+          try {
+            const sent = await checkAndAlertBalance(userPref.userId);
+            if (sent) alertsSent++;
+          } catch (error) {
+            checksFailed++;
+            logger.error('lowBalanceMonitor.checkFailed', { userId: userPref.userId, error: error.message });
+          }
+        },
+        BALANCE_CHECK_CONCURRENCY,
+      );
+
+      usersChecked += page.length;
+      cursor = page[page.length - 1].id;
+
+      if (page.length < BALANCE_CHECK_PAGE_SIZE) break;
     }
 
-    logger.info('lowBalanceMonitor.batchCheck', { alertsSent, checksFailed, usersChecked: usersWithAlerts.length });
-    return { alertsSent, checksFailed, usersChecked: usersWithAlerts.length };
+    const durationMs = Date.now() - startedAt;
+    recordCustomMetric('lowBalanceMonitor.job_duration_ms', durationMs, 'ms');
+    recordCustomMetric('lowBalanceMonitor.users_checked', usersChecked, 'count');
+    recordCustomMetric('lowBalanceMonitor.checks_failed', checksFailed, 'count');
+
+    logger.info('lowBalanceMonitor.batchCheck', { alertsSent, checksFailed, usersChecked, durationMs });
+    return { alertsSent, checksFailed, usersChecked };
   } catch (error) {
     logger.error('lowBalanceMonitor.batchCheckFailed', { error: error.message });
     return { alertsSent: 0, checksFailed: 0, usersChecked: 0 };
+  } finally {
+    balanceCheckRunning = false;
   }
 }
 

--- a/backend/src/utils/concurrency.js
+++ b/backend/src/utils/concurrency.js
@@ -1,0 +1,21 @@
+/**
+ * Run an async worker over a list of items with a bounded number of
+ * in-flight operations at any time, instead of one-at-a-time or unbounded.
+ * @param {Array<T>} items
+ * @param {(item: T) => Promise<void>} worker
+ * @param {number} limit - max concurrent workers
+ * @returns {Promise<void>}
+ */
+export async function runWithConcurrency(items, worker, limit) {
+  let cursor = 0;
+
+  async function runNext() {
+    while (cursor < items.length) {
+      const index = cursor++;
+      await worker(items[index]);
+    }
+  }
+
+  const poolSize = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: poolSize }, runNext));
+}


### PR DESCRIPTION
Closes #918 closes #919 closes #920  closes #921

## Summary
- **#918** — Integrate `idempotencyMiddleware` into stream creation (`streaming.js`), path payments (`pathPayment.js`), and multi-sig transaction builds (`multiSig.js`); document the `Idempotency-Key` header as a shared Swagger component parameter.
- **#919** — Replace the per-transaction `operations().forTransaction()` N+1 calls in `digestGenerator.js`'s `getTransactionSummary()` with a single paginated `payments().forAccount()` call chain, routed through the existing Horizon circuit breaker.
- **#920** — Page users through `checkAllUserBalances()` and `sendScheduledDigests()` in bounded batches (cursor pagination) with bounded concurrency instead of unbounded sequential processing; record job duration/success/failure metrics via the existing metrics collector; guard both jobs against overlapping runs.
- **#921** — Validate `from`/`to` query params on `GET /api/admin/audit-log` as ISO 8601 via `express-validator`, reject `from > to`, and document the params in Swagger.

Tests intentionally omitted per request.

