### PR TITLE
Fix issues #926, #927, #928, #929: webhook dead-letter tracking, design-token colors, SendPaymentPage i18n + AmountInput reuse

### DIFF
--- a/backend/prisma/migrations/20260727000000_add_webhook_delivery/migration.sql
+++ b/backend/prisma/migrations/20260727000000_add_webhook_delivery/migration.sql
@@ -1,0 +1,30 @@
+-- CreateEnum
+CREATE TYPE "WebhookDeliveryStatus" AS ENUM ('PENDING', 'DELIVERED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "WebhookDelivery" (
+    "id" TEXT NOT NULL,
+    "webhookId" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "attempt" INTEGER NOT NULL DEFAULT 0,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 3,
+    "status" "WebhookDeliveryStatus" NOT NULL DEFAULT 'PENDING',
+    "lastError" TEXT,
+    "nextAttemptAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deliveredAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WebhookDelivery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_webhookId_createdAt_idx" ON "WebhookDelivery"("webhookId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_accountId_createdAt_idx" ON "WebhookDelivery"("accountId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_status_nextAttemptAt_idx" ON "WebhookDelivery"("status", "nextAttemptAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -336,3 +336,32 @@ model AdminAuditLog {
   @@index([actionType])
   @@index([createdAt])
 }
+
+enum WebhookDeliveryStatus {
+  PENDING
+  DELIVERED
+  FAILED
+}
+
+// Durable record of every dispatched webhook event, one row per attempt cycle.
+// Replaces the previous fire-and-forget setTimeout retry loop so pending
+// retries survive process restarts and account owners can query failures.
+model WebhookDelivery {
+  id            String                @id @default(uuid())
+  webhookId     String
+  accountId     String
+  eventType     String
+  payload       Json
+  attempt       Int                   @default(0)
+  maxAttempts   Int                   @default(3)
+  status        WebhookDeliveryStatus @default(PENDING)
+  lastError     String?
+  nextAttemptAt DateTime              @default(now())
+  deliveredAt   DateTime?
+  createdAt     DateTime              @default(now())
+  updatedAt     DateTime              @updatedAt
+
+  @@index([webhookId, createdAt])
+  @@index([accountId, createdAt])
+  @@index([status, nextAttemptAt])
+}

--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -1,7 +1,8 @@
 import express from 'express';
 import { requireAuth } from '../middleware/auth.js';
-import { registerWebhook, listWebhooks, deleteWebhook, rotateWebhookSecret, verifyWebhookSignature } from '../webhooks/store.js';
+import { registerWebhook, listWebhooks, deleteWebhook, rotateWebhookSecret, verifyWebhookSignature, getWebhook } from '../webhooks/store.js';
 import { webhookSignatureMiddleware } from '../webhooks/verifySignature.js';
+import prisma from '../db/client.js';
 import logger from '../config/logger.js';
 
 const router = express.Router();
@@ -147,6 +148,75 @@ router.post('/:id/rotate-secret', requireAuth, (req, res) => {
     }
     logger.error({ err }, 'Failed to rotate webhook secret');
     res.status(500).json({ error: 'Failed to rotate webhook secret' });
+  }
+});
+
+/**
+ * @swagger
+ * /api/v1/webhooks/{id}/deliveries:
+ *   get:
+ *     summary: Get paginated delivery history for a webhook, including permanently failed (dead-letter) deliveries
+ *     tags: [Webhooks]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [PENDING, DELIVERED, FAILED]
+ *     responses:
+ *       200:
+ *         description: Paginated delivery history
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Webhook not found
+ */
+router.get('/:id/deliveries', requireAuth, async (req, res) => {
+  try {
+    const webhook = getWebhook(req.params.id);
+    if (!webhook || webhook.accountId !== req.user.sub) {
+      return res.status(404).json({ error: 'Webhook not found' });
+    }
+
+    const { page = 1, status } = req.query;
+    const take = Math.min(parseInt(req.query.limit) || 20, 100);
+    const skip = (parseInt(page) - 1) * take;
+
+    const where = { webhookId: webhook.id };
+    if (status) where.status = status;
+
+    const [deliveries, total] = await Promise.all([
+      prisma.webhookDelivery.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { createdAt: 'desc' },
+      }),
+      prisma.webhookDelivery.count({ where }),
+    ]);
+
+    res.json({
+      deliveries,
+      pagination: { page: parseInt(page), limit: take, total, pages: Math.ceil(total / take) },
+    });
+  } catch (err) {
+    logger.error({ err }, 'Failed to load webhook deliveries');
+    res.status(500).json({ error: 'Failed to load webhook deliveries' });
   }
 });
 

--- a/backend/src/scheduler.js
+++ b/backend/src/scheduler.js
@@ -4,6 +4,7 @@ import { expireStaleTransactions } from './services/multiSig.js';
 import { startScheduler as startBackupScheduler } from './backup/manager.js';
 import { sendScheduledDigests } from './services/digestGenerator.js';
 import { checkAllUserBalances } from './services/lowBalanceMonitor.js';
+import { processDueWebhookDeliveries } from './webhooks/dispatcher.js';
 
 let intervals = [];
 
@@ -30,6 +31,18 @@ export async function startScheduler() {
     }
   }, 60 * 1000);
   intervals.push(multiSigInterval);
