### PR TITLE
fix: ARIA semantics, i18n gaps, dynamic assets, stellar.js dedup (#94…

### DIFF
--- a/backend/src/services/stellar.js
+++ b/backend/src/services/stellar.js
@@ -5,7 +5,6 @@ import { getConfig } from '../config/env.js';
 import { getIssuer } from '../config/assets.js';
 import logger, { withContext } from '../config/logger.js';
 import prisma from '../db/client.js';
-import { getIssuer } from '../config/assets.js';
 import { callWithCircuitBreaker } from './circuitBreaker.js';
 import { getCachedBalance, invalidateBalanceCache } from '../cache/balanceCache.js';
 import { recordHorizonCall } from '../monitoring/horizonAlerter.js';
@@ -214,12 +213,6 @@ export async function createAccount(correlationId = null) {
     withContext(logger, { action: 'createAccount', correlationId }).info('stellar.createAccount', {
       publicKey,
     });
-  const pair = StellarSDK.Keypair.random();
-  const publicKey = pair.publicKey();
-  logger.info('stellar.createAccount', { publicKey });
-  withContext(logger, { action: 'createAccount', correlationId }).info('stellar.createAccount', {
-    publicKey,
-  });
 
     if (isTestnet()) {
       const friendbotRes = await fetch(`https://friendbot.stellar.org?addr=${publicKey}`);
@@ -249,18 +242,6 @@ export async function createAccount(correlationId = null) {
         create: { publicKey },
       })
       .catch((err) => logger.warn('db.user.upsert.failed', { error: err.message, correlationId }));
-  await prisma.user.upsert({
-    where: { publicKey },
-    update: {},
-    create: { publicKey },
-  }).catch(err => logger.warn('db.user.upsert.failed', { error: err.message }));
-  await prisma.user
-    .upsert({
-      where: { publicKey },
-      update: {},
-      create: { publicKey },
-    })
-    .catch((err) => logger.warn('db.user.upsert.failed', { error: err.message, correlationId }));
 
     return {
       publicKey,
@@ -269,19 +250,6 @@ export async function createAccount(correlationId = null) {
   });
 }
 
-export async function getBalance(publicKey) {
-  logger.debug('stellar.getBalance', { publicKey });
-  const account = await getHorizonServer().loadAccount(publicKey);
-  const balances = account.balances.map(b => ({
-    asset: b.asset_type === 'native' ? 'XLM' : `${b.asset_code}:${b.asset_issuer}`,
-    balance: b.balance
-  }));
-
-  logger.info('stellar.balanceFetched', { publicKey, balances });
-  await eventMonitor.publishEvent(publicKey, {
-    type: 'BalanceChecked',
-    data: { balances },
-    version: 1
 /**
  * Fetch all asset balances for a Stellar account from Horizon.
  * @param {string} publicKey - Stellar public key of the account
@@ -335,7 +303,6 @@ export async function sendPayment(
   // engineers can filter the full lifecycle with a single query.
   const txCorrelationId = correlationId ?? randomUUID();
 
-  const { assetIssuer } = getConfig().stellar;
   const sourceKeypair = StellarSDK.Keypair.fromSecret(sourceSecret);
   const sourcePublicKey = sourceKeypair.publicKey();
   logger.info('stellar.sendPayment.start', {
@@ -348,29 +315,6 @@ export async function sendPayment(
     correlationId: txCorrelationId,
   });
 
-  const sourceAccount = await getHorizonServer().loadAccount(sourcePublicKey);
-
-  if (assetCode !== 'XLM' && !assetIssuer) {
-    throw new Error('ASSET_ISSUER is required for non-XLM payments');
-  }
-
-  const asset = assetCode === 'XLM'
-    ? StellarSDK.Asset.native()
-    : new StellarSDK.Asset(assetCode, getIssuer(assetCode));
-
-  const transaction = new StellarSDK.TransactionBuilder(sourceAccount, {
-    fee: StellarSDK.BASE_FEE,
-    networkPassphrase: isTestnet()
-      ? StellarSDK.Networks.TESTNET
-      : StellarSDK.Networks.PUBLIC
-  })
-    .addOperation(StellarSDK.Operation.payment({
-      destination,
-      asset,
-      amount: amount.toString()
-    }))
-    .setTimeout(30)
-    .build();
   // Sequence Numbers
   // loadAccount fetches the current on-chain sequence number for the source account.
   // Every Stellar transaction must include a sequence number exactly one greater than
@@ -454,7 +398,6 @@ export async function sendPayment(
 
   let result;
   try {
-    result = await getHorizonServer().submitTransaction(transaction);
     result = await withHorizonRetry(() => getHorizonServer().submitTransaction(txToSubmit));
   } catch (err) {
     logger.error('stellar.sendPayment.failed', {
@@ -497,24 +440,6 @@ export async function sendPayment(
     version: 1,
   });
 
-  // Persist transaction — ensure both users exist first
-  await prisma.$transaction(async (tx) => {
-    const [sender, recipient] = await Promise.all([
-      tx.user.upsert({ where: { publicKey: sourcePublicKey }, update: {}, create: { publicKey: sourcePublicKey } }),
-      tx.user.upsert({ where: { publicKey: destination },    update: {}, create: { publicKey: destination } }),
-    ]);
-    await tx.transaction.create({
-      data: {
-        hash: result.hash,
-        assetCode: assetCode || 'XLM',
-        amount,
-        ledger: result.ledger ?? null,
-        successful: result.successful,
-        senderId: sender.id,
-        recipientId: recipient.id,
-      },
-    });
-  }).catch(err => logger.warn('db.transaction.save.failed', { error: err.message }));
   await prisma
     .$transaction(async (tx) => {
       const [sender, recipient] = await Promise.all([
@@ -632,7 +557,6 @@ export async function createTrustline(sourceSecret, assetCode) {
   return { hash: result.hash, assetCode, issuer };
 }
 
-export async function getTransactions(publicKey, { cursor, limit = 10, type, dateFrom, dateTo } = {}) {
 /**
  * Remove an existing trustline from an account. The asset balance must be zero.
  * @param {string} sourceSecret - Secret key of the account removing the trustline
@@ -786,7 +710,7 @@ export async function getTransactions(
 /**
  * Retrieve current network fee statistics from Horizon with an XLM/USD conversion via the SDEX.
  * @returns {Promise<{feeStroops: number, feeXLM: string, feeUsd: string|null, xlmUsd: string|null,
- *   traditionalFeeUsd: number, baseFeeStroops: number, baseFeeXLM: string, surgeMultiplier: string}>}
+ *   traditionalFeeUsd: number}>}
  * @throws {Error} If the Horizon feeStats call fails
  */
 export async function getFeeStats() {
@@ -806,28 +730,6 @@ export async function getFeeStats() {
     } catch (_) {
       /* non-critical: XLM/USD price lookup failure */
     }
-  const stats = await getHorizonServer().feeStats();
-  const stats = await withHorizonRetry(() => getHorizonServer().feeStats());
-  const baseFeeStroops = parseInt(stats.last_ledger_base_fee ?? StellarSDK.BASE_FEE);
-  const feeStroops = parseInt(stats.fee_charged?.mode ?? stats.fee_charged?.p50 ?? StellarSDK.BASE_FEE);
-  const feeXLM = feeStroops / 1e7;
-  const baseFeeXLM = baseFeeStroops / 1e7;
-  const surgeMultiplier = baseFeeStroops > 0 ? feeStroops / baseFeeStroops : 1;
-
-  // Fetch XLM/USD price via Stellar SDEX (XLM/USDC order book)
-  let xlmUsd = null;
-  try {
-    const usdc = new StellarSDK.Asset('USDC', 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN');
-    const book = await getHorizonServer().orderbook(StellarSDK.Asset.native(), usdc).limit(1).call();
-    const usdc = new StellarSDK.Asset('USDC', getIssuer('USDC'));
-    const book = await withHorizonRetry(() =>
-      getHorizonServer().orderbook(StellarSDK.Asset.native(), usdc).limit(1).call(),
-    );
-    const ask = parseFloat(book.asks?.[0]?.price);
-    if (ask > 0) xlmUsd = ask;
-  } catch (_) {
-    /* non-critical: XLM/USD price lookup failure */
-  }
 
     const feeUsd = xlmUsd ? feeXLM * xlmUsd : null;
 
@@ -839,17 +741,6 @@ export async function getFeeStats() {
       traditionalFeeUsd: 25,
     };
   });
-  return {
-    feeStroops,
-    feeXLM: feeXLM.toFixed(7),
-    feeUsd: feeUsd ? feeUsd.toFixed(6) : null,
-    xlmUsd: xlmUsd ? xlmUsd.toFixed(4) : null,
-    // Traditional wire transfer benchmark for comparison
-    traditionalFeeUsd: 25,
-    baseFeeStroops,
-    baseFeeXLM: baseFeeXLM.toFixed(7),
-    surgeMultiplier: surgeMultiplier.toFixed(2),
-  };
 }
 
 export async function getTransactionHistory(publicKey, { limit = 10, cursor } = {}) {
@@ -881,9 +772,6 @@ export async function getTransactionHistory(publicKey, { limit = 10, cursor } = 
 export async function getExchangeRate(from, to) {
   if (from === to) return 1.0;
   try {
-    const fromAsset = from === 'XLM' ? StellarSDK.Asset.native() : new StellarSDK.Asset(from, getIssuer(from));
-    const toAsset   = to   === 'XLM' ? StellarSDK.Asset.native() : new StellarSDK.Asset(to,   getIssuer(to));
-    const orderbook = await getHorizonServer().orderbook(fromAsset, toAsset).call();
     const fromAsset =
       from === 'XLM' ? StellarSDK.Asset.native() : new StellarSDK.Asset(from, getIssuer(from));
     const toAsset =
@@ -928,29 +816,6 @@ export async function getNetworkStatus() {
       };
     }
   });
-  const { horizonUrl } = getConfig().stellar;
-  try {
-    const root = await withHorizonRetry(() => getHorizonServer().root());
-    const status = {
-      network: isTestnet() ? 'testnet' : 'mainnet',
-      horizonUrl,
-      online: true,
-      horizonVersion: root.horizon_version,
-      networkPassphrase: root.network_passphrase,
-      currentProtocolVersion: root.current_protocol_version,
-      latencyMs: getLastHorizonLatency()?.latencyMs ?? null,
-    };
-    logger.debug('stellar.networkStatus', status);
-    return status;
-  } catch (err) {
-    logger.warn('stellar.networkStatus.offline', { error: err.message });
-    return {
-      network: isTestnet() ? 'testnet' : 'mainnet',
-      horizonUrl,
-      online: false,
-      latencyMs: null,
-    };
-  }
 }
 
 // Horizon latency monitor: pings the Horizon root endpoint on an interval
@@ -988,6 +853,8 @@ export function startHorizonLatencyMonitor(intervalMs = LATENCY_PING_INTERVAL_MS
 export function stopHorizonLatencyMonitor() {
   if (latencyPingTimer) clearInterval(latencyPingTimer);
   latencyPingTimer = null;
+}
+
 /**
  * List all non-native trustlines held by an account.
  * @param {string} publicKey - Stellar public key of the account
@@ -1071,17 +938,6 @@ export async function mergeAccount(sourceSecret, destination) {
 }
 
 /**
- * Build an unsigned XDR transaction envelope for a payment without submitting it to the network.
- * Useful for multisig workflows and hardware wallet signing.
- * @param {string} sourceSecret - Secret key of the source account (for sequence number)
- * @param {string} destination - Stellar public key of the recipient
- * @param {string} amount - Amount in stroops
- * @param {string} assetCode - Asset code (default: 'XLM')
- * @param {string} memo - Optional memo
- * @param {string} memoType - Type of memo ('text', 'id', 'hash', 'return')
- * @returns {Promise<{xdr: string}>} Base64-encoded unsigned transaction envelope
- */
-/**
  * Simulate an account merge operation to show expected outcomes
  * @param {string} sourcePublicKey - Public key of source account
  * @param {string} destinationPublicKey - Public key of destination account
@@ -1109,6 +965,17 @@ export async function simulateMergeAccount(sourcePublicKey, destinationPublicKey
   };
 }
 
+/**
+ * Build an unsigned XDR transaction envelope for a payment without submitting it to the network.
+ * Useful for multisig workflows and hardware wallet signing.
+ * @param {string} sourceSecret - Secret key of the source account (for sequence number)
+ * @param {string} destination - Stellar public key of the recipient
+ * @param {string} amount - Amount in stroops
+ * @param {string} assetCode - Asset code (default: 'XLM')
+ * @param {string} memo - Optional memo
+ * @param {string} memoType - Type of memo ('text', 'id', 'hash', 'return')
+ * @returns {Promise<{xdr: string}>} Base64-encoded unsigned transaction envelope
+ */
 export async function buildUnsignedXdr(
   sourceSecret,
   destination,

--- a/frontend/src/components/AmountInput.jsx
+++ b/frontend/src/components/AmountInput.jsx
@@ -1,16 +1,37 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatAssetAmount, normalizeAmountInput } from '../utils/formatAmount';
 
 const CURRENCIES = { XLM: 'Stellar Lumens', USDC: 'USD Coin', BTC: 'Bitcoin' };
 
+// Default fallback assets for callers that don't pass availableAssets
+const DEFAULT_ASSETS = [
+  { code: 'XLM', name: 'Stellar Lumens' },
+  { code: 'USDC', name: 'USD Coin' },
+  { code: 'BTC', name: 'Bitcoin' },
+];
+
 /**
  * AmountInput — numeric input with currency selector and live formatting.
- * Props: value, onChange, currency, onCurrencyChange, availableBalance
+ * Props: value, onChange, currency, onCurrencyChange, availableBalance,
+ *        availableAssets – array of { code, issuer?, balance?, name? }
+ *          When provided, the currency selector is populated from this list
+ *          instead of the hardcoded CURRENCIES constant, ensuring users can
+ *          only select assets they actually hold a trustline for.
+ *          Defaults to the static three-asset list for backward compatibility.
  */
-export function AmountInput({ value, onChange, currency = 'XLM', onCurrencyChange, availableBalance }) {
+export function AmountInput({ value, onChange, currency = 'XLM', onCurrencyChange, availableBalance, availableAssets }) {
   const { t, i18n } = useTranslation();
   const [focused, setFocused] = useState(false);
+
+  // Derive the asset list: use availableAssets prop when supplied,
+  // otherwise fall back to the static default list for backward compatibility.
+  const assetOptions = useMemo(() => {
+    if (availableAssets && availableAssets.length > 0) {
+      return availableAssets.map(a => ({ code: a.code, label: a.name ?? a.code }));
+    }
+    return DEFAULT_ASSETS.map(a => ({ code: a.code, label: a.name }));
+  }, [availableAssets]);
 
   const handleChange = (e) => {
     // Accept the locale's decimal separator (e.g. ',' in fr-FR) and
@@ -62,8 +83,8 @@ export function AmountInput({ value, onChange, currency = 'XLM', onCurrencyChang
         style={selectStyle}
         aria-label={t('amountInput.currency')}
       >
-        {Object.entries(CURRENCIES).map(([code, name]) => (
-          <option key={code} value={code} title={name}>{code}</option>
+        {assetOptions.map(({ code, label }) => (
+          <option key={code} value={code} title={label}>{code}</option>
         ))}
       </select>
     </div>

--- a/frontend/src/components/MultiSigTransactions.jsx
+++ b/frontend/src/components/MultiSigTransactions.jsx
@@ -6,18 +6,29 @@ import { FormField } from './FormField';
 import { Spinner } from './Spinner';
 import { StatusMessage } from './StatusMessage';
 
-const STATUS_BADGE = {
-  PENDING:   { label: 'Pending', color: 'var(--warning)' },
-  SUBMITTED: { label: 'Submitted', color: 'var(--success)' },
-  FAILED:    { label: 'Failed', color: 'var(--danger)' },
-  EXPIRED:   { label: 'Expired', color: 'var(--muted)' },
+const STATUS_BADGE_COLOR = {
+  PENDING:   'var(--warning)',
+  SUBMITTED: 'var(--success)',
+  FAILED:    'var(--danger)',
+  EXPIRED:   'var(--muted)',
 };
 
+function getStatusLabel(status, t) {
+  switch (status) {
+    case 'PENDING':   return t('multiSig.status.pending');
+    case 'SUBMITTED': return t('multiSig.status.submitted');
+    case 'FAILED':    return t('multiSig.status.failed');
+    case 'EXPIRED':   return t('multiSig.status.expired');
+    default:          return t('multiSig.status.unknown', { status });
+  }
+}
+
 function StatusBadge({ status }) {
-  const badge = STATUS_BADGE[status] ?? { label: status, color: 'var(--muted)' };
+  const { t } = useTranslation();
+  const color = STATUS_BADGE_COLOR[status] ?? 'var(--muted)';
   return (
-    <span style={{ background: badge.color, color: 'var(--on-primary)', borderRadius: 4, padding: '2px 8px', fontSize: '0.75rem', fontWeight: 600 }}>
-      {badge.label}
+    <span style={{ background: color, color: 'var(--on-primary)', borderRadius: 4, padding: '2px 8px', fontSize: '0.75rem', fontWeight: 600 }}>
+      {getStatusLabel(status, t)}
     </span>
   );
 }

--- a/frontend/src/components/VirtualList.jsx
+++ b/frontend/src/components/VirtualList.jsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback, useEffect, useMemo } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { useTranslation } from 'react-i18next';
 
 // ─── Shared ───────────────────────────────────────────────────────────────────
 
@@ -45,6 +46,7 @@ function useListPerf(label = 'VirtualList') {
  *   height       – container height in px (default 480)
  *   overscan     – extra rows to render outside viewport (default 5)
  *   emptyState   – JSX shown when items is empty
+ *   ariaLabel    – accessible label for the list (e.g. "Transaction list, 500 items")
  *   showPerf     – show perf overlay (dev only)
  */
 export function VirtualList({
@@ -54,8 +56,10 @@ export function VirtualList({
   height = 480,
   overscan = 5,
   emptyState,
+  ariaLabel,
   showPerf = false,
 }) {
+  const { t } = useTranslation();
   const parentRef = useRef(null);
   const perf = useListPerf('VirtualList');
 
@@ -67,16 +71,26 @@ export function VirtualList({
   });
 
   if (items.length === 0) {
-    return emptyState ?? <div style={emptyStyle}>No items to display.</div>;
+    return emptyState ?? <div style={emptyStyle}>{t('virtualList.emptyDefault')}</div>;
   }
+
+  const listLabel = ariaLabel ?? t('virtualList.listLabel', { count: items.length });
 
   return (
     <div style={{ position: 'relative' }}>
-      <div ref={parentRef} style={{ height, overflowY: 'auto', ...scrollStyle }}>
+      <div
+        ref={parentRef}
+        role="list"
+        aria-label={listLabel}
+        style={{ height, overflowY: 'auto', ...scrollStyle }}
+      >
         <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
           {virtualizer.getVirtualItems().map(vRow => (
             <div
               key={vRow.key}
+              role="listitem"
+              aria-setsize={items.length}
+              aria-posinset={vRow.index + 1}
               data-index={vRow.index}
               ref={virtualizer.measureElement}
               style={{
@@ -93,7 +107,7 @@ export function VirtualList({
         </div>
       </div>
       {showPerf && (
-        <div style={perfOverlayStyle}>
+        <div style={perfOverlayStyle} aria-hidden="true">
           renders: {perf.renders} | last: {perf.lastMs.toFixed(1)}ms | visible: {virtualizer.getVirtualItems().length}/{items.length}
         </div>
       )}
@@ -165,8 +179,10 @@ export function InfiniteVirtualList({
   overscan = 5,
   renderItem,
   emptyState,
+  ariaLabel,
   showPerf = false,
 }) {
+  const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const parentRef = useRef(null);
   const perf = useListPerf('InfiniteVirtualList');
@@ -192,16 +208,26 @@ export function InfiniteVirtualList({
   }, [virtualizer.getVirtualItems(), hasMore, loading, items.length, onLoadMore]);
 
   if (items.length === 0 && !hasMore) {
-    return emptyState ?? <div style={emptyStyle}>No items to display.</div>;
+    return emptyState ?? <div style={emptyStyle}>{t('virtualList.emptyDefault')}</div>;
   }
+
+  const listLabel = ariaLabel ?? t('virtualList.listLabel', { count: items.length });
 
   return (
     <div style={{ position: 'relative' }}>
-      <div ref={parentRef} style={{ height, overflowY: 'auto', ...scrollStyle }}>
+      <div
+        ref={parentRef}
+        role="list"
+        aria-label={listLabel}
+        style={{ height, overflowY: 'auto', ...scrollStyle }}
+      >
         <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
           {virtualizer.getVirtualItems().map(vRow => (
             <div
               key={vRow.key}
+              role="listitem"
+              aria-setsize={items.length}
+              aria-posinset={vRow.index + 1}
               data-index={vRow.index}
               ref={virtualizer.measureElement}
               style={{
@@ -218,7 +244,7 @@ export function InfiniteVirtualList({
         </div>
       </div>
       {showPerf && (
-        <div style={perfOverlayStyle}>
+        <div style={perfOverlayStyle} aria-hidden="true">
           renders: {perf.renders} | visible: {virtualizer.getVirtualItems().length}/{count} | {loading ? 'loading…' : 'idle'}
         </div>
       )}
@@ -238,6 +264,8 @@ export function InfiniteVirtualList({
  *   height       – container height (default 480)
  */
 export function TransactionList({ transactions = [], hasMore, onLoadMore, height = 480 }) {
+  const { t } = useTranslation();
+
   const renderItem = useCallback((tx) => (
     <div style={txRowStyle}>
       <span style={{ fontSize: 18 }}>{tx.type === 'received' ? '📥' : '📤'}</span>
@@ -268,7 +296,8 @@ export function TransactionList({ transactions = [], hasMore, onLoadMore, height
       height={height}
       hasMore={hasMore}
       onLoadMore={onLoadMore}
-      emptyState={<div style={emptyStyle}>No transactions yet.</div>}
+      ariaLabel={t('virtualList.transactionListLabel', { count: transactions.length })}
+      emptyState={<div style={emptyStyle}>{t('virtualList.noTransactions')}</div>}
     />
   );
 }

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -440,7 +440,14 @@
     "amountLabel": "Amount:",
     "signaturesLabel": "Signatures:",
     "txIdLabel": "txId:",
-    "submitTransaction": "Submit Transaction"
+    "submitTransaction": "Submit Transaction",
+    "status": {
+      "pending": "قيد الانتظار",
+      "submitted": "مُرسَل",
+      "failed": "فشل",
+      "expired": "منتهي الصلاحية",
+      "unknown": "{{status}}"
+    }
   },
   "notificationPermission": {
     "enabled": "✅ Push notifications enabled for incoming payments",
@@ -653,6 +660,12 @@
     "anyoneStrong": "Anyone with this key",
     "anyoneRest": "can access and transfer all your funds",
     "acknowledge": "I Understand the Risks"
+  },
+  "virtualList": {
+    "emptyDefault": "لا توجد عناصر للعرض.",
+    "listLabel": "قائمة، {{count}} عناصر",
+    "transactionListLabel": "قائمة المعاملات، {{count}} معاملة",
+    "noTransactions": "لا توجد معاملات بعد."
   },
   "secretKeyDisplay": {
     "publicKeyLabel": "Public Key (safe to share)",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -386,7 +386,14 @@
     "amountLabel": "Amount:",
     "signaturesLabel": "Signatures:",
     "txIdLabel": "txId:",
-    "submitTransaction": "Submit Transaction"
+    "submitTransaction": "Submit Transaction",
+    "status": {
+      "pending": "Pending",
+      "submitted": "Submitted",
+      "failed": "Failed",
+      "expired": "Expired",
+      "unknown": "{{status}}"
+    }
   },
   "notificationPermission": {
     "enabled": "✅ Push notifications enabled for incoming payments",
@@ -599,6 +606,12 @@
     "anyoneStrong": "Anyone with this key",
     "anyoneRest": "can access and transfer all your funds",
     "acknowledge": "I Understand the Risks"
+  },
+  "virtualList": {
+    "emptyDefault": "No items to display.",
+    "listLabel": "List, {{count}} items",
+    "transactionListLabel": "Transaction list, {{count}} items",
+    "noTransactions": "No transactions yet."
   },
   "secretKeyDisplay": {
     "publicKeyLabel": "Public Key (safe to share)",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -386,7 +386,14 @@
     "amountLabel": "Amount:",
     "signaturesLabel": "Signatures:",
     "txIdLabel": "txId:",
-    "submitTransaction": "Submit Transaction"
+    "submitTransaction": "Submit Transaction",
+    "status": {
+      "pending": "Pendiente",
+      "submitted": "Enviado",
+      "failed": "Fallido",
+      "expired": "Expirado",
+      "unknown": "{{status}}"
+    }
   },
   "notificationPermission": {
     "enabled": "✅ Push notifications enabled for incoming payments",
@@ -599,6 +606,12 @@
     "anyoneStrong": "Anyone with this key",
     "anyoneRest": "can access and transfer all your funds",
     "acknowledge": "I Understand the Risks"
+  },
+  "virtualList": {
+    "emptyDefault": "No hay elementos para mostrar.",
+    "listLabel": "Lista, {{count}} elementos",
+    "transactionListLabel": "Lista de transacciones, {{count}} transacciones",
+    "noTransactions": "Aún no hay transacciones."
   },
   "secretKeyDisplay": {
     "publicKeyLabel": "Public Key (safe to share)",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -386,7 +386,14 @@
     "amountLabel": "Amount:",
     "signaturesLabel": "Signatures:",
     "txIdLabel": "txId:",
-    "submitTransaction": "Submit Transaction"
+    "submitTransaction": "Submit Transaction",
+    "status": {
+      "pending": "En attente",
+      "submitted": "Soumis",
+      "failed": "Échoué",
+      "expired": "Expiré",
+      "unknown": "{{status}}"
+    }
   },
   "notificationPermission": {
     "enabled": "✅ Push notifications enabled for incoming payments",
@@ -599,6 +606,12 @@
     "anyoneStrong": "Anyone with this key",
     "anyoneRest": "can access and transfer all your funds",
     "acknowledge": "I Understand the Risks"
+  },
+  "virtualList": {
+    "emptyDefault": "Aucun élément à afficher.",
+    "listLabel": "Liste, {{count}} éléments",
+    "transactionListLabel": "Liste des transactions, {{count}} transactions",
+    "noTransactions": "Aucune transaction pour l'instant."
   },
   "secretKeyDisplay": {
     "publicKeyLabel": "Public Key (safe to share)",

--- a/frontend/src/i18n/locales/he.json
+++ b/frontend/src/i18n/locales/he.json
@@ -386,7 +386,14 @@
     "amountLabel": "Amount:",
     "signaturesLabel": "Signatures:",
     "txIdLabel": "txId:",
-    "submitTransaction": "Submit Transaction"
+    "submitTransaction": "Submit Transaction",
+    "status": {
+      "pending": "ממתין",
+      "submitted": "נשלח",
+      "failed": "נכשל",
+      "expired": "פג תוקף",
+      "unknown": "{{status}}"
+    }
   },
   "notificationPermission": {
     "enabled": "✅ Push notifications enabled for incoming payments",
@@ -599,6 +606,12 @@
     "anyoneStrong": "Anyone with this key",
     "anyoneRest": "can access and transfer all your funds",
     "acknowledge": "I Understand the Risks"
+  },
+  "virtualList": {
+    "emptyDefault": "אין פריטים להצגה.",
+    "listLabel": "רשימה, {{count}} פריטים",
+    "transactionListLabel": "רשימת עסקאות, {{count}} עסקאות",
+    "noTransactions": "אין עסקאות עדיין."
   },
   "secretKeyDisplay": {
     "publicKeyLabel": "Public Key (safe to share)",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -386,7 +386,14 @@
     "amountLabel": "Amount:",
     "signaturesLabel": "Signatures:",
     "txIdLabel": "txId:",
-    "submitTransaction": "Submit Transaction"
+    "submitTransaction": "Submit Transaction",
+    "status": {
+      "pending": "Pendente",
+      "submitted": "Enviado",
+      "failed": "Falhou",
+      "expired": "Expirado",
+      "unknown": "{{status}}"
+    }
   },
   "notificationPermission": {
     "enabled": "✅ Push notifications enabled for incoming payments",
@@ -599,6 +606,12 @@
     "anyoneStrong": "Anyone with this key",
     "anyoneRest": "can access and transfer all your funds",
     "acknowledge": "I Understand the Risks"
+  },
+  "virtualList": {
+    "emptyDefault": "Nenhum item para exibir.",
+    "listLabel": "Lista, {{count}} itens",
+    "transactionListLabel": "Lista de transações, {{count}} transações",
+    "noTransactions": "Nenhuma transação ainda."
   },
   "secretKeyDisplay": {
     "publicKeyLabel": "Public Key (safe to share)",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -386,7 +386,14 @@
     "amountLabel": "Amount:",
     "signaturesLabel": "Signatures:",
     "txIdLabel": "txId:",
-    "submitTransaction": "Submit Transaction"
+    "submitTransaction": "Submit Transaction",
+    "status": {
+      "pending": "待处理",
+      "submitted": "已提交",
+      "failed": "失败",
+      "expired": "已过期",
+      "unknown": "{{status}}"
+    }
   },
   "notificationPermission": {
     "enabled": "✅ Push notifications enabled for incoming payments",
@@ -599,6 +606,12 @@
     "anyoneStrong": "Anyone with this key",
     "anyoneRest": "can access and transfer all your funds",
     "acknowledge": "I Understand the Risks"
+  },
+  "virtualList": {
+    "emptyDefault": "没有可显示的项目。",
+    "listLabel": "列表，{{count}} 项",
+    "transactionListLabel": "交易列表，{{count}} 笔交易",
+    "noTransactions": "暂无交易记录。"
   },
   "secretKeyDisplay": {
     "publicKeyLabel": "Public Key (safe to share)",


### PR DESCRIPTION
…0 #941 #942 #943)

#941 — VirtualList ARIA list semantics
- Add role="list" + aria-label (ariaLabel prop, falls back to virtualList.listLabel translation) to the scroll container in VirtualList and InfiniteVirtualList
- Add role="listitem", aria-setsize={items.length}, and aria-posinset={index + 1} to every virtualized row
- TransactionList passes a translated ariaLabel describing total count
- perfOverlay gets aria-hidden="true" so it is invisible to AT

#940 — VirtualList empty state and MultiSigTransactions status badges
- Import useTranslation into VirtualList; replace hardcoded 'No items to display.' fallback with t('virtualList.emptyDefault')
- Add virtualList.* keys (emptyDefault, listLabel, transactionListLabel, noTransactions) to all 7 locale files
- Replace MultiSigTransactions static STATUS_BADGE label map with getStatusLabel(status, t) that resolves t('multiSig.status.*') at render time; StatusBadge now calls useTranslation itself
- Add multiSig.status.{pending,submitted,failed,expired,unknown} to all 7 locale files (ar/es/fr/he/pt/zh translated, en authoritative)

#942 — AmountInput dynamic asset list
- Add availableAssets prop (array of {code, issuer?, balance?, name?}) to AmountInput; when supplied, the currency <select> is populated from this list instead of the hardcoded CURRENCIES constant
- Existing callers that omit availableAssets continue to see the static XLM/USDC/BTC fallback — fully backward compatible
- CURRENCIES constant retained as documentation; DEFAULT_ASSETS drives the fallback rendering path

#943 — backend/src/services/stellar.js merge-conflict deduplication
- Remove duplicate import { getIssuer }
- createAccount: remove orphaned const pair / logger.info / prisma.user.upsert blocks; keep withSpan version with correlationId
- getBalance: remove bare first export; keep withSpan / getCachedBalance / withHorizonRetry / correlationId version
- getTransactions: remove body-less first export; keep full version with withHorizonRetry and date/type filtering
- sendPayment: remove first loadAccount, first asset/txBuilder block, raw submitTransaction call, and first prisma.; keep withHorizonRetry / memo / feeBump versions throughout
- getFeeStats: keep withSpan version; remove orphaned duplicate const blocks and dead second return
- getNetworkStatus: keep withSpan version; remove orphaned second impl
- getExchangeRate: keep withHorizonRetry versions; remove bare first set
- stopHorizonLatencyMonitor: restore missing closing brace
- node --check passes; all 29 named exports appear exactly once

Closes #940
Closes #941
Closes #942
Closes #943