### PR TITLE
 fix/issues-936-937-938-939

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -969,7 +969,7 @@ function App() {
                   animate={{ opacity: [0.6, 1, 0.6] }}
                   transition={{ repeat: Infinity, duration: 2 }}
                   style={{ fontSize: '0.8rem', display: 'flex', alignItems: 'center', gap: 6 }}
-                  aria-label={`WebSocket status: ${wsStatus}`}
+                  aria-label={t('wsStatus.label', { status: t(`wsStatus.${wsStatus}`, wsStatus) })}
                   role="status"
                 >
                   <span
@@ -986,7 +986,7 @@ function App() {
                     aria-hidden="true"
                     className={wsStatus === 'failed' ? 'ws-status-failed' : ''}
                   >
-                    {wsStatus === 'failed' ? 'Connection lost' : wsStatus}
+                    {t(`wsStatus.${wsStatus}`, wsStatus)}
                   </span>
                 </motion.span>
               </div>

--- a/frontend/src/components/Charts.jsx
+++ b/frontend/src/components/Charts.jsx
@@ -28,6 +28,26 @@ function useExport(title = 'chart') {
   return { ref, exportPng };
 }
 
+/**
+ * DataTable — visually hidden accessible table alternative for chart data.
+ * Visible only to screen readers via sr-only styling.
+ */
+function DataTable({ caption, headers, rows }) {
+  return (
+    <table className="sr-only">
+      <caption>{caption}</caption>
+      <thead>
+        <tr>{headers.map(h => <th key={h} scope="col">{h}</th>)}</tr>
+      </thead>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr key={i}>{row.map((cell, j) => <td key={j}>{cell}</td>)}</tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
 function ChartCard({ title, children, onExport }) {
   return (
     <div style={cardStyle}>
@@ -67,6 +87,11 @@ export function TransactionVolumeChart({ data = [] }) {
           </BarChart>
         </ResponsiveContainer>
       </div>
+      <DataTable
+        caption="Transaction Volume"
+        headers={['Date', 'Sent (XLM)', 'Received (XLM)']}
+        rows={data.map(d => [d.date, d.sent, d.received])}
+      />
     </ChartCard>
   );
 }
@@ -98,6 +123,11 @@ export function BalanceHistoryChart({ data = [] }) {
           </AreaChart>
         </ResponsiveContainer>
       </div>
+      <DataTable
+        caption="Balance History"
+        headers={['Date', 'Balance (XLM)']}
+        rows={data.map(d => [d.date, d.balance])}
+      />
     </ChartCard>
   );
 }
@@ -137,6 +167,11 @@ export function PortfolioPieChart({ data = [] }) {
           </PieChart>
         </ResponsiveContainer>
       </div>
+      <DataTable
+        caption="Portfolio Breakdown"
+        headers={['Asset', 'Balance (XLM)', 'Share (%)']}
+        rows={data.map(d => [d.asset, d.balance, total > 0 ? ((d.balance / total) * 100).toFixed(2) : '0.00'])}
+      />
     </ChartCard>
   );
 }
@@ -164,6 +199,11 @@ export function TransactionFlowChart({ data = [] }) {
           </LineChart>
         </ResponsiveContainer>
       </div>
+      <DataTable
+        caption="Transaction Flow"
+        headers={['Date', 'Inflow (XLM)', 'Outflow (XLM)']}
+        rows={data.map(d => [d.time, d.inflow, d.outflow])}
+      />
     </ChartCard>
   );
 }

--- a/frontend/src/components/FormWizard.jsx
+++ b/frontend/src/components/FormWizard.jsx
@@ -35,20 +35,38 @@ export function FormWizard({ steps = [], onComplete }) {
 
   return (
     <div>
-      {/* Progress bar */}
-      <div style={{ display: 'flex', gap: 4, marginBottom: 20 }}>
+      {/* Progress indicator — announced to screen readers as a group with step position */}
+      <div
+        role="group"
+        aria-label={t('formWizard.progressLabel', { current: current + 1, total: steps.length })}
+        style={{ display: 'flex', gap: 4, marginBottom: 20 }}
+      >
         {steps.map((s, i) => (
-          <div key={i} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
-            <div style={{
-              width: '100%', height: 4, borderRadius: 2,
-              background: i <= current ? 'var(--primary)' : 'var(--border)',
-              transition: 'background 0.3s',
-            }} />
-            <span style={{ fontSize: 11, color: i === current ? 'var(--primary)' : 'var(--muted)', fontWeight: i === current ? 700 : 400 }}>
+          <div
+            key={i}
+            style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}
+            aria-current={i === current ? 'step' : undefined}
+          >
+            <div
+              role="presentation"
+              style={{
+                width: '100%', height: 4, borderRadius: 2,
+                background: i <= current ? 'var(--primary)' : 'var(--border)',
+                transition: 'background 0.3s',
+              }}
+            />
+            <span
+              style={{ fontSize: 11, color: i === current ? 'var(--primary)' : 'var(--muted)', fontWeight: i === current ? 700 : 400 }}
+              aria-hidden={i !== current ? 'true' : undefined}
+            >
               {s.title}
             </span>
           </div>
         ))}
+      </div>
+      {/* Visually-hidden live region so step changes are announced */}
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {t('formWizard.stepAnnouncement', { title: step.title, current: current + 1, total: steps.length })}
       </div>
 
       {/* Step content */}

--- a/frontend/src/design-system/Modal.jsx
+++ b/frontend/src/design-system/Modal.jsx
@@ -2,7 +2,8 @@ import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 /**
- * Modal — accessible dialog with focus trap and keyboard dismissal.
+ * Modal — accessible dialog with focus trap, keyboard dismissal,
+ * and focus restoration to the triggering element on close.
  *
  * @param {boolean} open
  * @param {() => void} onClose
@@ -11,10 +12,17 @@ import { createPortal } from 'react-dom';
  */
 export function Modal({ open, onClose, title, size = 'md', children }) {
   const dialogRef = useRef(null);
+  // Capture the element that had focus when the modal opened so we can
+  // return focus to it when the modal closes (WCAG 2.1 SC 2.4.3).
+  const triggerRef = useRef(null);
 
-  // Focus trap + ESC to close
+  // Focus trap + ESC to close + focus restoration
   useEffect(() => {
     if (!open) return;
+
+    // Remember who triggered the modal before we move focus away.
+    triggerRef.current = document.activeElement;
+
     const el = dialogRef.current;
     el?.focus();
 
@@ -22,7 +30,12 @@ export function Modal({ open, onClose, title, size = 'md', children }) {
       if (e.key === 'Escape') onClose();
     };
     document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      // Restore focus to the triggering element when the modal unmounts.
+      triggerRef.current?.focus();
+      triggerRef.current = null;
+    };
   }, [open, onClose]);
 
   if (!open) return null;

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -248,6 +248,17 @@
   "chartsDashboard": {
     "empty": "No data yet. Create an account and make transactions to see charts."
   },
+  "wsStatus": {
+    "label": "حالة WebSocket: {{status}}",
+    "connected": "متصل",
+    "disconnected": "غير متصل",
+    "reconnecting": "جارٍ إعادة الاتصال…",
+    "failed": "فُقد الاتصال"
+  },
+  "formWizard": {
+    "progressLabel": "الخطوة {{current}} من {{total}}",
+    "stepAnnouncement": "{{title}}، الخطوة {{current}} من {{total}}"
+  },
   "inlineConfirmation": {
     "ariaLabel": "Confirm clear form"
   },

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -149,6 +149,17 @@
   "chartsDashboard": {
     "empty": "No data yet. Create an account and make transactions to see charts."
   },
+  "wsStatus": {
+    "label": "WebSocket status: {{status}}",
+    "connected": "Connected",
+    "disconnected": "Disconnected",
+    "reconnecting": "Reconnecting…",
+    "failed": "Connection lost"
+  },
+  "formWizard": {
+    "progressLabel": "Step {{current}} of {{total}}",
+    "stepAnnouncement": "{{title}}, step {{current}} of {{total}}"
+  },
   "inlineConfirmation": {
     "ariaLabel": "Confirm clear form"
   },

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -117,6 +117,17 @@
   "chartsDashboard": {
     "empty": "No data yet. Create an account and make transactions to see charts."
   },
+  "wsStatus": {
+    "label": "Estado de WebSocket: {{status}}",
+    "connected": "Conectado",
+    "disconnected": "Desconectado",
+    "reconnecting": "Reconectando…",
+    "failed": "Conexión perdida"
+  },
+  "formWizard": {
+    "progressLabel": "Paso {{current}} de {{total}}",
+    "stepAnnouncement": "{{title}}, paso {{current}} de {{total}}"
+  },
   "inlineConfirmation": {
     "ariaLabel": "Confirm clear form"
   },

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -149,6 +149,17 @@
   "chartsDashboard": {
     "empty": "No data yet. Create an account and make transactions to see charts."
   },
+  "wsStatus": {
+    "label": "Statut WebSocket : {{status}}",
+    "connected": "Connecté",
+    "disconnected": "Déconnecté",
+    "reconnecting": "Reconnexion…",
+    "failed": "Connexion perdue"
+  },
+  "formWizard": {
+    "progressLabel": "Étape {{current}} sur {{total}}",
+    "stepAnnouncement": "{{title}}, étape {{current}} sur {{total}}"
+  },
   "inlineConfirmation": {
     "ariaLabel": "Confirm clear form"
   },

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -117,6 +117,17 @@
   "chartsDashboard": {
     "empty": "No data yet. Create an account and make transactions to see charts."
   },
+  "wsStatus": {
+    "label": "סטטוס WebSocket: {{status}}",
+    "connected": "מחובר",
+    "disconnected": "מנותק",
+    "reconnecting": "מתחבר מחדש…",
+    "failed": "החיבור אבד"
+  },
+  "formWizard": {
+    "progressLabel": "שלב {{current}} מתוך {{total}}",
+    "stepAnnouncement": "{{title}}, שלב {{current}} מתוך {{total}}"
+  },
   "inlineConfirmation": {
     "ariaLabel": "Confirm clear form"
   },

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -149,6 +149,17 @@
   "chartsDashboard": {
     "empty": "No data yet. Create an account and make transactions to see charts."
   },
+  "wsStatus": {
+    "label": "Status do WebSocket: {{status}}",
+    "connected": "Conectado",
+    "disconnected": "Desconectado",
+    "reconnecting": "Reconectando…",
+    "failed": "Conexão perdida"
+  },
+  "formWizard": {
+    "progressLabel": "Passo {{current}} de {{total}}",
+    "stepAnnouncement": "{{title}}, passo {{current}} de {{total}}"
+  },
   "inlineConfirmation": {
     "ariaLabel": "Confirm clear form"
   },

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -149,6 +149,17 @@
   "chartsDashboard": {
     "empty": "No data yet. Create an account and make transactions to see charts."
   },
+  "wsStatus": {
+    "label": "WebSocket 状态：{{status}}",
+    "connected": "已连接",
+    "disconnected": "已断开",
+    "reconnecting": "重新连接中…",
+    "failed": "连接丢失"
+  },
+  "formWizard": {
+    "progressLabel": "第 {{current}} 步，共 {{total}} 步",
+    "stepAnnouncement": "{{title}}，第 {{current}} 步，共 {{total}} 步"
+  },
   "inlineConfirmation": {
     "ariaLabel": "Confirm clear form"
   },


### PR DESCRIPTION
## Summary

This PR addresses four accessibility and i18n issues across the frontend.

---

### Closes #936 - ChartsDashboard: accessible data-table alternatives

Each recharts-based chart in Charts.jsx (TransactionVolumeChart, BalanceHistoryChart, PortfolioPieChart, TransactionFlowChart) now renders a visually-hidden <table> alongside the visual chart. Screen readers can traverse the full dataset in tabular form without relying on the SVG.

---

### Closes #937 - FormWizard step progress indicator not announced

The progress bar wrapper in FormWizard.jsx now carries 
ole="group" and ria-label expressing the current step position (e.g. "Step 2 of 4"). Each active step gets ria-current="step". A ria-live="polite" region announces the new step title whenever the user navigates forward or back. Translations for ormWizard.progressLabel and ormWizard.stepAnnouncement are added to all 7 locale files.

---

### Closes #938 - Modal does not restore focus on close

Modal.jsx now captures document.activeElement into a ref before moving focus into the dialog. When the effect cleanup runs (on close or unmount), focus is returned to that element, completing the expected WCAG dialog focus-management cycle.

---

### Closes #939 - WebSocket connection status not localized

The raw wsStatus string and hard-coded 'Connection lost' copy in App.jsx are replaced with 	('wsStatus.<state>') lookups. A new wsStatus key group (connected, disconnected, 
econnecting, ailed, and the label template) has been added to all 7 locale files (en, es, fr, pt, ar, he, zh).