+
+  // Webhook delivery retry worker - check every 10 seconds so pending
+  // retries survive a process restart instead of living in a setTimeout.
+  const webhookDeliveryInterval = setInterval(async () => {
+    try {
+      const count = await processDueWebhookDeliveries();
+      if (count > 0) logger.info('scheduler.webhookDelivery.processed', { count });
+    } catch (err) {
+      logger.error('scheduler.webhookDelivery.failed', { error: err.message });
+    }
+  }, 10 * 1000);
+  intervals.push(webhookDeliveryInterval);
 
   // Backup scheduler
   try {

--- a/backend/src/webhooks/dispatcher.js
+++ b/backend/src/webhooks/dispatcher.js
@@ -1,11 +1,11 @@
-import { getWebhooksForAccount, signPayload } from './store.js';
+import { getWebhook, getWebhooksForAccount, signPayload } from './store.js';
+import prisma from '../db/client.js';
 import logger from '../config/logger.js';
 
 const MAX_RETRIES = 3;
-const RETRY_DELAYS = [1000, 5000, 15000]; // ms
+const RETRY_DELAYS = [1000, 5000, 15000]; // ms, indexed by attempt number (0-based)
 
-async function deliverOnce(webhook, event) {
-  const payload = { webhookId: webhook.id, event, timestamp: Date.now() };
+async function deliverOnce(webhook, payload) {
   const signature = signPayload(webhook.signingSecret, payload);
 
   const res = await fetch(webhook.url, {
@@ -22,22 +22,98 @@ async function deliverOnce(webhook, event) {
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
 }
 
-async function deliverWithRetry(webhook, event, attempt = 0) {
+/**
+ * Attempt delivery for a single WebhookDelivery row and persist the outcome.
+ * On success the row is marked DELIVERED. On failure it is either rescheduled
+ * (status stays PENDING with a bumped nextAttemptAt) or marked FAILED once
+ * maxAttempts is exhausted — the dead-letter state callers can query.
+ */
+async function attemptDelivery(delivery) {
+  const webhook = getWebhook(delivery.webhookId);
+  if (!webhook || webhook.accountId !== delivery.accountId) {
+    return prisma.webhookDelivery.update({
+      where: { id: delivery.id },
+      data: { status: 'FAILED', lastError: 'Webhook no longer registered' },
+    });
+  }
+
+  const payload = { webhookId: webhook.id, event: { type: delivery.eventType, accountId: delivery.accountId, data: delivery.payload }, timestamp: Date.now() };
+
   try {
-    await deliverOnce(webhook, event);
+    await deliverOnce(webhook, payload);
+    return prisma.webhookDelivery.update({
+      where: { id: delivery.id },
+      data: { status: 'DELIVERED', attempt: delivery.attempt + 1, deliveredAt: new Date(), lastError: null },
+    });
   } catch (err) {
-    if (attempt < MAX_RETRIES - 1) {
-      setTimeout(() => deliverWithRetry(webhook, event, attempt + 1), RETRY_DELAYS[attempt]);
-    } else {
-      logger.error({ webhookId: webhook.id, error: err.message }, `Webhook delivery failed after ${MAX_RETRIES} attempts`);
+    const attempt = delivery.attempt + 1;
+    if (attempt < delivery.maxAttempts) {
+      const delay = RETRY_DELAYS[Math.min(attempt - 1, RETRY_DELAYS.length - 1)];
+      return prisma.webhookDelivery.update({
+        where: { id: delivery.id },
+        data: { attempt, lastError: err.message, nextAttemptAt: new Date(Date.now() + delay) },
+      });
     }
+
+    logger.error({ webhookId: webhook.id, error: err.message }, `Webhook delivery failed after ${attempt} attempts`);
+    return prisma.webhookDelivery.update({
+      where: { id: delivery.id },
+      data: { status: 'FAILED', attempt, lastError: err.message },
+    });
   }
 }
 
-export function dispatchEvent(accountId, eventType, data) {
-  const hooks = getWebhooksForAccount(accountId).filter(
-    w => w.events.includes('*') || w.events.includes(eventType)
-  );
-  const event = { type: eventType, accountId, data };
-  hooks.forEach(w => deliverWithRetry(w, event));
+/**
+ * Dispatch an event to every webhook registered for the account. Creates a
+ * durable WebhookDelivery row per matching webhook (so the attempt survives a
+ * restart) and makes the first delivery attempt immediately.
+ */
+export async function dispatchEvent(accountId, eventType, data) {
+  try {
+    const hooks = getWebhooksForAccount(accountId).filter(
+      w => w.events.includes('*') || w.events.includes(eventType)
+    );
+    if (!hooks.length) return [];
+
+    const deliveries = await Promise.all(hooks.map(w => prisma.webhookDelivery.create({
+      data: {
+        webhookId: w.id,
+        accountId,
+        eventType,
+        payload: data,
+        maxAttempts: MAX_RETRIES,
+      },
+    })));
+
+    await Promise.all(deliveries.map(d => attemptDelivery(d).catch(err => {
+      logger.error({ webhookId: d.webhookId, error: err.message }, 'Webhook delivery attempt threw');
+    })));
+
+    return deliveries;
+  } catch (err) {
+    logger.error({ accountId, eventType, error: err.message }, 'dispatchEvent failed');
+    return [];
+  }
+}
+
+/**
+ * Scheduler tick: find every delivery that is due for a retry and attempt it.
+ * Replaces the previous in-process setTimeout chain so pending retries are
+ * durable across restarts.
+ */
+export async function processDueWebhookDeliveries() {
+  const due = await prisma.webhookDelivery.findMany({
+    where: { status: 'PENDING', nextAttemptAt: { lte: new Date() } },
+    take: 100,
+  });
+
+  for (const delivery of due) {
+    try {
+      await attemptDelivery(delivery);
+    } catch (err) {
+      logger.error({ deliveryId: delivery.id, error: err.message }, 'Webhook delivery retry threw');
+    }
+  }
+
+  return due.length;
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -61,6 +61,13 @@ export default [
       'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       'no-console': 'warn',
       'react/prop-types': 'off',
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: "Literal[value=/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/]",
+          message: 'Avoid hardcoded hex colors — use a design token from src/design-system/tokens.js or a CSS custom property (var(--token)) instead.',
+        },
+      ],
     },
   },
   prettier,

--- a/frontend/src/components/AutoComplete.jsx
+++ b/frontend/src/components/AutoComplete.jsx
@@ -63,7 +63,7 @@ export function AutoComplete({ value, onChange, suggestions = [], placeholder, o
                 role="option"
                 aria-selected={i === activeIdx}
                 onMouseDown={() => pick(item)}
-                style={{ ...itemStyle, background: i === activeIdx ? '#e8f0fe' : 'white' }}
+                style={{ ...itemStyle, background: i === activeIdx ? 'var(--card)' : 'var(--surface)' }}
               >
                 {item}
               </li>
@@ -77,10 +77,10 @@ export function AutoComplete({ value, onChange, suggestions = [], placeholder, o
 
 const dropdownStyle = {
   position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 100,
-  background: 'white', border: '1px solid #ddd', borderRadius: 4,
-  boxShadow: '0 4px 12px rgba(0,0,0,0.1)', listStyle: 'none',
+  background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 4,
+  boxShadow: 'var(--shadow)', listStyle: 'none',
   maxHeight: 200, overflowY: 'auto', margin: 0, padding: 0,
 };
 const itemStyle = {
-  padding: '8px 12px', cursor: 'pointer', fontSize: 14,
+  padding: '8px 12px', cursor: 'pointer', fontSize: 14, color: 'var(--text)',
 };

--- a/frontend/src/components/DatePicker.jsx
+++ b/frontend/src/components/DatePicker.jsx
@@ -41,7 +41,7 @@ export function DatePicker({ from, to, onChange }) {
         <button
           type="button"
           onClick={clear}
-          style={{ alignSelf: 'flex-end', background: 'none', color: '#888', border: '1px solid #ddd', borderRadius: 4, padding: '8px 10px', fontSize: 12, cursor: 'pointer', width: 'auto', minHeight: 'unset', minWidth: 'unset' }}
+          style={{ alignSelf: 'flex-end', background: 'none', color: 'var(--muted)', border: '1px solid var(--border)', borderRadius: 4, padding: '8px 10px', fontSize: 12, cursor: 'pointer', width: 'auto', minHeight: 'unset', minWidth: 'unset' }}
           aria-label={t('datePicker.clearDates')}
         >
           {t('datePicker.clear')}
@@ -51,5 +51,5 @@ export function DatePicker({ from, to, onChange }) {
   );
 }
 
-const labelStyle = { fontSize: 12, color: '#555', fontWeight: 600 };
-const inputStyle = { border: '1px solid #ddd', borderRadius: 4, padding: '8px 10px', fontSize: 14, minHeight: 44 };
+const labelStyle = { fontSize: 12, color: 'var(--muted)', fontWeight: 600 };
+const inputStyle = { border: '1px solid var(--border)', borderRadius: 4, padding: '8px 10px', fontSize: 14, minHeight: 44, background: 'var(--surface)', color: 'var(--text)' };

--- a/frontend/src/components/FormWizard.jsx
+++ b/frontend/src/components/FormWizard.jsx
@@ -41,10 +41,10 @@ export function FormWizard({ steps = [], onComplete }) {
           <div key={i} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
             <div style={{
               width: '100%', height: 4, borderRadius: 2,
-              background: i <= current ? '#0066cc' : '#e5e7eb',
+              background: i <= current ? 'var(--primary)' : 'var(--border)',
               transition: 'background 0.3s',
             }} />
-            <span style={{ fontSize: 11, color: i === current ? '#0066cc' : '#888', fontWeight: i === current ? 700 : 400 }}>
+            <span style={{ fontSize: 11, color: i === current ? 'var(--primary)' : 'var(--muted)', fontWeight: i === current ? 700 : 400 }}>
               {s.title}
             </span>
           </div>
@@ -85,7 +85,7 @@ export function FormWizard({ steps = [], onComplete }) {
 }
 
 const backBtnStyle = {
-  background: 'white', color: '#0066cc', border: '1px solid #0066cc',
+  background: 'var(--surface)', color: 'var(--primary)', border: '1px solid var(--primary)',
   borderRadius: 4, padding: '10px 16px', fontSize: 14, cursor: 'pointer',
   width: 'auto', minHeight: 44,
 };

--- a/frontend/src/components/MultiSigTransactions.jsx
+++ b/frontend/src/components/MultiSigTransactions.jsx
@@ -7,16 +7,16 @@ import { Spinner } from './Spinner';
 import { StatusMessage } from './StatusMessage';
 
 const STATUS_BADGE = {
-  PENDING:   { label: 'Pending', color: '#f59e0b' },
-  SUBMITTED: { label: 'Submitted', color: '#22c55e' },
-  FAILED:    { label: 'Failed', color: '#ef4444' },
-  EXPIRED:   { label: 'Expired', color: '#6b7280' },
+  PENDING:   { label: 'Pending', color: 'var(--warning)' },
+  SUBMITTED: { label: 'Submitted', color: 'var(--success)' },
+  FAILED:    { label: 'Failed', color: 'var(--danger)' },
+  EXPIRED:   { label: 'Expired', color: 'var(--muted)' },
 };
 
 function StatusBadge({ status }) {
-  const badge = STATUS_BADGE[status] ?? { label: status, color: '#6b7280' };
+  const badge = STATUS_BADGE[status] ?? { label: status, color: 'var(--muted)' };
   return (
-    <span style={{ background: badge.color, color: '#fff', borderRadius: 4, padding: '2px 8px', fontSize: '0.75rem', fontWeight: 600 }}>
+    <span style={{ background: badge.color, color: 'var(--on-primary)', borderRadius: 4, padding: '2px 8px', fontSize: '0.75rem', fontWeight: 600 }}>
       {badge.label}
     </span>
   );
@@ -176,7 +176,7 @@ export function MultiSigTransactions({ publicKey }) {
       {error && <StatusMessage type="error" message={error} />}
       {success && <StatusMessage type="success" message={success} />}
 
-      <div style={{ display: 'flex', gap: 8, marginBottom: 16, borderBottom: '1px solid #e5e7eb' }}>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 16, borderBottom: '1px solid var(--border)' }}>
         {['setup', 'build', 'sign', 'pending'].map((tab) => (
           <button
             key={tab}
@@ -185,9 +185,9 @@ export function MultiSigTransactions({ publicKey }) {
             style={{
               padding: '8px 12px',
               border: 'none',
-              background: activeTab === tab ? '#2563eb' : 'transparent',
-              color: activeTab === tab ? '#fff' : '#666',
-              borderBottom: activeTab === tab ? '2px solid #2563eb' : 'none',
+              background: activeTab === tab ? 'var(--primary)' : 'transparent',
+              color: activeTab === tab ? 'var(--on-primary)' : 'var(--muted)',
+              borderBottom: activeTab === tab ? '2px solid var(--primary)' : 'none',
               cursor: 'pointer',
               fontWeight: 500,
               fontSize: '0.9rem',
@@ -207,7 +207,7 @@ export function MultiSigTransactions({ publicKey }) {
                 placeholder="S..."
                 value={setupForm.sourceSecret}
                 onChange={(e) => setSetupForm({ ...setupForm, sourceSecret: e.target.value })}
-                style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
                 autoComplete="off"
               />
             </FormField>
@@ -217,7 +217,7 @@ export function MultiSigTransactions({ publicKey }) {
                 placeholder="GBRPYHIL2CI3..."
                 value={setupForm.signerPublicKey}
                 onChange={(e) => setSetupForm({ ...setupForm, signerPublicKey: e.target.value })}
-                style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
               />
             </FormField>
             <FormField label="Signer Weight" required>
@@ -227,7 +227,7 @@ export function MultiSigTransactions({ publicKey }) {
                 max="255"
                 value={setupForm.signerWeight}
                 onChange={(e) => setSetupForm({ ...setupForm, signerWeight: e.target.value })}
-                style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
               />
             </FormField>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}>
@@ -238,7 +238,7 @@ export function MultiSigTransactions({ publicKey }) {
                   max="255"
                   value={setupForm.lowThreshold}
                   onChange={(e) => setSetupForm({ ...setupForm, lowThreshold: e.target.value })}
-                  style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                  style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
                 />
               </FormField>
               <FormField label="Medium Threshold" required>
@@ -248,7 +248,7 @@ export function MultiSigTransactions({ publicKey }) {
                   max="255"
                   value={setupForm.medThreshold}
                   onChange={(e) => setSetupForm({ ...setupForm, medThreshold: e.target.value })}
-                  style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                  style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
                 />
               </FormField>
               <FormField label="High Threshold" required>
@@ -258,11 +258,11 @@ export function MultiSigTransactions({ publicKey }) {
                   max="255"
                   value={setupForm.highThreshold}
                   onChange={(e) => setSetupForm({ ...setupForm, highThreshold: e.target.value })}
-                  style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                  style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
                 />
               </FormField>
             </div>
-            <button type="submit" disabled={loading} style={{ padding: 10, background: '#2563eb', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer' }}>
+            <button type="submit" disabled={loading} style={{ padding: 10, background: 'var(--primary)', color: 'var(--on-primary)', border: 'none', borderRadius: 4, cursor: 'pointer' }}>
               {loading ? <Spinner /> : 'Create Multi-Sig Account'}
             </button>
           </form>
@@ -276,7 +276,7 @@ export function MultiSigTransactions({ publicKey }) {
                 placeholder="GBRPYHIL2CI3..."
                 value={buildForm.destination}
                 onChange={(e) => setBuildForm({ ...buildForm, destination: e.target.value })}
-                style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
               />
             </FormField>
             <FormField label="Amount (XLM)" required>
@@ -286,32 +286,32 @@ export function MultiSigTransactions({ publicKey }) {
                 min="0"
                 value={buildForm.amount}
                 onChange={(e) => setBuildForm({ ...buildForm, amount: e.target.value })}
-                style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
               />
             </FormField>
             <FormField label="Asset Code">
               <select
                 value={buildForm.assetCode}
                 onChange={(e) => setBuildForm({ ...buildForm, assetCode: e.target.value })}
-                style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
               >
                 <option value="XLM">XLM</option>
                 <option value="USDC">USDC</option>
               </select>
             </FormField>
             {builtTx && (
-              <div style={{ padding: 12, background: '#f0f9ff', border: '1px solid #bfdbfe', borderRadius: 4 }}>
+              <div style={{ padding: 12, background: 'var(--surface)', border: '1px solid var(--info)', borderRadius: 4 }}>
                 <p style={{ fontSize: '0.875rem', margin: '0 0 8px 0' }}><strong>{t('multiSig.transactionIdLabel')}</strong> <code>{builtTx.txId}</code></p>
                 <button
                   type="button"
                   onClick={() => navigator.clipboard.writeText(builtTx.txId)}
-                  style={{ fontSize: '0.75rem', padding: '4px 8px', background: '#3b82f6', color: '#fff', border: 'none', borderRadius: 3, cursor: 'pointer' }}
+                  style={{ fontSize: '0.75rem', padding: '4px 8px', background: 'var(--primary)', color: 'var(--on-primary)', border: 'none', borderRadius: 3, cursor: 'pointer' }}
                 >
                   {t('multiSig.copyTxId')}
                 </button>
               </div>
             )}
-            <button type="submit" disabled={loading} style={{ padding: 10, background: '#2563eb', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer' }}>
+            <button type="submit" disabled={loading} style={{ padding: 10, background: 'var(--primary)', color: 'var(--on-primary)', border: 'none', borderRadius: 4, cursor: 'pointer' }}>
               {loading ? <Spinner /> : 'Build Transaction'}
             </button>
           </form>
@@ -325,7 +325,7 @@ export function MultiSigTransactions({ publicKey }) {
                 placeholder="multisig-..."
                 value={signForm.txId}
                 onChange={(e) => setSignForm({ ...signForm, txId: e.target.value })}
-                style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
               />
             </FormField>
             <FormField label="Your Secret Key" required>
@@ -334,10 +334,10 @@ export function MultiSigTransactions({ publicKey }) {
                 placeholder="S..."
                 value={signForm.signerSecret}
                 onChange={(e) => setSignForm({ ...signForm, signerSecret: e.target.value })}
-                style={{ width: '100%', padding: 8, border: '1px solid #ccc', borderRadius: 4 }}
+                style={{ width: '100%', padding: 8, border: '1px solid var(--border)', borderRadius: 4 }}
               />
             </FormField>
-            <button type="submit" disabled={signLoading} style={{ padding: 10, background: '#2563eb', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer' }}>
+            <button type="submit" disabled={signLoading} style={{ padding: 10, background: 'var(--primary)', color: 'var(--on-primary)', border: 'none', borderRadius: 4, cursor: 'pointer' }}>
               {signLoading ? <Spinner /> : 'Sign Transaction'}
             </button>
           </form>
@@ -348,24 +348,24 @@ export function MultiSigTransactions({ publicKey }) {
             {pendingLoading ? (
               <Spinner />
             ) : pendingTxs.length === 0 ? (
-              <p style={{ color: '#999' }}>{t('multiSig.noPendingTransactions')}</p>
+              <p style={{ color: 'var(--muted)' }}>{t('multiSig.noPendingTransactions')}</p>
             ) : (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                 {pendingTxs.map((tx) => (
-                  <div key={tx.txId} style={{ padding: 12, border: '1px solid #e5e7eb', borderRadius: 4 }}>
+                  <div key={tx.txId} style={{ padding: 12, border: '1px solid var(--border)', borderRadius: 4 }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
                       <span style={{ fontSize: '0.875rem', fontWeight: 600 }}>→ {tx.destination.slice(0, 12)}...</span>
                       <StatusBadge status={tx.status} />
                     </div>
                     <p style={{ margin: '4px 0', fontSize: '0.875rem' }}><strong>{t('multiSig.amountLabel')}</strong> {tx.amount} {tx.assetCode}</p>
                     <p style={{ margin: '4px 0', fontSize: '0.875rem' }}><strong>{t('multiSig.signaturesLabel')}</strong> {tx.signatures.length}</p>
-                    <p style={{ margin: '4px 0', fontSize: '0.75rem', color: '#666' }}>{t('multiSig.txIdLabel')} <code>{tx.txId}</code></p>
+                    <p style={{ margin: '4px 0', fontSize: '0.75rem', color: 'var(--muted)' }}>{t('multiSig.txIdLabel')} <code>{tx.txId}</code></p>
                     {tx.status === 'pending' && (
                       <button
                         type="button"
                         onClick={() => handleSubmitTx(tx.txId)}
                         disabled={loading}
-                        style={{ marginTop: 8, padding: '6px 12px', background: '#22c55e', color: '#fff', border: 'none', borderRadius: 3, cursor: 'pointer', fontSize: '0.875rem' }}
+                        style={{ marginTop: 8, padding: '6px 12px', background: 'var(--success)', color: 'var(--on-primary)', border: 'none', borderRadius: 3, cursor: 'pointer', fontSize: '0.875rem' }}
                       >
                         {t('multiSig.submitTransaction')}
                       </button>

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -76,6 +76,20 @@
     "largeWarning": "⚠️ يرجى مراجعة وتأكيد تحذير المعاملة الكبيرة أدناه.",
     "kycRequired": "المعاملات الكبيرة التي تتجاوز {{limit}} XLM تستلزم موافقة KYC."
   },
+  "sendPayment": {
+    "title": "إرسال دفعة",
+    "recipientLabel": "عنوان المستلم",
+    "recipientPlaceholder": "G…",
+    "scanButton": "📱 مسح",
+    "invalidAddress": "عنوان غير صالح",
+    "amountLabel": "المبلغ (XLM)",
+    "sendButton": "إرسال الدفعة",
+    "sending": "جارٍ الإرسال…",
+    "kycRequired": "المعاملات الكبيرة تتطلب موافقة KYC",
+    "sentSuccess": "تم إرسال الدفعة! الرمز: {{hash}}…",
+    "sep7Prefilled": "تم تعبئة تفاصيل الدفع مسبقًا. يرجى المراجعة والتأكيد.",
+    "sep7InvalidLink": "رابط دفع غير صالح: {{error}}"
+  },
   "confirmation": {
     "title": "تأكيد الدفعة",
     "close": "إغلاق نافذة تأكيد الدفعة",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -50,6 +50,20 @@
     "queued": "You are offline. Payment queued and will sync automatically.",
     "largeWarning": "⚠️ Please review and confirm the large transaction warning below."
   },
+  "sendPayment": {
+    "title": "Send Payment",
+    "recipientLabel": "Recipient Address",
+    "recipientPlaceholder": "G…",
+    "scanButton": "📱 Scan",
+    "invalidAddress": "Invalid address",
+    "amountLabel": "Amount (XLM)",
+    "sendButton": "Send Payment",
+    "sending": "Sending…",
+    "kycRequired": "Large transactions require KYC approval",
+    "sentSuccess": "Payment sent! Hash: {{hash}}…",
+    "sep7Prefilled": "Payment details pre-filled. Please review and confirm.",
+    "sep7InvalidLink": "Invalid payment link: {{error}}"
+  },
   "validation": {
     "invalidAddress": "Invalid Stellar address format (must start with G and be 56 characters)"
   },

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -50,6 +50,20 @@
     "queued": "Estás sin conexión. Pago en cola, se sincronizará automáticamente.",
     "largeWarning": "⚠️ Por favor revisa y confirma la advertencia de transacción grande."
   },
+  "sendPayment": {
+    "title": "Enviar pago",
+    "recipientLabel": "Dirección del destinatario",
+    "recipientPlaceholder": "G…",
+    "scanButton": "📱 Escanear",
+    "invalidAddress": "Dirección inválida",
+    "amountLabel": "Monto (XLM)",
+    "sendButton": "Enviar pago",
+    "sending": "Enviando…",
+    "kycRequired": "Las transacciones grandes requieren aprobación KYC",
+    "sentSuccess": "¡Pago enviado! Hash: {{hash}}…",
+    "sep7Prefilled": "Detalles del pago prellenados. Por favor revisa y confirma.",
+    "sep7InvalidLink": "Enlace de pago inválido: {{error}}"
+  },
   "validation": {
     "invalidAddress": "Formato de dirección Stellar inválido (debe comenzar con G y tener 56 caracteres)"
   },

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -50,6 +50,20 @@
     "queued": "Vous êtes hors ligne. Paiement mis en file d'attente.",
     "largeWarning": "⚠️ Veuillez examiner et confirmer l'avertissement de grande transaction ci-dessous."
   },
+  "sendPayment": {
+    "title": "Envoyer un paiement",
+    "recipientLabel": "Adresse du destinataire",
+    "recipientPlaceholder": "G…",
+    "scanButton": "📱 Scanner",
+    "invalidAddress": "Adresse invalide",
+    "amountLabel": "Montant (XLM)",
+    "sendButton": "Envoyer le paiement",
+    "sending": "Envoi en cours…",
+    "kycRequired": "Les transactions importantes nécessitent une approbation KYC",
+    "sentSuccess": "Paiement envoyé ! Hash : {{hash}}…",
+    "sep7Prefilled": "Détails du paiement pré-remplis. Veuillez vérifier et confirmer.",
+    "sep7InvalidLink": "Lien de paiement invalide : {{error}}"
+  },
   "validation": {
     "invalidAddress": "Format d'adresse Stellar invalide (doit commencer par G et comporter 56 caractères)"
   },

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -50,6 +50,20 @@
     "queued": "אתה לא מחובר. התשלום נוסף לתור ויסונכרן אוטומטית.",
     "largeWarning": "⚠️ אנא בדוק ואשר את אזהרת העסקה הגדולה למטה."
   },
+  "sendPayment": {
+    "title": "שלח תשלום",
+    "recipientLabel": "כתובת הנמען",
+    "recipientPlaceholder": "G…",
+    "scanButton": "📱 סרוק",
+    "invalidAddress": "כתובת לא תקינה",
+    "amountLabel": "סכום (XLM)",
+    "sendButton": "שלח תשלום",
+    "sending": "שולח…",
+    "kycRequired": "עסקאות גדולות דורשות אישור KYC",
+    "sentSuccess": "התשלום נשלח! גיבוב: {{hash}}…",
+    "sep7Prefilled": "פרטי התשלום מולאו מראש. אנא בדוק ואשר.",
+    "sep7InvalidLink": "קישור תשלום לא תקין: {{error}}"
+  },
   "validation": {
     "invalidAddress": "פורמט כתובת Stellar לא חוקי (חייב להתחיל ב-G ולהיות 56 תווים)"
   },

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -50,6 +50,20 @@
     "queued": "Você está offline. Pagamento na fila, será sincronizado automaticamente.",
     "largeWarning": "⚠️ Por favor revise e confirme o aviso de transação grande abaixo."
   },
+  "sendPayment": {
+    "title": "Enviar pagamento",
+    "recipientLabel": "Endereço do destinatário",
+    "recipientPlaceholder": "G…",
+    "scanButton": "📱 Escanear",
+    "invalidAddress": "Endereço inválido",
+    "amountLabel": "Valor (XLM)",
+    "sendButton": "Enviar pagamento",
+    "sending": "Enviando…",
+    "kycRequired": "Transações grandes exigem aprovação KYC",
+    "sentSuccess": "Pagamento enviado! Hash: {{hash}}…",
+    "sep7Prefilled": "Detalhes do pagamento pré-preenchidos. Por favor revise e confirme.",
+    "sep7InvalidLink": "Link de pagamento inválido: {{error}}"
+  },
   "validation": {
     "invalidAddress": "Formato de endereço Stellar inválido (deve começar com G e ter 56 caracteres)"
   },

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -50,6 +50,20 @@
     "queued": "您处于离线状态。付款已排队，将在联网后自动同步。",
     "largeWarning": "⚠️ 请查看并确认下方的大额交易警告。"
   },
+  "sendPayment": {
+    "title": "发送付款",
+    "recipientLabel": "收款人地址",
+    "recipientPlaceholder": "G…",
+    "scanButton": "📱 扫描",
+    "invalidAddress": "地址无效",
+    "amountLabel": "金额 (XLM)",
+    "sendButton": "发送付款",
+    "sending": "发送中…",
+    "kycRequired": "大额交易需要 KYC 审批",
+    "sentSuccess": "付款已发送！哈希：{{hash}}…",
+    "sep7Prefilled": "付款详情已预填。请查看并确认。",
+    "sep7InvalidLink": "付款链接无效：{{error}}"
+  },
   "validation": {
     "invalidAddress": "Stellar地址格式无效（必须以G开头且为56个字符）"
   },

--- a/frontend/src/pages/SendPaymentPage.jsx
+++ b/frontend/src/pages/SendPaymentPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
 import apiClient from '../api/client.js';
 import { isValidStellarAddress } from '../utils/validateStellarAddress';
 import { validateAmount, formatAmount } from '../utils/validateAmount';
@@ -9,6 +10,7 @@ import { useMessages } from '../hooks/useMessages';
 import { makeVariants, tapScale } from '../utils/animations';
 import { useReducedMotion } from 'framer-motion';
 import { QRScanner } from '../components/QRScanner';
+import { AmountInput } from '../components/AmountInput';
 import { ConfirmSendDialog } from '../components/ConfirmSendDialog';
 import { PaymentConfirmationModal } from '../components/PaymentConfirmationModal';
 import { LargeTransactionWarning } from '../components/LargeTransactionWarning';
@@ -18,6 +20,7 @@ import { logError } from '../utils/errorLogger';
 const KYC_LARGE_TRANSACTION_LIMIT = 1000;
 
 export function SendPaymentPage() {
+  const { t } = useTranslation();
   const { account, balance, loading, recipient, amount, memo, memoType } = useAppState();
   const dispatch = useAppDispatch();
   const msg = useMessages();
@@ -75,16 +78,15 @@ export function SendPaymentPage() {
   const recipientTouched = recipient.length > 0;
   const largeTransactionBlocked = amountValid && kycStatus !== 'APPROVED' && parseFloat(amount) > KYC_LARGE_TRANSACTION_LIMIT;
 
-  const handleSendMax = () => {
-    if (xlmBalance === null) return;
-    const maxSendable = Math.max(0, parseFloat(xlmBalance) - 1 - 0.00001);
-    dispatch({ type: A.SET_AMOUNT, payload: maxSendable.toFixed(7).replace(/\.?0+$/, '') });
-  };
+  // Reserve buffer (1 XLM minimum reserve + base fee) kept out of the sendable max.
+  const maxSendable = xlmBalance !== null
+    ? Math.max(0, parseFloat(xlmBalance) - 1 - 0.00001).toFixed(7).replace(/\.?0+$/, '')
+    : null;
 
   const sendPayment = async () => {
     if (!account || !recipientValid || !amountValid) return;
     if (largeTransactionBlocked) {
-      msg.error('Large transactions require KYC approval');
+      msg.error(t('sendPayment.kycRequired'));
       return;
     }
 
@@ -99,7 +101,7 @@ export function SendPaymentPage() {
         memoType: memoType || undefined,
       });
 
-      msg.success(`Payment sent! Hash: ${data.hash?.slice(0, 8)}…`);
+      msg.success(t('sendPayment.sentSuccess', { hash: data.hash?.slice(0, 8) }));
       dispatch({ type: A.RESET_FORM });
       setShowPaymentConfirmation(false);
     } catch (error) {
@@ -128,25 +130,25 @@ export function SendPaymentPage() {
         dispatch({ type: A.SET_MEMO_TYPE, payload: parsed.memoType });
       }
     }
-    msg.info('Payment details pre-filled. Please review and confirm.');
+    msg.info(t('sendPayment.sep7Prefilled'));
   };
 
   const handleSep7Error = (error) => {
     setShowSep7Handler(false);
-    msg.error(`Invalid payment link: ${error}`);
+    msg.error(t('sendPayment.sep7InvalidLink', { error }));
   };
 
   return (
     <motion.section className="section" variants={v.fadeSlide}>
-      <h2>Send Payment</h2>
+      <h2>{t('sendPayment.title')}</h2>
 
       <div style={{ marginBottom: 16 }}>
-        <label htmlFor="recipient">Recipient Address</label>
+        <label htmlFor="recipient">{t('sendPayment.recipientLabel')}</label>
         <div style={{ display: 'flex', gap: 8 }}>
           <input
             id="recipient"
             type="text"
-            placeholder="G…"
+            placeholder={t('sendPayment.recipientPlaceholder')}
             value={recipient}
             onChange={(e) => dispatch({ type: A.SET_RECIPIENT, payload: e.target.value })}
             style={{
@@ -161,38 +163,22 @@ export function SendPaymentPage() {
             onClick={() => setShowScanner(!showScanner)}
             style={{ padding: '8px 16px', background: '#0066cc', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer' }}
           >
-            📱 Scan
+            {t('sendPayment.scanButton')}
           </button>
         </div>
-        {recipientTouched && !recipientValid && <p style={{ color: '#dc2626', fontSize: 12, marginTop: 4 }}>Invalid address</p>}
+        {recipientTouched && !recipientValid && <p style={{ color: '#dc2626', fontSize: 12, marginTop: 4 }}>{t('sendPayment.invalidAddress')}</p>}
       </div>
 
       {showScanner && <QRScanner onScan={(data) => { dispatch({ type: A.SET_RECIPIENT, payload: data }); setShowScanner(false); }} />}
 
       <div style={{ marginBottom: 16 }}>
-        <label htmlFor="amount">Amount (XLM)</label>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <input
-            id="amount"
-            type="number"
-            placeholder="0.00"
-            value={amount}
-            onChange={(e) => dispatch({ type: A.SET_AMOUNT, payload: e.target.value })}
-            style={{
-              flex: 1,
-              padding: '8px 12px',
-              border: amountTouched && !amountValid ? '2px solid #dc2626' : '1px solid #d1d5db',
-              borderRadius: 4,
-            }}
-          />
-          <button
-            type="button"
-            onClick={handleSendMax}
-            style={{ padding: '8px 16px', background: '#10b981', color: '#fff', border: 'none', borderRadius: 4, cursor: 'pointer' }}
-          >
-            Max
-          </button>
-        </div>
+        <label id="amount-label">{t('sendPayment.amountLabel')}</label>
+        <AmountInput
+          value={amount}
+          onChange={(value) => dispatch({ type: A.SET_AMOUNT, payload: value })}
+          currency="XLM"
+          availableBalance={maxSendable}
+        />
         {amountTouched && amountError && <p style={{ color: '#dc2626', fontSize: 12, marginTop: 4 }}>{amountError}</p>}
       </div>
 
@@ -212,7 +198,7 @@ export function SendPaymentPage() {
           fontWeight: 500,
         }}
       >
-        {loading === 'send' ? 'Sending…' : 'Send Payment'}
+        {loading === 'send' ? t('sendPayment.sending') : t('sendPayment.sendButton')}
       </button>
 
       <PaymentConfirmationModal


### PR DESCRIPTION
Closes #926
Closes #927
Closes #928
Closes #929

## Summary

- **#929** — `SendPaymentPage.jsx` now renders `<AmountInput />` instead of a raw `<input type="number">`, so it gets locale-aware decimal parsing/formatting for free. The MAX button keeps its existing reserve-buffer behavior (balance minus 1 XLM minimum reserve minus base fee) by passing that pre-computed value in as `availableBalance`. The old `handleSendMax` calculation is gone — there's now a single place that computes the sendable max.
- **#928** — Added a `sendPayment` i18n namespace to all 7 locale files (en, fr, es, pt, ar, zh, he) and replaced every hardcoded English string in `SendPaymentPage.jsx` (labels, placeholders, buttons, toasts) with `t()` calls, following the pattern used in `AddressBook.jsx`/`DatePicker.jsx`.
- **#927** — Replaced hardcoded hex/named colors in `AutoComplete.jsx`, `DatePicker.jsx`, `FormWizard.jsx`, and `MultiSigTransactions.jsx` with the existing design tokens / CSS custom properties (`var(--text)`, `var(--border)`, `var(--primary)`, `var(--surface)`, `var(--on-primary)`, etc.) so these components respect dark mode. Also added an ESLint `no-restricted-syntax` rule (severity `warn`, so it doesn't fail CI on the remaining pre-existing hex literals elsewhere in the codebase) that flags new hex color literals going forward.
- **#926** — Added a `WebhookDelivery` Prisma model (+ migration) that records one row per delivery attempt cycle: `webhookId`, `accountId`, `eventType`, `payload`, `attempt`/`maxAttempts`, `status` (`PENDING`/`DELIVERED`/`FAILED`), `lastError`, `nextAttemptAt`. Rewrote `dispatcher.js` so `dispatchEvent()` persists a delivery row per matching webhook and makes an immediate attempt; failures reschedule `nextAttemptAt` (same backoff delays as before: 1s/5s/15s) instead of chaining `setTimeout` calls, and permanent failures after `maxAttempts` are marked `FAILED` (the dead-letter state). A new `processDueWebhookDeliveries()` is polled by the scheduler every 10s so pending retries survive a process restart. Added `GET /api/v1/webhooks/:id/deliveries` (auth-scoped to the webhook's owning account) returning paginated delivery history, including dead-lettered deliveries, with optional `?status=` filtering.

Tests were intentionally skipped per request.