### PR TITLE
Fix webhook IDOR and add SSRF URL validation

### DIFF
--- a/backend/src/routes/webhooks.js
+++ b/backend/src/routes/webhooks.js
@@ -1,7 +1,15 @@
 import express from 'express';
 import { requireAuth } from '../middleware/auth.js';
-import { registerWebhook, listWebhooks, deleteWebhook, rotateWebhookSecret, verifyWebhookSignature, getWebhook } from '../webhooks/store.js';
+import {
+  registerWebhook,
+  listWebhooks,
+  deleteWebhook,
+  rotateWebhookSecret,
+  verifyWebhookSignature,
+  getWebhook,
+} from '../webhooks/store.js';
 import { webhookSignatureMiddleware } from '../webhooks/verifySignature.js';
+import { validateWebhookUrl } from '../webhooks/urlValidator.js';
 import prisma from '../db/client.js';
 import logger from '../config/logger.js';
 
@@ -36,18 +44,23 @@ const router = express.Router();
  *       401:
  *         description: Unauthorized
  */
-router.post('/', requireAuth, (req, res) => {
+router.post('/', requireAuth, async (req, res) => {
   const { url, events } = req.body;
-  
+
   if (!url) return res.status(400).json({ error: 'url is required' });
-  
+
+  const validation = await validateWebhookUrl(url);
+  if (!validation.valid) {
+    return res.status(400).json({ error: validation.error });
+  }
+
   try {
     const webhook = registerWebhook({
       url,
       accountId: req.user.sub,
       events: events || ['*'],
     });
-    
+
     logger.info({ webhookId: webhook.id, accountId: req.user.sub }, 'Webhook registered');
     res.status(201).json(webhook);
   } catch (err) {
@@ -104,9 +117,18 @@ router.get('/', requireAuth, (req, res) => {
  */
 router.delete('/:id', requireAuth, (req, res) => {
   try {
-    const deleted = deleteWebhook(req.params.id);
-    if (!deleted) return res.status(404).json({ error: 'Webhook not found' });
-    
+    const webhook = getWebhook(req.params.id);
+    if (!webhook || webhook.accountId !== req.user.sub) {
+      if (webhook) {
+        logger.warn(
+          { webhookId: req.params.id, accountId: req.user.sub, ownerAccountId: webhook.accountId },
+          'Denied cross-account webhook delete attempt',
+        );
+      }
+      return res.status(404).json({ error: 'Webhook not found' });
+    }
+
+    deleteWebhook(req.params.id);
     logger.info({ webhookId: req.params.id, accountId: req.user.sub }, 'Webhook deleted');
     res.json({ message: 'Webhook deleted' });
   } catch (err) {
@@ -139,6 +161,17 @@ router.delete('/:id', requireAuth, (req, res) => {
  */
 router.post('/:id/rotate-secret', requireAuth, (req, res) => {
   try {
+    const webhook = getWebhook(req.params.id);
+    if (!webhook || webhook.accountId !== req.user.sub) {
+      if (webhook) {
+        logger.warn(
+          { webhookId: req.params.id, accountId: req.user.sub, ownerAccountId: webhook.accountId },
+          'Denied cross-account webhook secret rotation attempt',
+        );
+      }
+      return res.status(404).json({ error: 'Webhook not found' });
+    }
+
     const result = rotateWebhookSecret(req.params.id);
     logger.info({ webhookId: req.params.id, accountId: req.user.sub }, 'Webhook secret rotated');
     res.json(result);
@@ -251,18 +284,21 @@ router.get('/:id/deliveries', requireAuth, async (req, res) => {
  * Signature is verified via HMAC-SHA256 before any processing occurs.
  */
 router.post('/incoming', webhookSignatureMiddleware, (req, res) => {
-  logger.info({ source: req.headers['x-webhook-source'] ?? 'unknown' }, 'Incoming webhook received');
+  logger.info(
+    { source: req.headers['x-webhook-source'] ?? 'unknown' },
+    'Incoming webhook received',
+  );
   // Dispatch to application logic based on payload type
   res.status(200).json({ received: true });
 });
 
 router.post('/verify', (req, res) => {
   const { webhookId, signature, payload } = req.body;
-  
+
   if (!webhookId || !signature || !payload) {
     return res.status(400).json({ error: 'webhookId, signature, and payload are required' });
   }
-  
+
   const valid = verifyWebhookSignature(webhookId, signature, payload);
   res.json({ valid });
 });

--- a/backend/src/webhooks/dispatcher.js
+++ b/backend/src/webhooks/dispatcher.js
@@ -1,4 +1,5 @@
 import { getWebhook, getWebhooksForAccount, signPayload } from './store.js';
+import { validateWebhookUrl } from './urlValidator.js';
 import prisma from '../db/client.js';
 import logger from '../config/logger.js';
 
@@ -6,6 +7,13 @@ const MAX_RETRIES = 3;
 const RETRY_DELAYS = [1000, 5000, 15000]; // ms, indexed by attempt number (0-based)
 
 async function deliverOnce(webhook, payload) {
+  // Re-check the URL at delivery time in case the resolved address changed
+  // since registration (DNS rebinding into a private/internal range).
+  const validation = await validateWebhookUrl(webhook.url);
+  if (!validation.valid) {
+    throw new Error(`Webhook URL failed validation: ${validation.error}`);
+  }
+
   const signature = signPayload(webhook.signingSecret, payload);
 
   const res = await fetch(webhook.url, {
@@ -37,13 +45,22 @@ async function attemptDelivery(delivery) {
     });
   }
 
-  const payload = { webhookId: webhook.id, event: { type: delivery.eventType, accountId: delivery.accountId, data: delivery.payload }, timestamp: Date.now() };
+  const payload = {
+    webhookId: webhook.id,
+    event: { type: delivery.eventType, accountId: delivery.accountId, data: delivery.payload },
+    timestamp: Date.now(),
+  };
 
   try {
     await deliverOnce(webhook, payload);
     return prisma.webhookDelivery.update({
       where: { id: delivery.id },
-      data: { status: 'DELIVERED', attempt: delivery.attempt + 1, deliveredAt: new Date(), lastError: null },
+      data: {
+        status: 'DELIVERED',
+        attempt: delivery.attempt + 1,
+        deliveredAt: new Date(),
+        lastError: null,
+      },
     });
   } catch (err) {
     const attempt = delivery.attempt + 1;
@@ -55,7 +72,10 @@ async function attemptDelivery(delivery) {
       });
     }
 
-    logger.error({ webhookId: webhook.id, error: err.message }, `Webhook delivery failed after ${attempt} attempts`);
+    logger.error(
+      { webhookId: webhook.id, error: err.message },
+      `Webhook delivery failed after ${attempt} attempts`,
+    );
     return prisma.webhookDelivery.update({
       where: { id: delivery.id },
       data: { status: 'FAILED', attempt, lastError: err.message },
@@ -71,23 +91,34 @@ async function attemptDelivery(delivery) {
 export async function dispatchEvent(accountId, eventType, data) {
   try {
     const hooks = getWebhooksForAccount(accountId).filter(
-      w => w.events.includes('*') || w.events.includes(eventType)
+      (w) => w.events.includes('*') || w.events.includes(eventType),
     );
     if (!hooks.length) return [];
 
-    const deliveries = await Promise.all(hooks.map(w => prisma.webhookDelivery.create({
-      data: {
-        webhookId: w.id,
-        accountId,
-        eventType,
-        payload: data,
-        maxAttempts: MAX_RETRIES,
-      },
-    })));
+    const deliveries = await Promise.all(
+      hooks.map((w) =>
+        prisma.webhookDelivery.create({
+          data: {
+            webhookId: w.id,
+            accountId,
+            eventType,
+            payload: data,
+            maxAttempts: MAX_RETRIES,
+          },
+        }),
+      ),
+    );
 
-    await Promise.all(deliveries.map(d => attemptDelivery(d).catch(err => {
-      logger.error({ webhookId: d.webhookId, error: err.message }, 'Webhook delivery attempt threw');
-    })));
+    await Promise.all(
+      deliveries.map((d) =>
+        attemptDelivery(d).catch((err) => {
+          logger.error(
+            { webhookId: d.webhookId, error: err.message },
+            'Webhook delivery attempt threw',
+          );
+        }),
+      ),
+    );
 
     return deliveries;
   } catch (err) {

--- a/backend/src/webhooks/urlValidator.js
+++ b/backend/src/webhooks/urlValidator.js
@@ -1,0 +1,105 @@
+import dns from 'node:dns';
+import net from 'node:net';
+import { getConfig } from '../config/env.js';
+
+const MAX_URL_LENGTH = 2048;
+
+// Escape hatch for local development / CI so tests can register plain
+// http://localhost webhook receivers without tripping SSRF protections,
+// mirroring the allowlist pattern used by src/security/ipWhitelist.js.
+const HOST_ALLOWLIST = new Set(
+  (process.env.WEBHOOK_HOST_ALLOWLIST || '')
+    .split(',')
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+function isPrivateOrReservedIp(ip) {
+  const type = net.isIP(ip);
+
+  if (type === 4) {
+    const [a, b] = ip.split('.').map(Number);
+    if (a === 127) return true; // loopback
+    if (a === 10) return true; // RFC1918
+    if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918
+    if (a === 192 && b === 168) return true; // RFC1918
+    if (a === 169 && b === 254) return true; // link-local (incl. cloud metadata)
+    if (a === 0) return true; // "this" network
+    if (a >= 224) return true; // multicast / reserved
+    return false;
+  }
+
+  if (type === 6) {
+    const lower = ip.toLowerCase();
+    if (lower === '::1' || lower === '::') return true; // loopback / unspecified
+    if (lower.startsWith('fe80:')) return true; // link-local
+    if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // unique local
+    if (lower.startsWith('::ffff:')) {
+      const v4 = lower.slice('::ffff:'.length);
+      if (net.isIP(v4) === 4) return isPrivateOrReservedIp(v4);
+    }
+    return false;
+  }
+
+  // Unparseable address — treat as unsafe.
+  return true;
+}
+
+/**
+ * Validate a webhook registration/delivery URL to prevent SSRF.
+ * Rejects malformed URLs, disallowed schemes, and hosts that resolve to
+ * private/loopback/link-local addresses. HTTPS is required outside of
+ * development/test so local receivers can still use http://localhost.
+ */
+export async function validateWebhookUrl(url, { appEnv, lookup = dns.promises.lookup } = {}) {
+  if (typeof url !== 'string' || url.trim().length === 0) {
+    return { valid: false, error: 'url is required' };
+  }
+  if (url.length > MAX_URL_LENGTH) {
+    return { valid: false, error: `url must not exceed ${MAX_URL_LENGTH} characters` };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { valid: false, error: 'url must be a valid absolute URL' };
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (!hostname) {
+    return { valid: false, error: 'url must include a hostname' };
+  }
+
+  if (HOST_ALLOWLIST.has(hostname)) {
+    return { valid: true };
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return { valid: false, error: 'url scheme must be http or https' };
+  }
+
+  const resolvedAppEnv = appEnv ?? getConfig().meta.appEnv;
+  const requireHttps = resolvedAppEnv === 'production' || resolvedAppEnv === 'staging';
+  if (requireHttps && parsed.protocol !== 'https:') {
+    return { valid: false, error: 'url must use https://' };
+  }
+
+  let addresses;
+  if (net.isIP(hostname)) {
+    addresses = [hostname];
+  } else {
+    try {
+      const results = await lookup(hostname, { all: true, verbatim: true });
+      addresses = results.map((r) => r.address);
+    } catch {
+      return { valid: false, error: 'url hostname could not be resolved' };
+    }
+  }
+
+  if (addresses.length === 0 || addresses.some(isPrivateOrReservedIp)) {
+    return { valid: false, error: 'url resolves to a private, loopback, or link-local address' };
+  }
+
+  return { valid: true };
+}

--- a/backend/tests/webhooks.ownership.test.js
+++ b/backend/tests/webhooks.ownership.test.js
@@ -1,0 +1,130 @@
+/**
+ * Regression tests for issue #912 — IDOR on webhook delete / rotate-secret.
+ *
+ * A webhook registered by one account must not be deletable or rotatable
+ * by a different authenticated account, even with a valid, guessed ID.
+ * Both "doesn't exist" and "belongs to someone else" must return an
+ * identical 404 response shape so existence isn't leaked.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+let currentUser;
+
+async function makeWebhooksApp() {
+  vi.resetModules();
+
+  vi.doMock('../src/middleware/auth.js', () => ({
+    requireAuth: (req, _res, next) => {
+      req.user = currentUser;
+      next();
+    },
+  }));
+
+  vi.doMock('../src/config/logger.js', () => ({
+    default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  }));
+
+  vi.doMock('../src/db/client.js', () => ({
+    default: {
+      webhookDelivery: {
+        findMany: vi.fn().mockResolvedValue([]),
+        count: vi.fn().mockResolvedValue(0),
+      },
+    },
+  }));
+
+  const { default: webhooksRouter } = await import('../src/routes/webhooks.js');
+
+  const app = express();
+  app.use(express.json());
+  app.use('/', webhooksRouter);
+  return app;
+}
+
+describe('Webhook ownership checks (issue #912)', () => {
+  const accountA = 'account-a';
+  const accountB = 'account-b';
+  let app;
+
+  beforeEach(async () => {
+    currentUser = { sub: accountA };
+    app = await makeWebhooksApp();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function registerWebhook(accountId, url = 'https://example.com/hook') {
+    currentUser = { sub: accountId };
+    const res = await request(app)
+      .post('/')
+      .send({ url, events: ['*'] });
+    expect(res.status).toBe(201);
+    return res.body.id;
+  }
+
+  it('rejects cross-account delete with 404', async () => {
+    const webhookId = await registerWebhook(accountA);
+
+    currentUser = { sub: accountB };
+    const res = await request(app).delete(`/${webhookId}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Webhook not found' });
+  });
+
+  it('rejects cross-account rotate-secret with 404', async () => {
+    const webhookId = await registerWebhook(accountA);
+
+    currentUser = { sub: accountB };
+    const res = await request(app).post(`/${webhookId}/rotate-secret`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Webhook not found' });
+  });
+
+  it('returns an identical 404 shape for a nonexistent webhook as for a cross-account one', async () => {
+    const webhookId = await registerWebhook(accountA);
+
+    currentUser = { sub: accountB };
+    const crossAccount = await request(app).delete(`/${webhookId}`);
+    const nonexistent = await request(app).delete('/does-not-exist');
+
+    expect(crossAccount.status).toBe(nonexistent.status);
+    expect(crossAccount.body).toEqual(nonexistent.body);
+  });
+
+  it('allows the owning account to delete its own webhook', async () => {
+    const webhookId = await registerWebhook(accountA);
+
+    currentUser = { sub: accountA };
+    const res = await request(app).delete(`/${webhookId}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: 'Webhook deleted' });
+  });
+
+  it('allows the owning account to rotate its own webhook secret', async () => {
+    const webhookId = await registerWebhook(accountA);
+
+    currentUser = { sub: accountA };
+    const res = await request(app).post(`/${webhookId}/rotate-secret`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.signingSecret).toBeDefined();
+  });
+
+  it('does not allow account B to delete a webhook it does not own even after registering its own', async () => {
+    const webhookIdA = await registerWebhook(accountA);
+    await registerWebhook(accountB);
+
+    currentUser = { sub: accountB };
+    const res = await request(app).delete(`/${webhookIdA}`);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/tests/webhooks.urlValidation.test.js
+++ b/backend/tests/webhooks.urlValidation.test.js
@@ -1,0 +1,111 @@
+/**
+ * Regression tests for issue #913 — SSRF via unvalidated webhook URLs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { validateWebhookUrl } from '../src/webhooks/urlValidator.js';
+
+describe('validateWebhookUrl', () => {
+  beforeEach(() => {
+    delete process.env.WEBHOOK_HOST_ALLOWLIST;
+  });
+
+  it('rejects a malformed URL', async () => {
+    const result = await validateWebhookUrl('not-a-url');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects a missing URL', async () => {
+    const result = await validateWebhookUrl('');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects an overly long URL', async () => {
+    const longUrl = `https://1.2.3.4/${'a'.repeat(3000)}`;
+    const result = await validateWebhookUrl(longUrl);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/exceed/);
+  });
+
+  it('rejects a disallowed scheme', async () => {
+    const result = await validateWebhookUrl('file:///etc/passwd');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects loopback IPs', async () => {
+    const result = await validateWebhookUrl('https://127.0.0.1/hook');
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/private|loopback|link-local/);
+  });
+
+  it('rejects the cloud metadata link-local address', async () => {
+    const result = await validateWebhookUrl('https://169.254.169.254/latest/meta-data/');
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects RFC1918 private ranges', async () => {
+    for (const ip of ['10.0.0.5', '172.16.0.5', '192.168.1.5']) {
+      const result = await validateWebhookUrl(`https://${ip}/hook`);
+      expect(result.valid).toBe(false);
+    }
+  });
+
+  it('rejects http:// in production configuration', async () => {
+    const result = await validateWebhookUrl('http://93.184.216.34/hook', { appEnv: 'production' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/https/);
+  });
+
+  it('accepts a valid public https URL', async () => {
+    const result = await validateWebhookUrl('https://93.184.216.34/hook', { appEnv: 'production' });
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts http:// outside production/staging', async () => {
+    const result = await validateWebhookUrl('http://93.184.216.34/hook', { appEnv: 'development' });
+    expect(result.valid).toBe(true);
+  });
+
+  it('resolves hostnames via DNS and rejects ones that resolve to a private range', async () => {
+    const lookup = vi.fn().mockResolvedValue([{ address: '10.1.2.3', family: 4 }]);
+    const result = await validateWebhookUrl('https://internal.example.com/hook', {
+      appEnv: 'production',
+      lookup,
+    });
+    expect(result.valid).toBe(false);
+    expect(lookup).toHaveBeenCalledWith('internal.example.com', { all: true, verbatim: true });
+  });
+
+  it('resolves hostnames via DNS and accepts ones that resolve to a public range', async () => {
+    const lookup = vi.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    const result = await validateWebhookUrl('https://public.example.com/hook', {
+      appEnv: 'production',
+      lookup,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('simulates DNS rebinding: registration-time public IP vs. dispatch-time private IP', async () => {
+    const registrationLookup = vi.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    const atRegistration = await validateWebhookUrl('https://rebinding.example.com/hook', {
+      appEnv: 'production',
+      lookup: registrationLookup,
+    });
+    expect(atRegistration.valid).toBe(true);
+
+    const dispatchLookup = vi.fn().mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+    const atDispatch = await validateWebhookUrl('https://rebinding.example.com/hook', {
+      appEnv: 'production',
+      lookup: dispatchLookup,
+    });
+    expect(atDispatch.valid).toBe(false);
+  });
+
+  it('allows an explicitly allowlisted host regardless of scheme or IP range', async () => {
+    process.env.WEBHOOK_HOST_ALLOWLIST = 'localhost';
+    vi.resetModules();
+    const { validateWebhookUrl: validate } = await import('../src/webhooks/urlValidator.js');
+    const result = await validate('http://localhost:4000/hook', { appEnv: 'production' });
+    expect(result.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Delete and rotate-secret handlers now verify `webhook.accountId === req.user.sub` before mutating, returning an identical `404 { error: 'Webhook not found' }` for both "doesn't exist" and "belongs to someone else" so existence isn't leaked. Denied cross-account attempts are logged via `logger.warn`.
- Added `validateWebhookUrl()` (`backend/src/webhooks/urlValidator.js`) and wired it into `POST /api/v1/webhooks`: rejects malformed/oversized URLs, requires `https://` in production/staging, and resolves hostnames to reject loopback/private/link-local ranges (including `169.254.169.254`).
- The dispatcher re-validates the URL immediately before each delivery attempt in `deliverOnce`, mitigating DNS rebinding between registration and delivery.
- An env-gated host allowlist (`WEBHOOK_HOST_ALLOWLIST`) preserves local dev/CI's ability to register `http://localhost` test receivers, mirroring the pattern in `src/security/ipWhitelist.js`.

## Test plan
- [x] `backend/tests/webhooks.ownership.test.js` (new) — cross-account delete/rotate both return 404 with an identical body; owning account can still delete/rotate; nonexistent vs. cross-account responses are byte-identical.
- [x] `backend/tests/webhooks.urlValidation.test.js` (new) — malformed/oversized URLs, disallowed schemes, loopback/link-local/RFC1918 rejection, cloud metadata address rejection, https-required-in-production, DNS-rebinding simulation (public IP at registration vs. private IP at dispatch), and the host allowlist escape hatch.
- [x] `npx vitest run tests/webhooks.*.test.js` — 29/29 passing.
- [x] `npx eslint` on all changed files — clean.

Closes #912
Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)